### PR TITLE
feat: show practiceable problem count on Practice page

### DIFF
--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -84,6 +84,24 @@ class PracticeHistoryResponse(BaseModel):
     hasMore: bool
 
 
+class PracticeStatsResponse(BaseModel):
+    practiceableCount: int
+
+
+@router.get("/stats", response_model=PracticeStatsResponse)
+async def get_practice_stats(
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> PracticeStatsResponse:
+    """Return count of problems eligible for practice (has correctAnswer, not deleted)."""
+    count = await database["problems"].count_documents({
+        "userId": current_user["_id"],
+        "isDeleted": False,
+        "correctAnswer.display": {"$exists": True, "$ne": ""},
+    })
+    return PracticeStatsResponse(practiceableCount=count)
+
+
 @router.post("/next", response_model=PracticeNextResponse)
 async def get_next_practice_problem(
     database: DatabaseDependency,

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -49,6 +49,12 @@ class FakeCollection:
                 return deepcopy(document)
         return None
 
+    async def count_documents(self, query: dict[str, Any]) -> int:
+        return len([
+            doc for doc in self._documents
+            if matches_query(doc, query)
+        ])
+
     async def update_one(
         self,
         query: dict[str, Any],
@@ -86,19 +92,38 @@ class FakeDatabase:
 
 def matches_query(document: dict[str, Any], query: dict[str, Any]) -> bool:
     for key, value in query.items():
-        actual = document.get(key)
-        if actual is None:
-            return False
-        if isinstance(value, dict) and "$in" in value:
-            if actual not in value["$in"]:
+        # Handle nested keys like "correctAnswer.display"
+        if "." in key:
+            parts = key.split(".")
+            actual = document
+            for part in parts:
+                if not isinstance(actual, dict):
+                    return False
+                actual = actual.get(part)
+        else:
+            actual = document.get(key)
+
+        if isinstance(value, dict):
+            if "$in" in value:
+                if actual not in value["$in"]:
+                    return False
+                continue
+            if "$ne" in value:
+                if actual == value["$ne"]:
+                    return False
+                continue
+            if "$exists" in value:
+                if value["$exists"]:
+                    if actual is None:
+                        return False
+                else:
+                    if actual is not None:
+                        return False
+                continue
+        else:
+            # Simple value comparison
+            if actual != value:
                 return False
-            continue
-        if isinstance(value, dict) and "$ne" in value:
-            if actual == value["$ne"]:
-                return False
-            continue
-        if actual != value:
-            return False
     return True
 
 

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -163,3 +163,26 @@ async def test_no_correct_answer_in_response(
     assert data["status"] == "ok"
     assert "correctAnswer" not in data["problem"]
     assert "secret" not in str(data["problem"])
+
+
+@pytest.mark.asyncio
+async def test_stats_returns_practiceable_count(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+
+    # Create 3 problems with correct answers
+    problems = [
+        make_problem(user_id, text=f"Problem {i}", correct_answer_display=str(i))
+        for i in range(3)
+    ]
+    # Create 1 problem without correct answer (should not be counted)
+    no_answer = make_problem(user_id, text="No answer", correct_answer_display="")
+    database.seed("problems", problems + [no_answer])
+
+    response = await client.get("/api/v1/practice/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["practiceableCount"] == 3

--- a/frontend/src/pages/PracticePage.test.tsx
+++ b/frontend/src/pages/PracticePage.test.tsx
@@ -41,10 +41,15 @@ describe("PracticePage", () => {
   });
 
   it("renders empty state when no history", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ items: [] }),
-    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 0 }),
+      });
 
     renderPracticePage();
 
@@ -55,26 +60,31 @@ describe("PracticePage", () => {
   });
 
   it("renders history with per-problem summary", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        items: [
-          {
-            problemId: "problem-1",
-            problemText: "What is 2+2?",
-            problemType: "short-answer",
-            summary: {
-              totalAttempts: 3,
-              correctCount: 2,
-              wrongCount: 1,
-              lastPracticedAt: "2024-01-01T12:00:00Z",
-              lastResult: "correct",
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              problemId: "problem-1",
+              problemText: "What is 2+2?",
+              problemType: "short-answer",
+              summary: {
+                totalAttempts: 3,
+                correctCount: 2,
+                wrongCount: 1,
+                lastPracticedAt: "2024-01-01T12:00:00Z",
+                lastResult: "correct",
+              },
+              attempts: [],
             },
-            attempts: [],
-          },
-        ],
-      }),
-    });
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 5 }),
+      });
 
     renderPracticePage();
 
@@ -87,33 +97,38 @@ describe("PracticePage", () => {
 
   it("expands row to show attempt details on click", async () => {
     const user = userEvent.setup();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        items: [
-          {
-            problemId: "problem-1",
-            problemText: "Test problem",
-            problemType: "short-answer",
-            summary: {
-              totalAttempts: 1,
-              correctCount: 1,
-              wrongCount: 0,
-              lastPracticedAt: "2024-01-01T12:00:00Z",
-              lastResult: "correct",
-            },
-            attempts: [
-              {
-                submittedAnswer: "my answer",
-                gradingStatus: "correct",
-                gradingMethod: "normalized-match",
-                createdAt: "2024-01-01T12:00:00Z",
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              problemId: "problem-1",
+              problemText: "Test problem",
+              problemType: "short-answer",
+              summary: {
+                totalAttempts: 1,
+                correctCount: 1,
+                wrongCount: 0,
+                lastPracticedAt: "2024-01-01T12:00:00Z",
+                lastResult: "correct",
               },
-            ],
-          },
-        ],
-      }),
-    });
+              attempts: [
+                {
+                  submittedAnswer: "my answer",
+                  gradingStatus: "correct",
+                  gradingMethod: "normalized-match",
+                  createdAt: "2024-01-01T12:00:00Z",
+                },
+              ],
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 1 }),
+      });
 
     renderPracticePage();
 
@@ -130,10 +145,15 @@ describe("PracticePage", () => {
   });
 
   it("shows Start Practice button", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ items: [] }),
-    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 0 }),
+      });
 
     renderPracticePage();
 
@@ -152,6 +172,10 @@ describe("PracticePage", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => ({ practiceableCount: 5 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ({ status: "ok", problem: { id: "p1", text: "Test", type: "short-answer" } }),
       });
 
@@ -164,10 +188,10 @@ describe("PracticePage", () => {
     await user.click(screen.getByTestId("start-practice-button"));
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      const secondCall = mockFetch.mock.calls[1];
-      expect(secondCall[0]).toBe("/api/v1/practice/next");
-      expect(secondCall[1].method).toBe("POST");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const lastCall = mockFetch.mock.calls[2];
+      expect(lastCall[0]).toBe("/api/v1/practice/next");
+      expect(lastCall[1].method).toBe("POST");
     });
   });
 
@@ -177,6 +201,10 @@ describe("PracticePage", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ items: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 5 }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -203,6 +231,10 @@ describe("PracticePage", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ items: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 0 }),
       })
       .mockResolvedValueOnce({
         ok: true,

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -10,6 +10,10 @@ interface PracticeHistoryResponse {
   items: PracticeHistoryItem[];
 }
 
+interface PracticeStatsResponse {
+  practiceableCount: number;
+}
+
 function formatDate(dateString?: string) {
   if (!dateString) return "—";
   return new Date(dateString).toLocaleString();
@@ -183,6 +187,11 @@ export function PracticePage() {
     queryFn: () => api.get<PracticeHistoryResponse>("/practice/history"),
   });
 
+  const { data: statsData } = useQuery<PracticeStatsResponse>({
+    queryKey: ["practice-stats"],
+    queryFn: () => api.get<PracticeStatsResponse>("/practice/stats"),
+  });
+
   const startPracticeMutation = useMutation({
     mutationFn: () => api.post<PracticeNextResponse>("/practice/next", {}),
     onSuccess: (response) => {
@@ -218,7 +227,9 @@ export function PracticePage() {
         <div>
           <h1 style={{ margin: 0 }}>Practice</h1>
           <p style={{ color: "#6b7280", margin: "0.5rem 0 0" }}>
-            Review your practice history or start a new session.
+            {statsData?.practiceableCount !== undefined
+              ? `${statsData.practiceableCount} problems available for practice.`
+              : "Review your practice history or start a new session."}
           </p>
         </div>
         <button


### PR DESCRIPTION
## Summary
Added a `/practice/stats` endpoint and frontend display to show the total count of practiceable problems when entering Practice mode.

## Implementation
- **Backend**: New `GET /api/v1/practice/stats` endpoint returns `{"practiceableCount": int}` - count of problems with correctAnswer set and not deleted
- **Frontend**: Fetches stats on page load and displays "X problems available for practice" in the Practice page header

## Test results
- **Backend tests**: 140 passed, 1 skipped (new test for stats endpoint added)
- **Frontend tests**: 129 passed (updated mocks for stats endpoint)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)