### PR TITLE
refactor: use for loop for VLM retry boundedness in practice grading

### DIFF
--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -183,8 +183,7 @@ async def _grade_answer(
         return status, GradingMethod.NORMALIZED_MATCH
 
     image_base64 = await _load_problem_image_base64(problem, storage)
-    retry_count = 0
-    while True:
+    for _ in range(2):
         try:
             result = await vlm_client.grade_short_answer(
                 image_base64=image_base64,
@@ -194,12 +193,12 @@ async def _grade_answer(
             status = GradingStatus.CORRECT if result.is_correct else GradingStatus.INCORRECT
             return status, GradingMethod.VLM
         except VLMError as exc:
-            if exc.retryable and retry_count < 1:
-                retry_count += 1
-                continue
-            return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
+            if not exc.retryable:
+                return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
+            continue
         except Exception:
             return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
+    return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
 
 
 @router.post("/attempts", response_model=PracticeAttemptResult, status_code=201)


### PR DESCRIPTION
## Summary
- Replaced `while True` with `retry_count` guard with an explicit `for _ in range(2)` loop
- Makes boundedness clearer and removes the need for a counter variable
- Logic is unchanged: retry once on retryable VLM errors, otherwise return PENDING_REVIEW

## Implementation
Changed from:
```python
retry_count = 0
while True:
    try:
        result = await vlm_client.grade_short_answer(...)
        return status, GradingMethod.VLM
    except VLMError as exc:
        if exc.retryable and retry_count < 1:
            retry_count += 1
            continue
        return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
```

To:
```python
for _ in range(2):
    try:
        result = await vlm_client.grade_short_answer(...)
        return status, GradingMethod.VLM
    except VLMError as exc:
        if not exc.retryable:
            return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
        continue
return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
```

## Test results
- Backend Tests: 136 passed, 1 skipped

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)