### PR TITLE
feat: add China mirrors for package management in Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
+    UV_INDEX_URL=https://mirrors.bfsu.edu.cn/pypi/web/simple \
     PATH="/app/.venv/bin:$PATH"
 
 WORKDIR /app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,10 +8,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org|http://mirrors.bfsu.edu.cn|g' /etc/apt/sources.list.d/debian.sources \
+    && apt-get update \
     && apt-get install --no-install-recommends -y curl \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir uv
+    && pip install --no-cache-dir -i https://mirrors.bfsu.edu.cn/pypi/web/simple uv
 
 COPY pyproject.toml uv.lock README.md ./
 RUN uv sync --frozen --no-dev --no-install-project

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,11 @@ FROM node:20-alpine AS build
 
 WORKDIR /app
 
+RUN sed -i 's|http://dl-cdn.alpinelinux.org|http://mirrors.bfsu.edu.cn|g' /etc/apk/repositories \
+    && apk update
+
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --registry=https://registry.npmmirror.com
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary

- Configure backend Dockerfile to use mirrors.bfsu.edu.cn for apt and pip
- Configure frontend Dockerfile to use mirrors.bfsu.edu.cn for apk and npmmirror.com for npm

## Changes

**Backend Dockerfile (Debian-based):**
- apt: mirrors.bfsu.edu.cn (replacing deb.debian.org)
- pip: mirrors.bfsu.edu.cn/pypi/web/simple (via -i flag)

**Frontend Dockerfile (Alpine-based):**
- apk: mirrors.bfsu.edu.cn (replacing dl-cdn.alpinelinux.org)
- npm: registry.npmmirror.com (via --registry flag)

## Test Results

- Backend tests: 139 passed, 1 skipped

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)