### PR TITLE
ci: add Docker Compose smoke test job on PR events

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e46817165094654c6fae5c3f524c6d6e735042ae # v3.11.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Create .env file
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -70,9 +70,10 @@ jobs:
 
       - name: Create .env file
         run: |
-          echo "VLM_API_KEY=ci-placeholder" >> .env
-          echo "S3_ACCESS_KEY=minioadmin" >> .env
-          echo "S3_SECRET_KEY=minioadmin" >> .env
+          mkdir -p backend
+          echo "VLM_API_KEY=ci-placeholder" >> backend/.env
+          echo "S3_ACCESS_KEY=minioadmin" >> backend/.env
+          echo "S3_SECRET_KEY=minioadmin" >> backend/.env
 
       - name: Build and start services
         run: docker compose up -d --build --wait

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -56,3 +56,38 @@ jobs:
       - name: Run frontend unit tests
         working-directory: frontend
         run: npm test -- --run
+
+  docker-smoke-test:
+    name: Docker Compose Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e46817165094654c6fae5c3f524c6d6e735042ae # v3.11.0
+
+      - name: Create .env file
+        run: |
+          echo "VLM_API_KEY=ci-placeholder" >> .env
+          echo "S3_ACCESS_KEY=minioadmin" >> .env
+          echo "S3_SECRET_KEY=minioadmin" >> .env
+
+      - name: Build and start services
+        run: docker compose up -d --build --wait
+        env:
+          DOCKER_BUILDKIT: 1
+
+      - name: Create S3 bucket
+        run: docker compose --profile bootstrap run --rm rustfs-bootstrap
+
+      - name: Smoke test backend health
+        run: curl -fsS http://localhost:8000/api/health
+
+      - name: Smoke test frontend health
+        run: curl -fsS http://localhost:8080/healthz
+
+      - name: Tear down
+        if: always()
+        run: docker compose down --volumes


### PR DESCRIPTION
## Summary

Add a new CI job `docker-smoke-test` to `pr-checks.yml` that verifies the full application stack builds and starts successfully via Docker Compose.

## Implementation

The job:
1. Sets up Docker Buildx for layer caching
2. Creates minimal `.env` with placeholder values (VLM_API_KEY not needed for health checks)
3. Runs `docker compose up -d --build --wait` to start all services and wait for healthchecks
4. Runs rustfs-bootstrap to create the S3 bucket
5. Smokes health endpoints: `curl http://localhost:8000/api/health` and `curl http://localhost:8080/healthz`
6. Tears down with `docker compose down --volumes` (always runs via `if: always()`)

## Why

This catches regressions that unit tests alone can't detect:
- Broken Dockerfiles or misconfigured healthchecks
- Compose syntax errors
- Missing dependencies
- Service connectivity issues

## Test Results

- Backend tests: 139 passed, 1 skipped
- CI workflow YAML syntax valid

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)