### PR TITLE
fix: cleanup unnecessary env vars in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,30 +111,9 @@ services:
     env_file:
       - ./backend/.env
     environment:
-      APP_ENV: ${APP_ENV:-development}
-      APP_HOST: ${APP_HOST:-0.0.0.0}
-      APP_PORT: ${APP_PORT:-8000}
-      APP_LOG_LEVEL: ${APP_LOG_LEVEL:-INFO}
+      # Docker-specific overrides for service hostnames (not in .env)
       MONGODB_URI: mongodb://mongodb:27017/learnloop?replicaSet=rs0&directConnection=true
-      MONGODB_DATABASE: ${MONGODB_DATABASE:-learnloop}
       S3_ENDPOINT: http://rustfs:9000
-      S3_ACCESS_KEY: ${S3_ACCESS_KEY:-replace-me}
-      S3_SECRET_KEY: ${S3_SECRET_KEY:-replace-me}
-      S3_BUCKET: ${S3_BUCKET:-learnloop-media}
-      S3_REGION: ${S3_REGION:-us-east-1}
-      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-true}
-      VLM_ENDPOINT: ${VLM_ENDPOINT:-https://example-vlm-provider.invalid/api}
-      VLM_MODEL: ${VLM_MODEL:-replace-me}
-      VLM_API_KEY: ${VLM_API_KEY:-replace-me}
-      VLM_TIMEOUT_SECONDS: ${VLM_TIMEOUT_SECONDS:-120}
-      PREVIEW_EXTRACTING_WINDOW_SECONDS: ${PREVIEW_EXTRACTING_WINDOW_SECONDS:-150}
-      SESSION_COOKIE_NAME: ${SESSION_COOKIE_NAME:-ll_session}
-      SESSION_SECURE: ${SESSION_SECURE:-false}
-      SESSION_SAMESITE: ${SESSION_SAMESITE:-lax}
-      PRACTICE_COOLDOWN_DAYS: ${PRACTICE_COOLDOWN_DAYS:-7}
-      PRACTICE_LAST_WRONG_WEIGHT: ${PRACTICE_LAST_WRONG_WEIGHT:-1.0}
-      PRACTICE_FAILURE_RATE_WEIGHT: ${PRACTICE_FAILURE_RATE_WEIGHT:-1.0}
-      PRACTICE_RECENCY_WEIGHT: ${PRACTICE_RECENCY_WEIGHT:-1.0}
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
## Summary
Removed redundant environment variables from `app.environment` in `docker-compose.yml` that are already defined in `backend/.env` (loaded via `env_file` directive).

## Implementation
Kept only Docker-specific hostname overrides that differ from localhost values in `.env`:
- `MONGODB_URI`: uses `mongodb` hostname instead of `localhost`
- `S3_ENDPOINT`: uses `rustfs:9000` instead of `localhost:9000`

Removed 22 redundant env vars including all APP_*, VLM_*, SESSION_*, and PRACTICE_* settings.

## Test results
- **Backend tests**: 139 passed, 1 skipped
- **Frontend tests**: 129 passed

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)