### PR TITLE
refactor: remove redundant x-app-env anchor from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,5 @@
 name: learnloop
 
-x-app-env: &app-env
-  APP_ENV: ${APP_ENV:-development}
-  APP_HOST: ${APP_HOST:-0.0.0.0}
-  APP_PORT: ${APP_PORT:-8000}
-  APP_LOG_LEVEL: ${APP_LOG_LEVEL:-INFO}
-  MONGODB_URI: ${MONGODB_URI:-mongodb://localhost:27017/learnloop?replicaSet=rs0&directConnection=true}
-  MONGODB_DATABASE: ${MONGODB_DATABASE:-learnloop}
-  S3_ENDPOINT: ${S3_ENDPOINT:-http://localhost:9000}
-  S3_ACCESS_KEY: ${S3_ACCESS_KEY:-replace-me}
-  S3_SECRET_KEY: ${S3_SECRET_KEY:-replace-me}
-  S3_BUCKET: ${S3_BUCKET:-learnloop-media}
-  S3_REGION: ${S3_REGION:-us-east-1}
-  S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-true}
-
 services:
   mongodb:
     image: mongo:4.4
@@ -99,7 +85,9 @@ services:
       rustfs:
         condition: service_healthy
     environment:
-      <<: *app-env
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-replace-me}
+      S3_BUCKET: ${S3_BUCKET:-learnloop-media}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:-replace-me}
     entrypoint: ["/bin/sh", "-ec"]
     command:
       - |


### PR DESCRIPTION
## Summary

- Remove the `x-app-env` YAML anchor block (13 lines of dead config)
- Replace `<<: *app-env` in `rustfs-bootstrap` with a minimal `environment:` block containing only the 3 variables it needs

## Why

After adding `env_file: ./backend/.env` to the `app` service, the `x-app-env` anchor became redundant. The `app` service no longer references it, and `rustfs-bootstrap` was the only remaining consumer — it only needed `S3_ACCESS_KEY`, `S3_SECRET_KEY`, and `S3_BUCKET`.

## Test Results

- Backend tests: 139 passed, 1 skipped

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)