### PR TITLE
feat: read-only settings page showing effective app configuration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from app.presentation.media import router as media_router
 from app.presentation.problems import router as problems_router
 from app.presentation.tags import router as tags_router
 from app.presentation.practice import router as practice_router
+from app.presentation.settings import router as settings_router
 
 
 @asynccontextmanager
@@ -53,6 +54,7 @@ def create_app() -> FastAPI:
     api_v1_router.include_router(media_router)
     api_v1_router.include_router(tags_router)
     api_v1_router.include_router(practice_router)
+    api_v1_router.include_router(settings_router)
     application.include_router(api_v1_router)
 
     return application

--- a/backend/app/presentation/settings.py
+++ b/backend/app/presentation/settings.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter
+
+from app.infrastructure.config.settings import get_settings
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+
+@router.get("")
+async def get_settings_info() -> dict:
+    settings = get_settings()
+    return {
+        "app": {
+            "env": settings.app_env,
+            "host": settings.app_host,
+            "port": settings.app_port,
+            "log_level": settings.app_log_level,
+        },
+        "database": {
+            "name": settings.mongodb_database,
+        },
+        "storage": {
+            "endpoint": settings.s3_endpoint,
+            "bucket": settings.s3_bucket,
+            "region": settings.s3_region,
+            "force_path_style": settings.s3_force_path_style,
+        },
+        "vlm": {
+            "endpoint": settings.vlm_endpoint,
+            "model": settings.vlm_model,
+            "timeout_seconds": settings.vlm_timeout_seconds,
+            "preview_extracting_window_seconds": settings.preview_extracting_window_seconds,
+        },
+        "session": {
+            "cookie_name": settings.session_cookie_name,
+            "secure": settings.session_secure,
+            "samesite": settings.session_samesite,
+        },
+        "practice": {
+            "cooldown_days": settings.practice_cooldown_days,
+            "last_wrong_weight": settings.practice_last_wrong_weight,
+            "failure_rate_weight": settings.practice_failure_rate_weight,
+            "recency_weight": settings.practice_recency_weight,
+        },
+    }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { ExamDetailPage } from "@/pages/ExamDetailPage";
 import { TagsPage } from "@/pages/TagsPage";
 import { PracticePage } from "@/pages/PracticePage";
 import { ActivePracticePage } from "@/pages/ActivePracticePage";
+import { SettingsPage } from "@/pages/SettingsPage";
 
 function AppShell({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
@@ -27,6 +28,7 @@ function AppShell({ children }: { children: ReactNode }) {
     { label: "Exams", path: "/exams" },
     { label: "Tags", path: "/tags" },
     { label: "Practice", path: "/practice" },
+    { label: "Settings", path: "/settings" },
   ];
 
   const handleLogout = async () => {
@@ -180,6 +182,14 @@ export function AppRoutes() {
         element={
           <ProtectedPage>
             <ActivePracticePage />
+          </ProtectedPage>
+        }
+      />
+      <Route
+        path="/settings"
+        element={
+          <ProtectedPage>
+            <SettingsPage />
           </ProtectedPage>
         }
       />

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { SettingsPage } from "./SettingsPage";
+
+vi.mock("../api/client", () => ({
+  api: {
+    get: vi.fn().mockResolvedValue({
+      app: { env: "development", host: "0.0.0.0", port: 8000, log_level: "INFO" },
+      database: { name: "learnloop" },
+      storage: { endpoint: "http://localhost:9000", bucket: "media", region: "us-east-1", force_path_style: true },
+      vlm: { endpoint: "https://example.com", model: "test", timeout_seconds: 120, preview_extracting_window_seconds: 150 },
+      session: { cookie_name: "ll_session", secure: false, samesite: "lax" },
+      practice: { cooldown_days: 7, last_wrong_weight: 1.0, failure_rate_weight: 1.0, recency_weight: 1.0 },
+    }),
+  },
+}));
+
+function renderWithProviders() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <SettingsPage />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+}
+
+describe("SettingsPage", () => {
+  it("renders settings heading", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Settings")).toBeInTheDocument();
+  });
+
+  it("renders read-only notice", async () => {
+    renderWithProviders();
+    expect(await screen.findByText(/read-only/i)).toBeInTheDocument();
+  });
+
+  it("renders app settings section", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Application")).toBeInTheDocument();
+    expect(await screen.findByText("Environment")).toBeInTheDocument();
+    expect(await screen.findByText("development")).toBeInTheDocument();
+  });
+
+  it("renders database settings section", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Database")).toBeInTheDocument();
+    expect(await screen.findByText("learnloop")).toBeInTheDocument();
+  });
+
+  it("renders storage settings section", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Storage (S3)")).toBeInTheDocument();
+    expect(await screen.findByText("http://localhost:9000")).toBeInTheDocument();
+  });
+
+  it("renders VLM settings section", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Vision Language Model")).toBeInTheDocument();
+    expect(await screen.findByText("test")).toBeInTheDocument();
+  });
+
+  it("renders session settings section", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Session")).toBeInTheDocument();
+    expect(await screen.findByText("ll_session")).toBeInTheDocument();
+  });
+
+  it("renders practice settings section", async () => {
+    renderWithProviders();
+    expect(await screen.findByText("Practice Mode")).toBeInTheDocument();
+    expect(await screen.findByText("7")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,175 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "@/api/client";
+
+interface SettingsResponse {
+  app: {
+    env: string;
+    host: string;
+    port: number;
+    log_level: string;
+  };
+  database: {
+    name: string;
+  };
+  storage: {
+    endpoint: string;
+    bucket: string;
+    region: string;
+    force_path_style: boolean;
+  };
+  vlm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
+    preview_extracting_window_seconds: number;
+  };
+  session: {
+    cookie_name: string;
+    secure: boolean;
+    samesite: string;
+  };
+  practice: {
+    cooldown_days: number;
+    last_wrong_weight: number;
+    failure_rate_weight: number;
+    recency_weight: number;
+  };
+}
+
+function SettingRow({ label, value }: { label: string; value: unknown }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        padding: "0.5rem 0",
+        borderBottom: "1px solid #e5e7eb",
+      }}
+    >
+      <span style={{ fontWeight: 500, color: "#374151" }}>{label}</span>
+      <span style={{ color: "#6b7280", fontFamily: "monospace" }}>
+        {String(value)}
+      </span>
+    </div>
+  );
+}
+
+function SettingSection({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section style={{ marginBottom: "1.5rem" }}>
+      <h2
+        style={{
+          fontSize: "1.125rem",
+          fontWeight: 600,
+          marginBottom: "0.75rem",
+          color: "#111827",
+          borderBottom: "2px solid #3b82f6",
+          paddingBottom: "0.25rem",
+        }}
+      >
+        {title}
+      </h2>
+      <div>{children}</div>
+    </section>
+  );
+}
+
+export function SettingsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["settings"],
+    queryFn: async () => api.get<SettingsResponse>("/settings"),
+  });
+
+  if (isLoading) {
+    return (
+      <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+        <h1 style={{ marginBottom: "1rem" }}>Settings</h1>
+        <p style={{ color: "#6b7280" }}>Loading settings...</p>
+      </main>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+        <h1 style={{ marginBottom: "1rem" }}>Settings</h1>
+        <p style={{ color: "#dc2626" }}>Failed to load settings.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+      <h1 style={{ marginBottom: "1.5rem" }}>Settings</h1>
+      <p
+        style={{
+          color: "#6b7280",
+          marginBottom: "1.5rem",
+          fontStyle: "italic",
+        }}
+      >
+        These are the effective runtime settings of the application (read-only).
+      </p>
+
+      <SettingSection title="Application">
+        <SettingRow label="Environment" value={data.app.env} />
+        <SettingRow label="Host" value={data.app.host} />
+        <SettingRow label="Port" value={data.app.port} />
+        <SettingRow label="Log Level" value={data.app.log_level} />
+      </SettingSection>
+
+      <SettingSection title="Database">
+        <SettingRow label="Database Name" value={data.database.name} />
+      </SettingSection>
+
+      <SettingSection title="Storage (S3)">
+        <SettingRow label="Endpoint" value={data.storage.endpoint} />
+        <SettingRow label="Bucket" value={data.storage.bucket} />
+        <SettingRow label="Region" value={data.storage.region} />
+        <SettingRow
+          label="Force Path Style"
+          value={data.storage.force_path_style.toString()}
+        />
+      </SettingSection>
+
+      <SettingSection title="Vision Language Model">
+        <SettingRow label="Endpoint" value={data.vlm.endpoint} />
+        <SettingRow label="Model" value={data.vlm.model} />
+        <SettingRow
+          label="Timeout (seconds)"
+          value={data.vlm.timeout_seconds}
+        />
+        <SettingRow
+          label="Preview Window (seconds)"
+          value={data.vlm.preview_extracting_window_seconds}
+        />
+      </SettingSection>
+
+      <SettingSection title="Session">
+        <SettingRow label="Cookie Name" value={data.session.cookie_name} />
+        <SettingRow label="Secure" value={data.session.secure.toString()} />
+        <SettingRow label="SameSite" value={data.session.samesite} />
+      </SettingSection>
+
+      <SettingSection title="Practice Mode">
+        <SettingRow label="Cooldown Days" value={data.practice.cooldown_days} />
+        <SettingRow
+          label="Last Wrong Weight"
+          value={data.practice.last_wrong_weight}
+        />
+        <SettingRow
+          label="Failure Rate Weight"
+          value={data.practice.failure_rate_weight}
+        />
+        <SettingRow label="Recency Weight" value={data.practice.recency_weight} />
+      </SettingSection>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a Settings button to the navigation header
- Create a read-only settings page (`/settings`) that displays all effective runtime settings
- Add backend endpoint `/api/v1/settings` exposing safe-to-expose configuration (no sensitive values)

## Implementation

**Backend:**
- New `settings.py` router returns structured settings grouped by category
- Sensitive values (API keys, secrets, MongoDB URI) are intentionally excluded

**Frontend:**
- `SettingsPage.tsx` fetches settings via React Query and renders them in organized sections
- Each section shows key-value pairs in a clean table-like layout
- 8 unit tests cover the page rendering and data display

Settings displayed:
- Application: env, host, port, log_level
- Database: name
- Storage/S3: endpoint, bucket, region, force_path_style
- VLM: endpoint, model, timeout_seconds, preview_extracting_window_seconds
- Session: cookie_name, secure, samesite
- Practice Mode: cooldown_days, last_wrong_weight, failure_rate_weight, recency_weight

## Test Results

- Backend tests: 139 passed, 1 skipped
- Frontend tests: 120 passed (including 8 new SettingsPage tests)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)