### PR TITLE
fix: add env_file directive to load backend/.env in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,8 @@ services:
         condition: service_healthy
       rustfs:
         condition: service_healthy
+    env_file:
+      - ./backend/.env
     environment:
       APP_ENV: ${APP_ENV:-development}
       APP_HOST: ${APP_HOST:-0.0.0.0}


### PR DESCRIPTION
## Summary

- Add `env_file: - ./backend/.env` directive to the `app` service in docker-compose.yml
- This ensures user settings defined in `backend/.env` (like `PRACTICE_COOLDOWN_DAYS=0`) are automatically forwarded to the container

## Problem

Docker Compose reads `.env` from the project root by default, but the backend application's settings are configured in `backend/.env` (where pydantic-settings reads from). This caused user settings to be ignored when running via Docker Compose.

## Solution

Adding the `env_file` directive makes Docker Compose load all environment variables from `backend/.env`. The explicit `environment` entries still take precedence for Docker-specific overrides (e.g., `MONGODB_URI` uses the container hostname `mongodb` instead of `localhost`).

## Test Results

- Backend tests: 139 passed, 1 skipped
- No frontend changes

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)