### PR TITLE
feat(frontend): add practice module scaffolding (types, nav, route)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { ActiveExamPage } from "@/pages/ActiveExamPage";
 import { ExamsPage } from "@/pages/ExamsPage";
 import { ExamDetailPage } from "@/pages/ExamDetailPage";
 import { TagsPage } from "@/pages/TagsPage";
+import { PracticePage } from "@/pages/PracticePage";
 
 function AppShell({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
@@ -24,6 +25,7 @@ function AppShell({ children }: { children: ReactNode }) {
     { label: "Ingest", path: "/ingest" },
     { label: "Exams", path: "/exams" },
     { label: "Tags", path: "/tags" },
+    { label: "Practice", path: "/practice" },
   ];
 
   const handleLogout = async () => {
@@ -161,6 +163,14 @@ export function AppRoutes() {
         element={
           <ProtectedPage>
             <TagsPage />
+          </ProtectedPage>
+        }
+      />
+      <Route
+        path="/practice"
+        element={
+          <ProtectedPage>
+            <PracticePage />
           </ProtectedPage>
         }
       />

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -1,0 +1,7 @@
+export function PracticePage() {
+  return (
+    <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+      <h1>Practice</h1>
+    </main>
+  );
+}

--- a/frontend/src/types/practice.ts
+++ b/frontend/src/types/practice.ts
@@ -1,0 +1,42 @@
+export interface PracticeProblem {
+  id: string;
+  text: string;
+  type: string;
+  imageUrl?: string;
+}
+
+export interface PracticeAttemptResult {
+  gradingStatus: string;
+  gradingMethod: string;
+}
+
+export interface PracticeAttemptDetail {
+  submittedAnswer: string;
+  gradingStatus: string;
+  gradingMethod: string;
+  createdAt: string;
+}
+
+export interface PracticeHistorySummary {
+  totalAttempts: number;
+  correctCount: number;
+  wrongCount: number;
+  lastPracticedAt?: string;
+  lastResult?: string;
+}
+
+export interface PracticeHistoryItem {
+  problemId: string;
+  problemText: string;
+  problemType: string;
+  imageUrl?: string;
+  summary: PracticeHistorySummary;
+  attempts: PracticeAttemptDetail[];
+}
+
+export type PracticeNextStatus = "ok" | "no_eligible" | "no_problems";
+
+export interface PracticeNextResponse {
+  status: PracticeNextStatus;
+  problem?: PracticeProblem;
+}


### PR DESCRIPTION
## Summary

Add TypeScript types for the practice API, a "Practice" navigation item in the top-level nav bar, and a route definition with a placeholder page.

- Create `frontend/src/types/practice.ts` with all required types:
  - `PracticeProblem`, `PracticeAttemptResult`, `PracticeHistoryItem`
  - `PracticeHistorySummary`, `PracticeAttemptDetail`, `PracticeNextResponse`
- Add "Practice" nav button to `AppShell` in `App.tsx`
- Add `/practice` route rendering `PracticePage` placeholder

## Implementation Notes

- Follows existing patterns from `TagsPage` and `App.tsx`
- Types mirror the API response shapes defined in the spec
- No dependencies on backend implementation

## Test Results

```bash
cd frontend && npm test -- --run
# 76 tests passed, no regressions
```

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)