### PR TITLE
feat: add continue/discard exam functionality

### DIFF
--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field
@@ -154,8 +154,8 @@ class User(BaseModel):
     id: Optional[str] = None
     username: str
     passwordHash: str
-    createdAt: datetime = Field(default_factory=datetime.utcnow)
-    updatedAt: datetime = Field(default_factory=datetime.utcnow)
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     lastLoginAt: Optional[datetime] = None
     status: str = "active"
 
@@ -163,9 +163,9 @@ class User(BaseModel):
 class Session(BaseModel):
     id: Optional[str] = None
     userId: str
-    createdAt: datetime = Field(default_factory=datetime.utcnow)
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     expiresAt: datetime
-    lastSeenAt: datetime = Field(default_factory=datetime.utcnow)
+    lastSeenAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     invalidatedAt: Optional[datetime] = None
     clientMeta: ClientMeta = Field(default_factory=ClientMeta)
 
@@ -177,8 +177,8 @@ class IngestionPreview(BaseModel):
     sourceImage: SourceImage
     extraction: Extraction = Field(default_factory=Extraction)
     editableDraft: EditableDraft = Field(default_factory=EditableDraft)
-    createdAt: datetime = Field(default_factory=datetime.utcnow)
-    updatedAt: datetime = Field(default_factory=datetime.utcnow)
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     expiresAt: datetime
 
 
@@ -195,8 +195,8 @@ class Problem(BaseModel):
     tracking: Tracking = Field(default_factory=Tracking)
     isDeleted: bool = False
     deletedAt: Optional[datetime] = None
-    createdAt: datetime = Field(default_factory=datetime.utcnow)
-    updatedAt: datetime = Field(default_factory=datetime.utcnow)
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
 class Exam(BaseModel):
@@ -206,8 +206,8 @@ class Exam(BaseModel):
     configSnapshot: ExamConfigSnapshot
     items: List[ExamItem] = Field(default_factory=list)
     summary: ExamSummary
-    createdAt: datetime = Field(default_factory=datetime.utcnow)
+    createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     startedAt: Optional[datetime] = None
     submittedAt: Optional[datetime] = None
     discardedAt: Optional[datetime] = None
-    updatedAt: datetime = Field(default_factory=datetime.utcnow)
+    updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -15,6 +15,7 @@ class ProblemType(str, Enum):
 class ExamState(str, Enum):
     IN_PROGRESS = "in-progress"
     SUBMITTED = "submitted"
+    DISCARDED = "discarded"
 
 
 class IngestionPreviewStatus(str, Enum):
@@ -208,4 +209,5 @@ class Exam(BaseModel):
     createdAt: datetime = Field(default_factory=datetime.utcnow)
     startedAt: Optional[datetime] = None
     submittedAt: Optional[datetime] = None
+    discardedAt: Optional[datetime] = None
     updatedAt: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/domain/state.py
+++ b/backend/app/domain/state.py
@@ -83,8 +83,9 @@ def transition_preview_state(
 
 # Exam State Transitions
 EXAM_TRANSITIONS = {
-    ExamState.IN_PROGRESS: [ExamState.SUBMITTED],
+    ExamState.IN_PROGRESS: [ExamState.SUBMITTED, ExamState.DISCARDED],
     ExamState.SUBMITTED: [],
+    ExamState.DISCARDED: [],
 }
 
 

--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -89,6 +89,7 @@ class ExamPayload(BaseModel):
     createdAt: datetime
     startedAt: datetime | None = None
     submittedAt: datetime | None = None
+    discardedAt: datetime | None = None
     updatedAt: datetime
 
 
@@ -113,7 +114,8 @@ class ExamHistoryItemPayload(BaseModel):
     id: str
     state: ExamState
     createdAt: datetime
-    submittedAt: datetime
+    submittedAt: datetime | None = None
+    discardedAt: datetime | None = None
     summary: ExamSummaryPayload
 
 
@@ -207,5 +209,6 @@ def serialize_exam(exam: Mapping[str, Any]) -> ExamPayload:
         createdAt=exam["createdAt"],
         startedAt=exam.get("startedAt"),
         submittedAt=exam.get("submittedAt"),
+        discardedAt=exam.get("discardedAt"),
         updatedAt=exam["updatedAt"],
     )

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -306,6 +306,39 @@ async def submit_exam(
     return ExamResponse(exam=serialize_exam(submitted_exam))
 
 
+@router.post("/{exam_id}/discard", response_model=ExamResponse)
+async def discard_exam(
+    exam_id: str,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> ExamResponse:
+    exam = await get_owned_exam(database, exam_id, current_user["_id"])
+    if exam.get("state") != ExamState.IN_PROGRESS.value:
+        raise ApiError(409, "INVALID_EXAM_STATE", "Exam is not in progress")
+
+    discarded_at = datetime.now(UTC)
+    next_state = transition_exam_state(ExamState(exam["state"]), ExamState.DISCARDED)
+    await database["exams"].update_one(
+        {"_id": exam["_id"]},
+        {
+            "$set": {
+                "state": next_state.value,
+                "discardedAt": discarded_at,
+                "updatedAt": discarded_at,
+            }
+        },
+    )
+    updated_exam = deepcopy(exam)
+    updated_exam.update(
+        {
+            "state": next_state.value,
+            "discardedAt": discarded_at,
+            "updatedAt": discarded_at,
+        }
+    )
+    return ExamResponse(exam=serialize_exam(updated_exam))
+
+
 @router.post("/{exam_id}/items/{item_id}/self-report", response_model=SelfReportResponse)
 async def self_report_exam_item(
     exam_id: str,
@@ -392,9 +425,12 @@ async def list_exam_history(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
 ) -> ExamHistoryResponse:
-    query = {"userId": current_user["_id"], "state": ExamState.SUBMITTED.value}
+    query = {
+        "userId": current_user["_id"],
+        "state": {"$in": [ExamState.SUBMITTED.value, ExamState.DISCARDED.value]},
+    }
     total = await database["exams"].count_documents(query)
-    cursor = database["exams"].find(query).sort("submittedAt", -1)
+    cursor = database["exams"].find(query).sort("updatedAt", -1)
     cursor = cursor.skip((page - 1) * page_size).limit(page_size)
     documents = await cursor.to_list(length=page_size)
     return ExamHistoryResponse(
@@ -403,7 +439,8 @@ async def list_exam_history(
                 id=str(document["_id"]),
                 state=ExamState(document["state"]),
                 createdAt=document["createdAt"],
-                submittedAt=document["submittedAt"],
+                submittedAt=document.get("submittedAt"),
+                discardedAt=document.get("discardedAt"),
                 summary=serialize_exam_summary(dict(document.get("summary", {}))),
             )
             for document in documents

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -168,7 +168,10 @@ class FakeVLMClient:
 
 def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
     for key, value in query.items():
-        if document.get(key) != value:
+        if isinstance(value, dict) and "$in" in value:
+            if document.get(key) not in value["$in"]:
+                return False
+        elif document.get(key) != value:
             return False
     return True
 

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -72,6 +72,10 @@ class FakeCursor:
 def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
     for key, value in query.items():
         actual = document.get(key)
+        if isinstance(value, dict) and "$in" in value:
+            if actual not in value["$in"]:
+                return False
+            continue
         if isinstance(actual, list):
             if value not in actual:
                 return False

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -31,9 +31,12 @@ export interface MeResponse {
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
-    throw new Error(
+    const error = new Error(
       errorData.error?.message || `HTTP ${response.status}: ${response.statusText}`,
     );
+    (error as Error & { code?: string; status?: number }).code = errorData.error?.code;
+    (error as Error & { code?: string; status?: number }).status = response.status;
+    throw error;
   }
   return response.json() as Promise<T>;
 }

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -38,6 +38,10 @@ async function submitExam(examId: string): Promise<ExamResponse> {
   return api.post<ExamResponse>(`/exams/${examId}/submit`, {});
 }
 
+async function discardExam(examId: string): Promise<ExamResponse> {
+  return api.post<ExamResponse>(`/exams/${examId}/discard`, {});
+}
+
 function parseOptions(text: string): string[] {
   const lines = text.split("\n");
   const options: string[] = [];
@@ -243,6 +247,7 @@ export function ActiveExamPage() {
   const [localAnswer, setLocalAnswer] = useState("");
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
   const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
 
   const {
     data: examData,
@@ -280,9 +285,20 @@ export function ActiveExamPage() {
   const submitExamMutation = useMutation({
     mutationFn: (examId: string) => submitExam(examId),
     onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["exams"] });
       navigate(`/exams/${data.exam.id}`);
     },
   });
+
+  const discardExamMutation = useMutation({
+    mutationFn: (examId: string) => discardExam(examId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exams"] });
+      navigate("/exams");
+    },
+  });
+
+  const isMutating = submitExamMutation.isPending || discardExamMutation.isPending;
 
   useEffect(() => {
     if (currentItem) {
@@ -329,6 +345,15 @@ export function ActiveExamPage() {
     await handleSaveAnswer();
     submitExamMutation.mutate(exam.id);
   }, [exam, handleSaveAnswer, submitExamMutation]);
+
+  const handleDiscard = useCallback(() => {
+    setShowDiscardConfirm(true);
+  }, []);
+
+  const confirmDiscard = useCallback(() => {
+    if (!exam) return;
+    discardExamMutation.mutate(exam.id);
+  }, [exam, discardExamMutation]);
 
   const handleCreateExam = useCallback(() => {
     createExamMutation.mutate({ maxProblemCount: 10 });
@@ -410,10 +435,10 @@ export function ActiveExamPage() {
         <div style={{ display: "flex", gap: "0.5rem" }}>
           <button
             onClick={handlePrevious}
-            disabled={isFirstItem || submitExamMutation.isPending}
+            disabled={isFirstItem || isMutating}
             style={{
               padding: "0.5rem 1rem",
-              cursor: isFirstItem || submitExamMutation.isPending ? "not-allowed" : "pointer",
+              cursor: isFirstItem || isMutating ? "not-allowed" : "pointer",
               opacity: isFirstItem ? 0.5 : 1,
             }}
           >
@@ -421,30 +446,46 @@ export function ActiveExamPage() {
           </button>
           <button
             onClick={handleNext}
-            disabled={isLastItem || submitExamMutation.isPending}
+            disabled={isLastItem || isMutating}
             style={{
               padding: "0.5rem 1rem",
-              cursor: isLastItem || submitExamMutation.isPending ? "not-allowed" : "pointer",
+              cursor: isLastItem || isMutating ? "not-allowed" : "pointer",
               opacity: isLastItem ? 0.5 : 1,
             }}
           >
             Next
           </button>
         </div>
-        <button
-          onClick={handleSubmit}
-          disabled={submitExamMutation.isPending}
-          style={{
-            padding: "0.5rem 1.5rem",
-            backgroundColor: submitExamMutation.isPending ? "#6ee7b7" : "#10b981",
-            color: "white",
-            border: "none",
-            borderRadius: "0.25rem",
-            cursor: submitExamMutation.isPending ? "not-allowed" : "pointer",
-          }}
-        >
-          {submitExamMutation.isPending ? "Submitting..." : "Submit Exam"}
-        </button>
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <button
+            onClick={handleDiscard}
+            disabled={isMutating}
+            style={{
+              padding: "0.5rem 1rem",
+              backgroundColor: "#fee2e2",
+              color: "#dc2626",
+              border: "1px solid #fecaca",
+              borderRadius: "0.25rem",
+              cursor: isMutating ? "not-allowed" : "pointer",
+            }}
+          >
+            Discard
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={isMutating}
+            style={{
+              padding: "0.5rem 1.5rem",
+              backgroundColor: submitExamMutation.isPending ? "#6ee7b7" : "#10b981",
+              color: "white",
+              border: "none",
+              borderRadius: "0.25rem",
+              cursor: isMutating ? "not-allowed" : "pointer",
+            }}
+          >
+            {submitExamMutation.isPending ? "Submitting..." : "Submit Exam"}
+          </button>
+        </div>
       </div>
 
       <div style={{ backgroundColor: "#f9fafb", border: "1px solid #e5e7eb", borderRadius: "0.5rem", padding: "1.5rem", marginBottom: "1rem" }}>
@@ -476,7 +517,7 @@ export function ActiveExamPage() {
             onChange={setLocalAnswer}
             onBlur={handleBlur}
             options={options}
-            disabled={submitExamMutation.isPending}
+            disabled={isMutating}
           />
           <div
             style={{ marginTop: "0.5rem", fontSize: "0.875rem", color:
@@ -519,6 +560,40 @@ export function ActiveExamPage() {
                 }}
               >
                 {submitExamMutation.isPending ? "Submitting..." : "Submit"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showDiscardConfirm && (
+        <div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, backgroundColor: "rgba(0,0,0,0.5)", display: "flex", alignItems: "center", justifyContent: "center" }}>
+          <div style={{ backgroundColor: "white", padding: "2rem", borderRadius: "0.5rem", maxWidth: "400px" }}>
+            <h2 style={{ marginTop: 0 }}>Discard Exam?</h2>
+            <p>
+              This exam will be closed and marked as discarded. It will appear in your exam history but will not affect your statistics.
+            </p>
+            <div style={{ display: "flex", gap: "1rem", marginTop: "1.5rem", justifyContent: "flex-end" }}>
+              <button
+                onClick={() => setShowDiscardConfirm(false)}
+                disabled={discardExamMutation.isPending}
+                style={{ padding: "0.5rem 1rem" }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => void confirmDiscard()}
+                disabled={discardExamMutation.isPending}
+                style={{
+                  padding: "0.5rem 1rem",
+                  backgroundColor: discardExamMutation.isPending ? "#fca5a5" : "#dc2626",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "0.25rem",
+                  cursor: discardExamMutation.isPending ? "not-allowed" : "pointer",
+                }}
+              >
+                {discardExamMutation.isPending ? "Discarding..." : "Discard Exam"}
               </button>
             </div>
           </div>

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -296,6 +296,13 @@ export function ActiveExamPage() {
       queryClient.invalidateQueries({ queryKey: ["exams"] });
       navigate("/exams");
     },
+    onError: (err) => {
+      const code = (err as Error & { code?: string }).code;
+      if (code === "INVALID_EXAM_STATE") {
+        queryClient.invalidateQueries({ queryKey: ["exams"] });
+        navigate("/exams");
+      }
+    },
   });
 
   const isMutating = submitExamMutation.isPending || discardExamMutation.isPending;

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api/client";
-import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest, CreateExamResponse } from "@/types/exam";
+import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest, CreateExamResponse, ExamResponse } from "@/types/exam";
 
 function formatDate(dateString?: string) {
   if (!dateString) {
@@ -21,7 +21,22 @@ function formatScore(score: number | null) {
   return `${Math.round(score * 100)}%`;
 }
 
+function getStateStyle(state: string) {
+  switch (state) {
+    case "submitted":
+      return { backgroundColor: "#dcfce7", color: "#166534" };
+    case "discarded":
+      return { backgroundColor: "#fee2e2", color: "#991b1b" };
+    default:
+      return { backgroundColor: "#fef3c7", color: "#92400e" };
+  }
+}
+
 function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () => void }) {
+  const stateStyle = getStateStyle(exam.state);
+  const completionDate = exam.state === "discarded" ? exam.discardedAt : exam.submittedAt;
+  const completionLabel = exam.state === "discarded" ? "Discarded" : "Submitted";
+
   return (
     <button
       type="button"
@@ -55,8 +70,7 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
           style={{
             padding: "0.25rem 0.75rem",
             borderRadius: "9999px",
-            backgroundColor: exam.state === "submitted" ? "#dcfce7" : "#fef3c7",
-            color: exam.state === "submitted" ? "#166534" : "#92400e",
+            ...stateStyle,
             alignSelf: "flex-start",
             fontSize: "0.875rem",
             fontWeight: 600,
@@ -76,12 +90,12 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
         }}
       >
         <div>
-          <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>Submitted</div>
-          <div>{formatDate(exam.submittedAt)}</div>
+          <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>{completionLabel}</div>
+          <div>{formatDate(completionDate)}</div>
         </div>
         <div>
           <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>Score</div>
-          <div>{formatScore(exam.summary.score)}</div>
+          <div>{exam.state === "discarded" ? "—" : formatScore(exam.summary.score)}</div>
         </div>
         <div>
           <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>Total</div>
@@ -89,20 +103,30 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
         </div>
         <div>
           <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>Correct</div>
-          <div>{exam.summary.correctProblems}</div>
+          <div>{exam.state === "discarded" ? "—" : exam.summary.correctProblems}</div>
         </div>
         <div>
           <div style={{ color: "#6b7280", fontSize: "0.75rem" }}>Incorrect</div>
-          <div>{exam.summary.failedProblems}</div>
+          <div>{exam.state === "discarded" ? "—" : exam.summary.failedProblems}</div>
         </div>
       </div>
     </button>
   );
 }
 
+async function checkActiveExam(): Promise<ExamResponse | null> {
+  try {
+    return await api.get<ExamResponse>("/exams/active");
+  } catch {
+    return null;
+  }
+}
+
 export function ExamsPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
+  const [showActiveExamPrompt, setShowActiveExamPrompt] = useState(false);
   const pageSize = 10;
 
   const { data, isLoading, error } = useQuery<ExamHistoryResponse>({
@@ -111,9 +135,28 @@ export function ExamsPage() {
   });
 
   const createExamMutation = useMutation({
-    mutationFn: (req: CreateExamRequest) => api.post<CreateExamResponse>("/exams", req),
-    onSuccess: () => navigate("/exams/active"),
+    mutationFn: async (req: CreateExamRequest) => {
+      const activeExam = await checkActiveExam();
+      if (activeExam) {
+        throw new Error("ACTIVE_EXAM_EXISTS");
+      }
+      return api.post<CreateExamResponse>("/exams", req);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["exams"] });
+      navigate("/exams/active");
+    },
   });
+
+  const handleCreateExam = async () => {
+    try {
+      await createExamMutation.mutateAsync({ maxProblemCount: 10 });
+    } catch (err) {
+      if (err instanceof Error && err.message === "ACTIVE_EXAM_EXISTS") {
+        setShowActiveExamPrompt(true);
+      }
+    }
+  };
 
   const exams = data?.items ?? [];
   const total = data?.total ?? 0;
@@ -139,7 +182,7 @@ export function ExamsPage() {
         </div>
         <button
           type="button"
-          onClick={() => createExamMutation.mutate({ maxProblemCount: 10 })}
+          onClick={() => void handleCreateExam()}
           disabled={createExamMutation.isPending}
           style={{
             padding: "0.75rem 1rem",
@@ -153,12 +196,53 @@ export function ExamsPage() {
         >
           {createExamMutation.isPending ? "Creating..." : "Start New Exam"}
         </button>
-        {createExamMutation.error && (
-          <p style={{ color: "#dc2626", fontSize: "0.875rem", marginTop: "0.5rem" }}>
-            {(createExamMutation.error as Error).message}
-          </p>
-        )}
       </div>
+
+      {showActiveExamPrompt && (
+        <div
+          style={{
+            padding: "1rem",
+            backgroundColor: "#fef3c7",
+            border: "1px solid #fcd34d",
+            borderRadius: "0.5rem",
+            marginBottom: "1rem",
+          }}
+        >
+          <p style={{ margin: "0 0 0.75rem" }}>
+            An active exam already exists. Would you like to continue it?
+          </p>
+          <div style={{ display: "flex", gap: "0.75rem" }}>
+            <button
+              type="button"
+              onClick={() => navigate("/exams/active")}
+              style={{
+                padding: "0.5rem 1rem",
+                backgroundColor: "#2563eb",
+                color: "white",
+                border: "none",
+                borderRadius: "0.375rem",
+                cursor: "pointer",
+                fontWeight: 600,
+              }}
+            >
+              Continue Exam
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowActiveExamPrompt(false)}
+              style={{
+                padding: "0.5rem 1rem",
+                backgroundColor: "#f3f4f6",
+                border: "1px solid #d1d5db",
+                borderRadius: "0.375rem",
+                cursor: "pointer",
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       {isLoading ? (
         <div>Loading exams...</div>

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api/client";
-import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest, CreateExamResponse, ExamResponse } from "@/types/exam";
+import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest, CreateExamResponse } from "@/types/exam";
 
 function formatDate(dateString?: string) {
   if (!dateString) {
@@ -114,14 +114,6 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
   );
 }
 
-async function checkActiveExam(): Promise<ExamResponse | null> {
-  try {
-    return await api.get<ExamResponse>("/exams/active");
-  } catch {
-    return null;
-  }
-}
-
 export function ExamsPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -135,13 +127,7 @@ export function ExamsPage() {
   });
 
   const createExamMutation = useMutation({
-    mutationFn: async (req: CreateExamRequest) => {
-      const activeExam = await checkActiveExam();
-      if (activeExam) {
-        throw new Error("ACTIVE_EXAM_EXISTS");
-      }
-      return api.post<CreateExamResponse>("/exams", req);
-    },
+    mutationFn: (req: CreateExamRequest) => api.post<CreateExamResponse>("/exams", req),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["exams"] });
       navigate("/exams/active");
@@ -152,7 +138,8 @@ export function ExamsPage() {
     try {
       await createExamMutation.mutateAsync({ maxProblemCount: 10 });
     } catch (err) {
-      if (err instanceof Error && err.message === "ACTIVE_EXAM_EXISTS") {
+      const code = (err as Error & { code?: string }).code;
+      if (code === "ACTIVE_EXAM_EXISTS") {
         setShowActiveExamPrompt(true);
       }
     }

--- a/frontend/src/types/exam.ts
+++ b/frontend/src/types/exam.ts
@@ -4,7 +4,7 @@ export type ProblemType =
   | "fill-in-the-blank"
   | "short-answer";
 
-export type ExamState = "in-progress" | "submitted";
+export type ExamState = "in-progress" | "submitted" | "discarded";
 
 export type GradingStatus =
   | "ungraded"
@@ -94,6 +94,7 @@ export interface Exam {
   createdAt: string;
   startedAt?: string;
   submittedAt?: string;
+  discardedAt?: string;
   updatedAt: string;
 }
 
@@ -101,7 +102,8 @@ export interface ExamHistoryItem {
   id: string;
   state: ExamState;
   createdAt: string;
-  submittedAt: string;
+  submittedAt?: string;
+  discardedAt?: string;
   summary: ExamSummary;
 }
 


### PR DESCRIPTION
## Summary
- Add ability to continue an active exam when user already has one in progress
- Add ability to discard an active exam (closes it without affecting statistics)
- Discarded exams appear in exam history with "discarded" state

## Implementation
- **Backend**: Added `ExamState.DISCARDED` state, `discardedAt` timestamp, and `POST /exams/{id}/discard` endpoint
- **Frontend**: Added "Continue Exam" prompt on ExamsPage when active exam exists, added "Discard" button with confirmation dialog on ActiveExamPage
- **History**: Updated exam history to include both submitted and discarded exams, with appropriate display for each state

## Changes
- `backend/app/domain/models.py`: Add `DISCARDED` to `ExamState` enum, add `discardedAt` field
- `backend/app/domain/state.py`: Allow transition from `IN_PROGRESS` to `DISCARDED`
- `backend/app/presentation/exams.py`: Add discard endpoint, update history query to include discarded exams
- `backend/app/presentation/exam_serialization.py`: Add `discardedAt` to payloads
- `frontend/src/types/exam.ts`: Add `discarded` state type, `discardedAt` fields
- `frontend/src/pages/ExamsPage.tsx`: Show "Continue Exam" prompt when active exam exists, display discarded state in history
- `frontend/src/pages/ActiveExamPage.tsx`: Add "Discard" button with confirmation dialog

## Test plan
- Backend tests: All 93 tests pass (updated `_matches` helpers to support MongoDB `$in` operator)
- Frontend tests: All 68 tests pass
- Manual testing:
  1. Start a new exam
  2. Navigate to Exams page and try to start another exam → should show "Continue Exam" prompt
  3. Click "Continue Exam" → returns to active exam
  4. Click "Discard" button → shows confirmation dialog
  5. Confirm discard → exam closes, redirects to exam history
  6. Exam appears in history with "discarded" state and no score/statistics

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)