### PR TITLE
T01: Add teacherPasswordHash to user model and TEACHER_PASSWORD_DEFAULT config

### DIFF
--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -159,6 +159,7 @@ class User(BaseModel):
     id: Optional[str] = None
     username: str
     passwordHash: str
+    teacherPasswordHash: Optional[str] = None
     createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     lastLoginAt: Optional[datetime] = None

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     practice_failure_rate_weight: float = Field(default=1.0, ge=0)
     practice_recency_weight: float = Field(default=1.0, ge=0)
 
+    # Teacher password configuration
+    teacher_password_default: str = Field(default="default-teacher-password")
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:

--- a/backend/app/presentation/auth.py
+++ b/backend/app/presentation/auth.py
@@ -58,6 +58,7 @@ def normalize_username(username: str) -> str:
 async def register(
     payload: CredentialsRequest,
     database=Depends(get_database),
+    settings: Settings = Depends(get_app_settings),
 ) -> UserResponse:
     username = normalize_username(payload.username)
     existing_user = await database["users"].find_one({"username": username})
@@ -70,6 +71,7 @@ async def register(
         "_id": ObjectId(),
         "username": username,
         "passwordHash": hash_password(payload.password),
+        "teacherPasswordHash": hash_password(settings.teacher_password_default),
         "createdAt": now,
         "updatedAt": now,
         "lastLoginAt": None,

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -82,6 +82,8 @@ async def app() -> FastAPI:
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_app_settings] = lambda: settings
+    # Store database on app for tests that need direct access
+    application.state.test_database = database
 
     @application.get("/api/v1/protected")
     async def protected_route(_: dict[str, Any] = Depends(get_current_user)) -> dict[str, bool]:
@@ -219,3 +221,22 @@ async def test_protected_route_rejects_unauthenticated_access(client: AsyncClien
             "message": "Authentication required",
         }
     }
+
+
+@pytest.mark.asyncio
+async def test_register_sets_teacher_password_hash(client: AsyncClient, app: FastAPI) -> None:
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"username": "student1", "password": "secret"},
+    )
+
+    assert response.status_code == 201
+
+    # Get the user from the fake database
+    users = app.state.test_database["users"]._documents
+    assert len(users) == 1
+    user = users[0]
+    assert "teacherPasswordHash" in user
+    assert user["teacherPasswordHash"] is not None
+    # Verify it looks like a bcrypt hash (starts with $2b$ or $2a$)
+    assert user["teacherPasswordHash"].startswith("$2")


### PR DESCRIPTION
This PR implements T01:

- Add teacherPasswordHash optional field to User model
- Add teacher_password_default setting with default value 'default-teacher-password'
- Update register endpoint to set teacherPasswordHash to hashed default password

Closes #70