### PR TITLE
Add collapsible error details for VLM extraction failures

### DIFF
--- a/frontend/src/components/IngestionWizard.test.tsx
+++ b/frontend/src/components/IngestionWizard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { IngestionWizard } from "./IngestionWizard";
 
 vi.mock("@/hooks/useTagSuggestions", () => ({
@@ -60,5 +60,210 @@ describe("IngestionWizard", () => {
 
     render(<IngestionWizard />);
     expect(screen.getByTestId("ingestion-wizard")).toBeInTheDocument();
+  });
+
+  describe("VLM error details", () => {
+    it("shows error details when failureCode is present", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "vlm-failed",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {
+                failureCode: "VLM_ERROR",
+                failureMessage: null,
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Extraction Failed/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("View error details")).toBeInTheDocument();
+
+      const details = screen.getByText("View error details").closest("details");
+      expect(details).toBeInTheDocument();
+    });
+
+    it("shows error details when failureMessage is present", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "vlm-failed",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {
+                failureCode: null,
+                failureMessage: "Connection timeout",
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Extraction Failed/)).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("View error details")).toBeInTheDocument();
+    });
+
+    it("displays failureCode when expanded", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "vlm-failed",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {
+                failureCode: "TIMEOUT_ERROR",
+                failureMessage: null,
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Extraction Failed/)).toBeInTheDocument();
+      });
+
+      const summary = screen.getByText("View error details");
+      fireEvent.click(summary);
+
+      await waitFor(() => {
+        expect(screen.getByText(/TIMEOUT_ERROR/)).toBeInTheDocument();
+      });
+    });
+
+    it("displays failureMessage when expanded", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "vlm-failed",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {
+                failureCode: null,
+                failureMessage: "Rate limit exceeded",
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Extraction Failed/)).toBeInTheDocument();
+      });
+
+      const summary = screen.getByText("View error details");
+      fireEvent.click(summary);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Rate limit exceeded/)).toBeInTheDocument();
+      });
+    });
+
+    it("does not show error details when failureCode and failureMessage are null", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "vlm-failed",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {
+                failureCode: null,
+                failureMessage: null,
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Extraction Failed/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("View error details")).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -28,6 +28,8 @@ interface PreviewExtraction {
   rawGraphDsl?: string | null;
   rawCorrectAnswer?: string | null;
   rawTags?: string[];
+  failureCode?: string | null;
+  failureMessage?: string | null;
   [key: string]: unknown;
 }
 
@@ -570,6 +572,37 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
                 <p style={{ color: "#7f1d1d", fontSize: "14px", margin: "0 0 12px" }}>
                   The AI was unable to extract problem data from the image.
                 </p>
+                {(preview?.extraction?.failureCode || preview?.extraction?.failureMessage) && (
+                  <details style={{ marginBottom: "12px" }}>
+                    <summary style={{ cursor: "pointer", color: "#7f1d1d", fontSize: "13px" }}>
+                      View error details
+                    </summary>
+                    <div
+                      style={{
+                        marginTop: "8px",
+                        padding: "12px",
+                        backgroundColor: "#fee2e2",
+                        borderRadius: "4px",
+                        fontSize: "12px",
+                        fontFamily: "monospace",
+                      }}
+                    >
+                      {preview.extraction.failureCode && (
+                        <div style={{ marginBottom: "8px" }}>
+                          <span style={{ fontWeight: 600 }}>Code:</span> {preview.extraction.failureCode}
+                        </div>
+                      )}
+                      {preview.extraction.failureMessage && (
+                        <div>
+                          <span style={{ fontWeight: 600 }}>Message:</span>{" "}
+                          <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+                            {preview.extraction.failureMessage}
+                          </pre>
+                        </div>
+                      )}
+                    </div>
+                  </details>
+                )}
                 <div style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}>
                   <button
                     onClick={handleRetry}


### PR DESCRIPTION
## Summary
- Adds a collapsible `<details>` section to the VLM extraction failure UI in `IngestionWizard.tsx`
- When extraction fails, users can click "View error details" to see the `failureCode` and `failureMessage`
- Backend already returns these fields; frontend now displays them

## Implementation
- Extended `PreviewExtraction` interface to include `failureCode` and `failureMessage`
- Added conditional collapsible details block inside the `vlm-failed` status section
- Shows failure code and message in a styled monospace container

## Test results
- Frontend: 85 tests pass (including 6 IngestionWizard tests)
- Backend: 136 tests pass

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)