### PR TITLE
feat(practice): add practice selection algorithm and configuration

### DIFF
--- a/backend/app/domain/practice_selection.py
+++ b/backend/app/domain/practice_selection.py
@@ -1,0 +1,97 @@
+import random
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import List, Optional
+
+from .models import Problem
+
+
+@dataclass
+class PracticeSelectionConfig:
+    cooldown_days: int = 7
+    last_wrong_weight: float = 1.0
+    failure_rate_weight: float = 1.0
+    recency_weight: float = 1.0
+
+
+@dataclass
+class PracticeSelectionResult:
+    selected_problem: Optional[Problem]
+    status: str  # "ok", "no_eligible", "no_problems"
+
+
+def select_practice_problem(
+    problems: List[Problem],
+    config: PracticeSelectionConfig,
+    now: datetime,
+    rng: random.Random | None = None
+) -> PracticeSelectionResult:
+    if not problems:
+        return PracticeSelectionResult(None, "no_problems")
+
+    eligible = []
+    for p in problems:
+        if p.isDeleted:
+            continue
+        if not p.correctAnswer or not p.correctAnswer.normalizedText:
+            continue
+        if p.tracking.lastTestedAt:
+            last_tested = _ensure_utc(p.tracking.lastTestedAt)
+            cutoff = now - timedelta(days=config.cooldown_days)
+            if last_tested > cutoff:
+                continue
+        eligible.append(p)
+
+    if not eligible:
+        all_eligible = [p for p in problems if not p.isDeleted and p.correctAnswer and p.correctAnswer.normalizedText]
+        if all_eligible:
+            return PracticeSelectionResult(None, "no_eligible")
+        return PracticeSelectionResult(None, "no_problems")
+
+    weighted = []
+    for problem in eligible:
+        weight = _compute_problem_weight(problem, config, now)
+        weighted.append((problem, weight))
+
+    total = sum(w for _, w in weighted)
+    if total <= 0:
+        selected = (rng or random).choice(eligible)
+    else:
+        r = (rng or random).random() * total
+        cumulative = 0.0
+        selected = eligible[0]
+        for problem, weight in weighted:
+            cumulative += weight
+            if r <= cumulative:
+                selected = problem
+                break
+
+    return PracticeSelectionResult(selected, "ok")
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _compute_problem_weight(problem: Problem, config: PracticeSelectionConfig, now: datetime) -> float:
+    last_wrong_score = 1.0
+    if problem.tracking.lastAttemptCorrect is False:
+        last_wrong_score = 2.0
+
+    failure_score = 1.0
+    if problem.tracking.exposureCount > 0:
+        failure_rate = problem.tracking.failedCount / problem.tracking.exposureCount
+        failure_score = 1.0 + failure_rate
+
+    recency_score = 1.0
+    if problem.tracking.lastTestedAt:
+        days_since = (now - _ensure_utc(problem.tracking.lastTestedAt)).days
+        recency_score = 1.0 + days_since / 30.0
+
+    return (
+        last_wrong_score * config.last_wrong_weight +
+        failure_score * config.failure_rate_weight +
+        recency_score * config.recency_weight
+    )

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -42,6 +42,12 @@ class Settings(BaseSettings):
     session_secure: bool = Field(default=False)
     session_samesite: Literal["lax", "strict", "none"] = Field(default="lax")
 
+    # Practice mode configuration
+    practice_cooldown_days: int = Field(default=7, ge=0)
+    practice_last_wrong_weight: float = Field(default=1.0, ge=0)
+    practice_failure_rate_weight: float = Field(default=1.0, ge=0)
+    practice_recency_weight: float = Field(default=1.0, ge=0)
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -1,0 +1,223 @@
+from datetime import UTC, datetime, timedelta
+import random
+
+from app.domain.models import CorrectAnswer, Problem, Tracking
+from app.domain.practice_selection import (
+    PracticeSelectionConfig,
+    PracticeSelectionResult,
+    select_practice_problem,
+)
+
+
+def _make_problem(
+    pid: str,
+    text: str = "Test problem",
+    is_deleted: bool = False,
+    correct_answer: str | None = "answer",
+    last_tested_at: datetime | None = None,
+    last_attempt_correct: bool | None = None,
+    exposure_count: int = 0,
+    failed_count: int = 0,
+) -> Problem:
+    return Problem(
+        id=pid,
+        userId="user1",
+        text=text,
+        problemType="single-choice",
+        correctAnswer=CorrectAnswer(
+            display=correct_answer or "",
+            normalizedText=correct_answer or "",
+            normalizedSet=[correct_answer] if correct_answer else [],
+            format="single",
+        ),
+        tracking=Tracking(
+            exposureCount=exposure_count,
+            correctCount=exposure_count - failed_count if exposure_count >= failed_count else 0,
+            failedCount=failed_count,
+            lastTestedAt=last_tested_at,
+            lastAttemptCorrect=last_attempt_correct,
+        ),
+        isDeleted=is_deleted,
+    )
+
+
+def test_cooldown_enforcement():
+    now = datetime.now(UTC)
+    recent = now - timedelta(days=2)
+    old = now - timedelta(days=10)
+
+    problems = [
+        _make_problem("recent", last_tested_at=recent),
+        _make_problem("old", last_tested_at=old),
+    ]
+    config = PracticeSelectionConfig(cooldown_days=7)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "old"
+
+
+def test_shared_cooldown_exam_within_period():
+    now = datetime.now(UTC)
+    recent = now - timedelta(days=3)
+
+    problems = [_make_problem("exam-tested", last_tested_at=recent)]
+    config = PracticeSelectionConfig(cooldown_days=7)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "no_eligible"
+
+
+def test_last_wrong_boost():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("correct", last_attempt_correct=True, exposure_count=1, failed_count=0),
+        _make_problem("wrong", last_attempt_correct=False, exposure_count=1, failed_count=1),
+    ]
+    config = PracticeSelectionConfig()
+    rng = random.Random(42)
+
+    wrong_count = 0
+    for _ in range(100):
+        result = select_practice_problem(problems, config, now, rng=rng)
+        if result.selected_problem.id == "wrong":
+            wrong_count += 1
+
+    assert wrong_count > 50
+
+
+def test_failure_rate_weight():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("low-fail", exposure_count=10, failed_count=1),
+        _make_problem("high-fail", exposure_count=10, failed_count=8),
+    ]
+    config = PracticeSelectionConfig()
+    rng = random.Random(42)
+
+    high_fail_count = 0
+    for _ in range(100):
+        result = select_practice_problem(problems, config, now, rng=rng)
+        if result.selected_problem.id == "high-fail":
+            high_fail_count += 1
+
+    assert high_fail_count > 50
+
+
+def test_recency_weight():
+    now = datetime.now(UTC)
+    old = now - timedelta(days=60)
+    recent = now - timedelta(days=5)
+
+    problems = [
+        _make_problem("recent-test", last_tested_at=recent),
+        _make_problem("old-test", last_tested_at=old),
+    ]
+    config = PracticeSelectionConfig(cooldown_days=3)
+    rng = random.Random(42)
+
+    old_count = 0
+    for _ in range(100):
+        result = select_practice_problem(problems, config, now, rng=rng)
+        if result.selected_problem.id == "old-test":
+            old_count += 1
+
+    assert old_count > 50
+
+
+def test_all_equal_weights_baseline():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("a"),
+        _make_problem("b"),
+        _make_problem("c"),
+    ]
+    config = PracticeSelectionConfig()
+    rng = random.Random(42)
+
+    counts = {"a": 0, "b": 0, "c": 0}
+    for _ in range(300):
+        result = select_practice_problem(problems, config, now, rng=rng)
+        counts[result.selected_problem.id] += 1
+
+    assert all(c > 50 for c in counts.values())
+
+
+def test_zero_eligible_problems():
+    now = datetime.now(UTC)
+    problems = [_make_problem("deleted", is_deleted=True)]
+    config = PracticeSelectionConfig()
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "no_problems"
+
+
+def test_all_in_cooldown():
+    now = datetime.now(UTC)
+    recent = now - timedelta(days=2)
+
+    problems = [
+        _make_problem("a", last_tested_at=recent),
+        _make_problem("b", last_tested_at=recent),
+    ]
+    config = PracticeSelectionConfig(cooldown_days=7)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "no_eligible"
+
+
+def test_never_tested_always_eligible():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("never-tested", last_tested_at=None),
+        _make_problem("recent-test", last_tested_at=now - timedelta(days=2)),
+    ]
+    config = PracticeSelectionConfig(cooldown_days=7)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "never-tested"
+
+
+def test_default_config_values():
+    config = PracticeSelectionConfig()
+
+    assert config.cooldown_days == 7
+    assert config.last_wrong_weight == 1.0
+    assert config.failure_rate_weight == 1.0
+    assert config.recency_weight == 1.0
+
+
+def test_deleted_problems_excluded():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("deleted", is_deleted=True),
+        _make_problem("active"),
+    ]
+    config = PracticeSelectionConfig()
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "active"
+
+
+def test_empty_answer_excluded():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("no-answer", correct_answer=""),
+        _make_problem("has-answer", correct_answer="answer"),
+    ]
+    config = PracticeSelectionConfig()
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "has-answer"
+
+
+def test_empty_problem_list():
+    now = datetime.now(UTC)
+    config = PracticeSelectionConfig()
+    result = select_practice_problem([], config, now)
+
+    assert result.status == "no_problems"
+    assert result.selected_problem is None


### PR DESCRIPTION
## Summary

Implements the weighted random selection algorithm for practice mode and adds associated configuration fields to the backend settings system.

- Add practice configuration fields to Settings: `PRACTICE_COOLDOWN_DAYS`, `PRACTICE_LAST_WRONG_WEIGHT`, `PRACTICE_FAILURE_RATE_WEIGHT`, `PRACTICE_RECENCY_WEIGHT`
- Implement `select_practice_problem()` in `backend/app/domain/practice_selection.py`
- Algorithm filters out deleted, empty-answer, and cooldown-ineligible problems
- Composite weight computed from last-wrong boost, failure rate, and recency factors
- Weighted random sampling selects one problem
- Returns appropriate status: "ok", "no_eligible", or "no_problems"

## Implementation Notes

- Follows the pattern of existing `select_problems()` in `selection.py` for exam selection
- Pure function: takes problems and config as input, returns selection result
- Configurable via environment variables or `.env` file
- `lastTestedAt` is checked at show time (shared cooldown behavior per FR-17)

## Test Results

```bash
cd backend && uv run pytest tests/domain/test_practice_selection.py -v
# 13 tests passed

cd backend && uv run pytest
# 120 passed, 1 skipped, no regressions
```

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)