### PR TITLE
fix: pass problem data via navigation state when starting practice

### DIFF
--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -187,7 +187,7 @@ export function PracticePage() {
     mutationFn: () => api.post<PracticeNextResponse>("/practice/next", {}),
     onSuccess: (response) => {
       if (response.status === "ok" && response.problem) {
-        navigate("/practice/active");
+        navigate("/practice/active", { state: { problem: response.problem } });
       } else if (response.status === "no_eligible") {
         setStatusMessage("No problems available for practice right now. Try again later.");
       } else if (response.status === "no_problems") {


### PR DESCRIPTION
## Summary

- Pass `response.problem` via navigation state when navigating to `/practice/active` in PracticePage

## Problem

`PracticePage.tsx` navigated to `/practice/active` without passing the problem data returned from `POST /practice/next`. `ActivePracticePage` reads the problem from `location.state`, and when null, immediately redirects back to `/practice`. This caused the "Start Practice" button to appear to do nothing.

## Solution

Pass the problem data via navigation state:
```typescript
navigate("/practice/active", { state: { problem: response.problem } });
```

## Test Results

- Frontend tests: 129 passed

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)