### PR TITLE
feat: hide correct answer by default with toggle on problem detail page

### DIFF
--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -73,6 +73,7 @@ describe("ProblemDetailPage", () => {
   });
 
   it("renders problem details", async () => {
+    const user = userEvent.setup();
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -92,8 +93,19 @@ describe("ProblemDetailPage", () => {
     expect(screen.getByText("single-choice")).toBeInTheDocument();
     expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
     expect(screen.getByText("algebra")).toBeInTheDocument();
-    expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("Reference: abc123")).toBeInTheDocument();
+
+    // Answer is hidden by default
+    expect(screen.getByRole("button", { name: "Show Answer" })).toBeInTheDocument();
+    expect(screen.queryByText("42")).not.toBeInTheDocument();
+
+    // Click to reveal answer
+    await user.click(screen.getByRole("button", { name: "Show Answer" }));
+
+    expect(screen.getByRole("button", { name: "Hide Answer" })).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+
+    // Tracking statistics still show exposure count
     expect(screen.getAllByText("4").length).toBeGreaterThanOrEqual(1);
   });
 
@@ -119,6 +131,41 @@ describe("ProblemDetailPage", () => {
 
     expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    // Answer input is shown directly in edit mode (no toggle needed)
+    expect(screen.getByDisplayValue("4")).toBeInTheDocument();
+  });
+
+  it("hides answer by default and toggles visibility", async () => {
+    const user = userEvent.setup();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ problem: baseProblem }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => baseTracking,
+      });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
+    });
+
+    // Answer hidden by default - check for the answer container not existing
+    expect(screen.queryByRole("button", { name: "Hide Answer" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show Answer" })).toBeInTheDocument();
+
+    // Show answer
+    await user.click(screen.getByRole("button", { name: "Show Answer" }));
+    // The answer should now be visible in a styled container
+    expect(screen.getByRole("button", { name: "Hide Answer" })).toBeInTheDocument();
+
+    // Hide answer again
+    await user.click(screen.getByRole("button", { name: "Hide Answer" }));
+    expect(screen.queryByRole("button", { name: "Hide Answer" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show Answer" })).toBeInTheDocument();
   });
 
   it("saves edited problem", async () => {

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -60,6 +60,7 @@ export function ProblemDetailPage() {
   const problemId = id ?? "";
 
   const [isEditing, setIsEditing] = useState(false);
+  const [showAnswer, setShowAnswer] = useState(false);
   const [editForm, setEditForm] = useState<UpdateProblemInput>({});
   const [error, setError] = useState<string | null>(null);
   const tagSuggestions = useTagSuggestions();
@@ -310,7 +311,35 @@ export function ProblemDetailPage() {
                 style={{ width: "100%", marginTop: "0.5rem" }}
               />
             ) : (
-              <div>{problem.correctAnswer?.display}</div>
+              <div style={{ marginTop: "0.5rem" }}>
+                <button
+                  type="button"
+                  onClick={() => setShowAnswer((prev) => !prev)}
+                  style={{
+                    padding: "0.375rem 0.75rem",
+                    backgroundColor: showAnswer ? "#fee2e2" : "#dcfce7",
+                    border: "1px solid",
+                    borderColor: showAnswer ? "#fecaca" : "#bbf7d0",
+                    borderRadius: "0.25rem",
+                    cursor: "pointer",
+                    marginBottom: showAnswer ? "0.5rem" : 0,
+                  }}
+                >
+                  {showAnswer ? "Hide Answer" : "Show Answer"}
+                </button>
+                {showAnswer && (
+                  <div
+                    style={{
+                      padding: "0.5rem",
+                      backgroundColor: "#f9fafb",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: "0.25rem",
+                    }}
+                  >
+                    {problem.correctAnswer?.display}
+                  </div>
+                )}
+              </div>
             )}
           </div>
         )}

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -315,11 +315,13 @@ export function ProblemDetailPage() {
                 <button
                   type="button"
                   onClick={() => setShowAnswer((prev) => !prev)}
+                  aria-expanded={showAnswer}
+                  aria-controls="answer-container"
                   style={{
                     padding: "0.375rem 0.75rem",
-                    backgroundColor: showAnswer ? "#fee2e2" : "#dcfce7",
+                    backgroundColor: showAnswer ? "#fee2e2" : "#e0f2fe",
                     border: "1px solid",
-                    borderColor: showAnswer ? "#fecaca" : "#bbf7d0",
+                    borderColor: showAnswer ? "#fecaca" : "#bae6fd",
                     borderRadius: "0.25rem",
                     cursor: "pointer",
                     marginBottom: showAnswer ? "0.5rem" : 0,
@@ -329,6 +331,9 @@ export function ProblemDetailPage() {
                 </button>
                 {showAnswer && (
                   <div
+                    id="answer-container"
+                    role="region"
+                    aria-live="polite"
                     style={{
                       padding: "0.5rem",
                       backgroundColor: "#f9fafb",


### PR DESCRIPTION
## Summary
- Correct answer is now hidden by default when viewing problem details
- A "Show Answer" / "Hide Answer" toggle button reveals or conceals the answer
- In edit mode, the answer input is shown directly without the toggle

## Implementation
- Added `showAnswer` state (default: `false`) to `ProblemDetailPage`
- Replaced the direct answer display with a toggle button + conditional reveal
- Answer is shown in a styled container when revealed
- Edit mode bypasses the toggle and shows the input field directly

## Changes
- `frontend/src/pages/ProblemDetailPage.tsx`: Add `showAnswer` state, replace answer display with toggle
- `frontend/src/pages/ProblemDetailPage.test.tsx`: Update tests to verify hide/show behavior

## Test plan
- Frontend tests: All 69 tests pass
- Manual testing:
  1. Navigate to a problem detail page
  2. Correct answer should be hidden by default
  3. Click "Show Answer" → answer is revealed with "Hide Answer" button
  4. Click "Hide Answer" → answer is hidden again
  5. Click "Edit" → answer input field is visible directly (no toggle)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)