### PR TITLE
feat: show original image during ingestion edit stage

### DIFF
--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -3,16 +3,19 @@ from __future__ import annotations
 import hashlib
 import mimetypes
 from collections.abc import Mapping
+from io import BytesIO
 from pathlib import Path
 from typing import Any, Annotated
 
 from bson import ObjectId
 from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from app.domain import IngestionPreviewStatus, ProblemType, normalize_answer
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import Document
+from app.infrastructure.storage.s3 import StorageObjectNotFoundError
 from app.infrastructure.vlm.client import VLMClient
 from app.presentation.deps import DatabaseDependency, StorageDependency, create_vlm_client, get_app_settings, get_current_user, get_s3_storage
 from app.presentation.errors import ApiError
@@ -341,3 +344,28 @@ async def confirm_preview(
         raise ApiError(500, "PROBLEM_CREATION_FAILED", "Failed to create problem. Please retry confirmation.")
     await _register_tags(database, user["_id"], list(draft.get("tags", [])))
     return ProblemResponse(problem=serialize_problem(problem))
+
+
+@router.get("/{preview_id}/image")
+async def stream_preview_image(
+    preview_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+    s3_storage: S3Dependency,
+) -> StreamingResponse:
+    preview = await _get_owned_preview(database, preview_id, user)
+    source_image = dict(preview.get("sourceImage") or {})
+    bucket = source_image.get("bucket")
+    object_key = source_image.get("objectKey")
+    if not bucket or not object_key:
+        raise ApiError(404, "NOT_FOUND", "Preview image not found")
+
+    try:
+        image_bytes = s3_storage.get_object(str(bucket), str(object_key))
+    except StorageObjectNotFoundError as exc:
+        raise ApiError(404, "NOT_FOUND", "Preview image not found") from exc
+
+    return StreamingResponse(
+        BytesIO(image_bytes),
+        media_type=str(source_image.get("contentType") or "application/octet-stream"),
+    )

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -797,3 +797,81 @@ async def test_ingestion_routes_require_authentication(
     assert response.json() == {
         "error": {"code": "UNAUTHENTICATED", "message": "Authentication required"}
     }
+
+
+@pytest.mark.asyncio
+async def test_stream_preview_image_returns_image(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    database: FakeDatabase = ingestion_app.state.fake_database
+    storage: FakeStorage = ingestion_app.state.fake_storage
+    user = await database["users"].find_one({"username": "student1"})
+    assert user is not None
+    user_id = user["_id"]
+
+    image_bytes = make_png_bytes()
+    preview = make_preview(user_id)
+    preview["sourceImage"] = {
+        "bucket": "learnloop-media",
+        "objectKey": "test/preview-image.png",
+        "contentType": "image/png",
+        "sizeBytes": len(image_bytes),
+    }
+    storage.seed("learnloop-media", "test/preview-image.png", image_bytes)
+    database["ingestion_previews"].seed(preview)
+
+    response = await authenticated_client.get(f"/api/v1/ingestion-previews/{preview['_id']}/image")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.content == image_bytes
+
+
+@pytest.mark.asyncio
+async def test_stream_preview_image_returns_404_for_missing_source_image(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    database: FakeDatabase = ingestion_app.state.fake_database
+    user = await database["users"].find_one({"username": "student1"})
+    assert user is not None
+    user_id = user["_id"]
+
+    preview = make_preview(user_id)
+    preview["sourceImage"] = {}
+    database["ingestion_previews"].seed(preview)
+
+    response = await authenticated_client.get(f"/api/v1/ingestion-previews/{preview['_id']}/image")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {"code": "NOT_FOUND", "message": "Preview image not found"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_stream_preview_image_returns_404_for_other_user_preview(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    database: FakeDatabase = ingestion_app.state.fake_database
+    storage: FakeStorage = ingestion_app.state.fake_storage
+    other_user_id = ObjectId()
+
+    image_bytes = make_png_bytes()
+    preview = make_preview(other_user_id)
+    preview["sourceImage"] = {
+        "bucket": "learnloop-media",
+        "objectKey": "test/other-user-image.png",
+        "contentType": "image/png",
+    }
+    storage.seed("learnloop-media", "test/other-user-image.png", image_bytes)
+    database["ingestion_previews"].seed(preview)
+
+    response = await authenticated_client.get(f"/api/v1/ingestion-previews/{preview['_id']}/image")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {"code": "NOT_FOUND", "message": "Preview not found"}
+    }

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -695,6 +695,33 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
               Edit Problem Details
             </h3>
 
+            {previewId && preview?.sourceImage && (
+              <div style={{ marginBottom: "24px" }}>
+                <label
+                  style={{
+                    display: "block",
+                    marginBottom: "6px",
+                    fontSize: "14px",
+                    fontWeight: 500,
+                    color: "#374151",
+                  }}
+                >
+                  Original Image
+                </label>
+                <img
+                  src={`/api/v1/ingestion-previews/${previewId}/image`}
+                  alt="Original problem image"
+                  style={{
+                    maxWidth: "100%",
+                    maxHeight: "300px",
+                    borderRadius: "6px",
+                    border: "1px solid #e5e7eb",
+                  }}
+                  data-testid="source-image"
+                />
+              </div>
+            )}
+
             <div style={{ marginBottom: "24px" }}>
               <label
                 style={{


### PR DESCRIPTION
## Summary

Adds a backend endpoint to stream preview images and displays the original uploaded image above the problem text during the editing step of ingestion.

## Implementation

### Backend
- Added `GET /ingestion-previews/{preview_id}/image` endpoint to stream the source image for a preview

### Frontend
- Added "Original Image" section in the editing step displaying the source image
- Image is shown above the problem text with max dimensions for reference

## Test Results

- **Backend tests:** 19 passed (ingestion tests)
- **Frontend tests:** 129 passed
- **E2E tests:** Skipped

Closes #68