### PR TITLE
feat: modern tag input with autocomplete suggestions

### DIFF
--- a/frontend/src/components/IngestionWizard.test.tsx
+++ b/frontend/src/components/IngestionWizard.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { IngestionWizard } from "./IngestionWizard";
 
+vi.mock("@/hooks/useTagSuggestions", () => ({
+  useTagSuggestions: () => [],
+}));
+
 describe("IngestionWizard", () => {
   beforeEach(() => {
     localStorage.clear();

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent } from "react";
 import { GraphSandbox } from "./GraphSandbox";
+import { TagInput } from "./TagInput";
 import api from "@/api/client";
+import { useTagSuggestions } from "@/hooks/useTagSuggestions";
 
 interface PreviewSourceImage {
   bucket: string;
@@ -86,7 +88,7 @@ function mapPreviewToFormData(preview: IngestionPreview) {
     problemType: preview.draft.problemType || "",
     graphDsl: preview.draft.graphDsl || "",
     correctAnswer: preview.draft.correctAnswer || "",
-    tags: preview.draft.tags.join(", "),
+    tags: preview.draft.tags,
   };
 }
 
@@ -210,17 +212,18 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
     problemType: string;
     graphDsl: string;
     correctAnswer: string;
-    tags: string;
+    tags: string[];
   }>({
     text: "",
     problemType: "",
     graphDsl: "",
     correctAnswer: "",
-    tags: "",
+    tags: [] as string[],
   });
 
   const [graphError, setGraphError] = useState<string>("");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const tagSuggestions = useTagSuggestions();
 
   useEffect(() => {
     const savedDraft = localStorage.getItem("ingestion-draft");
@@ -232,7 +235,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
           problemType: draft.problemType || "",
           graphDsl: draft.graphDsl || "",
           correctAnswer: draft.correctAnswer || "",
-          tags: draft.tags || "",
+          tags: Array.isArray(draft.tags) ? draft.tags : [],
         });
       } catch {
       }
@@ -394,7 +397,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
   }, [previewId, startPolling]);
 
   const handleFieldChange = useCallback(
-    (field: keyof typeof formData, value: string) => {
+    (field: keyof typeof formData, value: string | string[]) => {
       setFormData((prev) => ({ ...prev, [field]: value }));
     },
     []
@@ -412,7 +415,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
         problemType: formData.problemType,
         graphDsl: formData.graphDsl,
         correctAnswer: formData.correctAnswer,
-        tags: formData.tags.split(",").map((t) => t.trim()).filter(Boolean),
+        tags: formData.tags,
       });
 
       const result = await confirmPreview(previewId);
@@ -812,32 +815,12 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
             </div>
 
             <div style={{ marginBottom: "24px" }}>
-              <label
-                style={{
-                  display: "block",
-                  marginBottom: "6px",
-                  fontSize: "14px",
-                  fontWeight: 500,
-                  color: "#374151",
-                }}
-              >
-                Tags (comma-separated)
-              </label>
-              <input
-                type="text"
-                value={formData.tags}
-                onChange={(e) => handleFieldChange("tags", e.target.value)}
-                style={{
-                  width: "100%",
-                  padding: "10px 12px",
-                  border: "1px solid #d1d5db",
-                  borderRadius: "6px",
-                  fontSize: "14px",
-                  fontFamily: "inherit",
-                  boxSizing: "border-box",
-                }}
-                placeholder="e.g., difficult, exam, chapter-1..."
-                data-testid="tags-input"
+              <TagInput
+                tags={formData.tags}
+                onChange={(tags) => handleFieldChange("tags", tags)}
+                suggestions={tagSuggestions}
+                placeholder="Add a tag..."
+                testId="tags-input"
               />
             </div>
 
@@ -1003,7 +986,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
                   Tags
                 </div>
                 <div style={{ fontSize: "14px", color: "#111827" }}>
-                  {formData.tags || "(empty)"}
+                  {formData.tags.length > 0 ? formData.tags.join(", ") : "(empty)"}
                 </div>
               </div>
             </div>

--- a/frontend/src/components/TagInput.test.tsx
+++ b/frontend/src/components/TagInput.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { TagInput } from "./TagInput";
+
+describe("TagInput", () => {
+  it("renders with existing tags as bubbles", () => {
+    render(<TagInput tags={["math", "algebra"]} onChange={vi.fn()} testId="tags-input" />);
+
+    expect(screen.getByTestId("tags-input")).toBeInTheDocument();
+    expect(screen.getByTestId("tags-input-tag-math")).toBeInTheDocument();
+    expect(screen.getByTestId("tags-input-tag-algebra")).toBeInTheDocument();
+  });
+
+  it("removes a tag when × is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<TagInput tags={["math", "algebra"]} onChange={onChange} testId="tags-input" />);
+
+    await user.click(screen.getByTestId("tags-input-remove-math"));
+
+    expect(onChange).toHaveBeenCalledWith(["algebra"]);
+  });
+
+  it("adds a tag when Enter is pressed", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<TagInput tags={["math"]} onChange={onChange} testId="tags-input" />);
+
+    await user.type(screen.getByTestId("tags-input-field"), "geometry{enter}");
+
+    expect(onChange).toHaveBeenCalledWith(["math", "geometry"]);
+  });
+
+  it("does not add duplicate tags", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<TagInput tags={["math"]} onChange={onChange} testId="tags-input" />);
+
+    await user.type(screen.getByTestId("tags-input-field"), "math{enter}");
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+  });
+
+  it("does not add empty tags", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+    await user.type(screen.getByTestId("tags-input-field"), "   {enter}");
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+  });
+
+  it("shows filtered suggestions when typing", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TagInput
+        tags={["math"]}
+        onChange={vi.fn()}
+        suggestions={["math", "matrix", "matter", "geometry"]}
+        testId="tags-input"
+      />,
+    );
+
+    await user.type(screen.getByTestId("tags-input-field"), "ma");
+
+    expect(screen.getByTestId("tags-input-suggestions")).toBeInTheDocument();
+    expect(screen.getByTestId("tags-input-suggestion-matrix")).toBeInTheDocument();
+    expect(screen.getByTestId("tags-input-suggestion-matter")).toBeInTheDocument();
+    expect(screen.queryByTestId("tags-input-suggestion-math")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("tags-input-suggestion-geometry")).not.toBeInTheDocument();
+  });
+
+  it("adds tag when suggestion is clicked", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <TagInput tags={[]} onChange={onChange} suggestions={["algebra", "geometry"]} testId="tags-input" />,
+    );
+
+    await user.type(screen.getByTestId("tags-input-field"), "al");
+    await user.click(screen.getByTestId("tags-input-suggestion-algebra"));
+
+    expect(onChange).toHaveBeenCalledWith(["algebra"]);
+  });
+
+  it("hides suggestions when Escape is pressed", async () => {
+    const user = userEvent.setup();
+
+    render(<TagInput tags={[]} onChange={vi.fn()} suggestions={["algebra"]} testId="tags-input" />);
+
+    await user.type(screen.getByTestId("tags-input-field"), "al");
+    expect(screen.getByTestId("tags-input-suggestions")).toBeInTheDocument();
+
+    await user.type(screen.getByTestId("tags-input-field"), "{escape}");
+
+    expect(screen.queryByTestId("tags-input-suggestions")).not.toBeInTheDocument();
+    expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+  });
+
+  it("removes last tag on Backspace when input is empty", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<TagInput tags={["math", "algebra"]} onChange={onChange} testId="tags-input" />);
+
+    await user.click(screen.getByTestId("tags-input-field"));
+    await user.type(screen.getByTestId("tags-input-field"), "{backspace}");
+
+    expect(onChange).toHaveBeenCalledWith(["math"]);
+  });
+
+  it("calls onChange correctly for all operations", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <TagInput
+        tags={["math"]}
+        onChange={onChange}
+        suggestions={["algebra", "geometry"]}
+        testId="tags-input"
+      />,
+    );
+
+    await user.click(screen.getByTestId("tags-input-remove-math"));
+    await user.type(screen.getByTestId("tags-input-field"), "geometry{enter}");
+
+    expect(onChange).toHaveBeenNthCalledWith(1, []);
+    expect(onChange).toHaveBeenNthCalledWith(2, ["math", "geometry"]);
+  });
+});

--- a/frontend/src/components/TagInput.test.tsx
+++ b/frontend/src/components/TagInput.test.tsx
@@ -138,4 +138,78 @@ describe("TagInput", () => {
     expect(onChange).toHaveBeenNthCalledWith(1, []);
     expect(onChange).toHaveBeenNthCalledWith(2, ["math", "geometry"]);
   });
+
+  describe("accessibility", () => {
+    it("has combobox role on the input", () => {
+      render(<TagInput tags={[]} onChange={vi.fn()} testId="tags-input" />);
+
+      const input = screen.getByTestId("tags-input-field");
+      expect(input).toHaveAttribute("role", "combobox");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+      expect(input).toHaveAttribute("aria-haspopup", "listbox");
+      expect(input).toHaveAttribute("aria-autocomplete", "list");
+    });
+
+    it("sets aria-expanded to true when suggestions are shown", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TagInput tags={[]} onChange={vi.fn()} suggestions={["algebra", "geometry"]} testId="tags-input" />,
+      );
+
+      const input = screen.getByTestId("tags-input-field");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+
+      await user.type(input, "al");
+
+      expect(input).toHaveAttribute("aria-expanded", "true");
+      expect(input).toHaveAttribute("aria-controls", "tags-input-suggestions");
+    });
+
+    it("has listbox role on the suggestions dropdown", async () => {
+      const user = userEvent.setup();
+
+      render(<TagInput tags={[]} onChange={vi.fn()} suggestions={["algebra"]} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "al");
+
+      const listbox = screen.getByTestId("tags-input-suggestions");
+      expect(listbox).toHaveAttribute("role", "listbox");
+    });
+
+    it("has option role with aria-selected on suggestion items", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TagInput tags={[]} onChange={vi.fn()} suggestions={["algebra", "algorithm"]} testId="tags-input" />,
+      );
+
+      await user.type(screen.getByTestId("tags-input-field"), "al");
+
+      const firstOption = screen.getByTestId("tags-input-suggestion-algebra");
+      expect(firstOption).toHaveAttribute("role", "option");
+      expect(firstOption).toHaveAttribute("aria-selected", "true");
+
+      const secondOption = screen.getByTestId("tags-input-suggestion-algorithm");
+      expect(secondOption).toHaveAttribute("role", "option");
+      expect(secondOption).toHaveAttribute("aria-selected", "false");
+    });
+
+    it("sets aria-activedescendant to the highlighted suggestion", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TagInput tags={[]} onChange={vi.fn()} suggestions={["algebra", "algorithm"]} testId="tags-input" />,
+      );
+
+      await user.type(screen.getByTestId("tags-input-field"), "al");
+
+      const input = screen.getByTestId("tags-input-field");
+      expect(input).toHaveAttribute("aria-activedescendant", "tags-input-suggestion-algebra");
+
+      await user.type(input, "{arrowDown}");
+
+      expect(input).toHaveAttribute("aria-activedescendant", "tags-input-suggestion-algorithm");
+    });
+  });
 });

--- a/frontend/src/components/TagInput.tsx
+++ b/frontend/src/components/TagInput.tsx
@@ -1,0 +1,294 @@
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from "react";
+
+export interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  suggestions?: string[];
+  placeholder?: string;
+  disabled?: boolean;
+  label?: string;
+  testId?: string;
+}
+
+export function TagInput({
+  tags,
+  onChange,
+  suggestions = [],
+  placeholder,
+  disabled = false,
+  label,
+  testId = "tag-input",
+}: TagInputProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [hoveredRemoveTag, setHoveredRemoveTag] = useState<string | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const filteredSuggestions = useMemo(() => {
+    const trimmedInput = inputValue.trim().toLowerCase();
+
+    if (!trimmedInput) {
+      return [];
+    }
+
+    return suggestions.filter((suggestion) => {
+      const normalizedSuggestion = suggestion.toLowerCase();
+      return normalizedSuggestion.startsWith(trimmedInput) && !tags.includes(suggestion);
+    });
+  }, [inputValue, suggestions, tags]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setHighlightedIndex((currentIndex) => {
+      if (filteredSuggestions.length === 0) {
+        return 0;
+      }
+
+      return Math.min(currentIndex, filteredSuggestions.length - 1);
+    });
+  }, [filteredSuggestions, isOpen]);
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+        setHighlightedIndex(0);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const closeSuggestions = () => {
+    setIsOpen(false);
+    setHighlightedIndex(0);
+  };
+
+  const addTag = (value: string) => {
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue) {
+      setInputValue("");
+      closeSuggestions();
+      return;
+    }
+
+    if (tags.includes(trimmedValue)) {
+      setInputValue("");
+      closeSuggestions();
+      return;
+    }
+
+    onChange([...tags, trimmedValue]);
+    setInputValue("");
+    closeSuggestions();
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    onChange(tags.filter((tag) => tag !== tagToRemove));
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) {
+      return;
+    }
+
+    if (event.key === "ArrowDown") {
+      if (filteredSuggestions.length > 0) {
+        event.preventDefault();
+        setIsOpen(true);
+        setHighlightedIndex((currentIndex) => (currentIndex + 1) % filteredSuggestions.length);
+      }
+      return;
+    }
+
+    if (event.key === "ArrowUp") {
+      if (filteredSuggestions.length > 0) {
+        event.preventDefault();
+        setIsOpen(true);
+        setHighlightedIndex((currentIndex) =>
+          currentIndex === 0 ? filteredSuggestions.length - 1 : currentIndex - 1,
+        );
+      }
+      return;
+    }
+
+    if (event.key === "Enter") {
+      event.preventDefault();
+
+      if (isOpen && filteredSuggestions[highlightedIndex]) {
+        addTag(filteredSuggestions[highlightedIndex]);
+        return;
+      }
+
+      addTag(inputValue);
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setInputValue("");
+      closeSuggestions();
+      return;
+    }
+
+    if (event.key === "Backspace" && inputValue === "" && tags.length > 0) {
+      event.preventDefault();
+      onChange(tags.slice(0, -1));
+    }
+  };
+
+  const showSuggestions = isOpen && filteredSuggestions.length > 0 && !disabled;
+
+  return (
+    <div style={{ marginBottom: "24px", position: "relative" }} ref={wrapperRef} data-testid={testId}>
+      {label ? (
+        <label
+          style={{
+            display: "block",
+            marginBottom: "6px",
+            fontSize: "14px",
+            fontWeight: 500,
+            color: "#374151",
+          }}
+        >
+          {label}
+        </label>
+      ) : null}
+
+      <div
+        style={{
+          width: "100%",
+          border: "1px solid #d1d5db",
+          borderRadius: "6px",
+          padding: "6px 8px",
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          gap: "4px",
+          boxSizing: "border-box",
+          backgroundColor: disabled ? "#f9fafb" : "white",
+        }}
+      >
+        {tags.map((tag) => (
+          <span
+            key={tag}
+            style={{
+              padding: "4px 8px",
+              backgroundColor: "#e0e7ff",
+              borderRadius: "4px",
+              fontSize: "13px",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "4px",
+              margin: "2px",
+            }}
+            data-testid={`${testId}-tag-${tag}`}
+          >
+            <span>{tag}</span>
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              disabled={disabled}
+              aria-label={`Remove ${tag}`}
+              data-testid={`${testId}-remove-${tag}`}
+              onMouseEnter={() => setHoveredRemoveTag(tag)}
+              onMouseLeave={() => setHoveredRemoveTag((currentTag) => (currentTag === tag ? null : currentTag))}
+              style={{
+                border: "none",
+                background: "transparent",
+                cursor: disabled ? "not-allowed" : "pointer",
+                color: hoveredRemoveTag === tag ? "#dc2626" : "#6b7280",
+                fontSize: "16px",
+                lineHeight: 1,
+                padding: "0 2px",
+              }}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+
+        <input
+          type="text"
+          value={inputValue}
+          disabled={disabled}
+          placeholder={placeholder}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            setInputValue(nextValue);
+            setIsOpen(nextValue.trim().length > 0);
+            setHighlightedIndex(0);
+          }}
+          onFocus={() => {
+            if (inputValue.trim()) {
+              setIsOpen(true);
+            }
+          }}
+          onKeyDown={handleKeyDown}
+          data-testid={`${testId}-field`}
+          style={{
+            border: "none",
+            outline: "none",
+            flex: 1,
+            minWidth: "120px",
+            fontSize: "14px",
+            padding: "4px 0",
+            fontFamily: "inherit",
+            backgroundColor: "transparent",
+          }}
+        />
+      </div>
+
+      {showSuggestions ? (
+        <div
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: 0,
+            right: 0,
+            marginTop: "4px",
+            backgroundColor: "white",
+            border: "1px solid #d1d5db",
+            borderRadius: "6px",
+            boxShadow: "0 4px 6px rgba(0,0,0,0.1)",
+            maxHeight: "200px",
+            overflowY: "auto",
+            zIndex: 10,
+          }}
+          data-testid={`${testId}-suggestions`}
+        >
+          {filteredSuggestions.map((suggestion, index) => (
+            <button
+              key={suggestion}
+              type="button"
+              onMouseDown={(event) => {
+                event.preventDefault();
+              }}
+              onClick={() => addTag(suggestion)}
+              data-testid={`${testId}-suggestion-${suggestion}`}
+              style={{
+                width: "100%",
+                border: "none",
+                textAlign: "left",
+                backgroundColor: index === highlightedIndex ? "#eff6ff" : "white",
+                padding: "8px 12px",
+                cursor: "pointer",
+                fontSize: "14px",
+              }}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/TagInput.tsx
+++ b/frontend/src/components/TagInput.tsx
@@ -218,6 +218,16 @@ export function TagInput({
 
         <input
           type="text"
+          role="combobox"
+          aria-expanded={showSuggestions}
+          aria-haspopup="listbox"
+          aria-autocomplete="list"
+          aria-controls={showSuggestions ? `${testId}-suggestions` : undefined}
+          aria-activedescendant={
+            showSuggestions && filteredSuggestions[highlightedIndex]
+              ? `${testId}-suggestion-${filteredSuggestions[highlightedIndex]}`
+              : undefined
+          }
           value={inputValue}
           disabled={disabled}
           placeholder={placeholder}
@@ -249,6 +259,7 @@ export function TagInput({
 
       {showSuggestions ? (
         <div
+          role="listbox"
           style={{
             position: "absolute",
             top: "100%",
@@ -266,14 +277,16 @@ export function TagInput({
           data-testid={`${testId}-suggestions`}
         >
           {filteredSuggestions.map((suggestion, index) => (
-            <button
+            <div
               key={suggestion}
-              type="button"
+              role="option"
+              aria-selected={index === highlightedIndex}
               onMouseDown={(event) => {
                 event.preventDefault();
               }}
               onClick={() => addTag(suggestion)}
               data-testid={`${testId}-suggestion-${suggestion}`}
+              id={`${testId}-suggestion-${suggestion}`}
               style={{
                 width: "100%",
                 border: "none",
@@ -285,7 +298,7 @@ export function TagInput({
               }}
             >
               {suggestion}
-            </button>
+            </div>
           ))}
         </div>
       ) : null}

--- a/frontend/src/hooks/useTagSuggestions.ts
+++ b/frontend/src/hooks/useTagSuggestions.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/api/client";
+
+interface TagsResponse {
+  items: string[];
+}
+
+export function useTagSuggestions() {
+  const { data } = useQuery({
+    queryKey: ["problem-tags"],
+    queryFn: async () => {
+      const response = await api.get<TagsResponse>("/problems/tags");
+      return response.items;
+    },
+    staleTime: 30_000,
+  });
+
+  return data ?? [];
+}

--- a/frontend/src/pages/IngestPage.test.tsx
+++ b/frontend/src/pages/IngestPage.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { IngestPage } from "./IngestPage";
 
+vi.mock("@/hooks/useTagSuggestions", () => ({
+  useTagSuggestions: () => [],
+}));
+
 const mockNavigate = vi.fn();
 
 vi.mock("react-router-dom", async () => {

--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -6,6 +6,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { ProblemDetailPage } from "./ProblemDetailPage";
 
+vi.mock("@/hooks/useTagSuggestions", () => ({
+  useTagSuggestions: () => [],
+}));
+
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -4,6 +4,8 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
+import { TagInput } from "@/components/TagInput";
+import { useTagSuggestions } from "@/hooks/useTagSuggestions";
 
 interface CorrectAnswer {
   display: string;
@@ -60,6 +62,7 @@ export function ProblemDetailPage() {
   const [isEditing, setIsEditing] = useState(false);
   const [editForm, setEditForm] = useState<UpdateProblemInput>({});
   const [error, setError] = useState<string | null>(null);
+  const tagSuggestions = useTagSuggestions();
 
   const {
     data: problem,
@@ -241,17 +244,12 @@ export function ProblemDetailPage() {
         <div style={{ marginBottom: "1rem" }}>
           <label style={{ fontWeight: "bold" }}>Tags:</label>
           {isEditing ? (
-            <input
-              type="text"
-              value={(editForm.tags || []).join(", ")}
-              onChange={(e) =>
-                setEditForm((prev) => ({
-                  ...prev,
-                  tags: e.target.value.split(",").map((t) => t.trim()),
-                }))
-              }
-              placeholder="Comma-separated tags"
-              style={{ width: "100%", marginTop: "0.5rem" }}
+            <TagInput
+              tags={editForm.tags || []}
+              onChange={(tags) => setEditForm((prev) => ({ ...prev, tags }))}
+              suggestions={tagSuggestions}
+              placeholder="Add a tag..."
+              testId="edit-tags-input"
             />
           ) : problem.tags.length > 0 ? (
             <div style={{ marginTop: "0.5rem", display: "flex", flexWrap: "wrap", gap: "0.375rem" }}>


### PR DESCRIPTION
## Summary

Implements issue #2 — modern tag input UI with auto-completion.

### Changes

**New files:**
- `frontend/src/components/TagInput.tsx` — Reusable tag input component with:
  - Tag bubbles with × remove buttons
  - Autocomplete suggestions dropdown with case-insensitive prefix filtering
  - Keyboard navigation (Arrow keys, Enter, Escape, Backspace)
  - Click-outside to close dropdown
  - Duplicate prevention
- `frontend/src/components/TagInput.test.tsx` — 10 unit tests covering all behaviors
- `frontend/src/hooks/useTagSuggestions.ts` — React Query hook for `GET /api/v1/problems/tags`

**Modified files:**
- `frontend/src/components/IngestionWizard.tsx` — Replaced comma-separated text input with TagInput; tags stored as `string[]` throughout
- `frontend/src/pages/ProblemDetailPage.tsx` — Replaced plain text input in edit mode with TagInput
- `frontend/src/components/IngestionWizard.test.tsx` — Added `useTagSuggestions` mock
- `frontend/src/pages/IngestPage.test.tsx` — Added `useTagSuggestions` mock
- `frontend/src/pages/ProblemDetailPage.test.tsx` — Added `useTagSuggestions` mock

### Test Results
- Frontend: 63/63 tests pass
- Backend: 93/93 tests pass, 1 skipped
- Build: clean (`tsc -b && vite build`)

### Screenshots
The tag input shows:
- Tags as blue bubbles with × buttons inside the input field
- Autocomplete dropdown appears when typing, filtered by prefix
- Suggestions exclude already-added tags

Closes #2