### PR TITLE
T02: Teacher password verification API endpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.presentation.problems import router as problems_router
 from app.presentation.tags import router as tags_router
 from app.presentation.practice import router as practice_router
 from app.presentation.settings import router as settings_router
+from app.presentation.teacher_password import router as teacher_password_router
 
 
 @asynccontextmanager
@@ -55,6 +56,7 @@ def create_app() -> FastAPI:
     api_v1_router.include_router(tags_router)
     api_v1_router.include_router(practice_router)
     api_v1_router.include_router(settings_router)
+    api_v1_router.include_router(teacher_password_router)
     application.include_router(api_v1_router)
 
     return application

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -75,3 +75,10 @@ def log_auth_event(event: str, **fields: Any) -> None:
         f"auth:{event}",
         extra={"auth_event": event, **fields},
     )
+
+
+def log_teacher_password_event(event: str, **fields: Any) -> None:
+    get_logger("learnloop.teacher_password").info(
+        f"teacher_password:{event}",
+        extra={"teacher_password_event": event, **fields},
+    )

--- a/backend/app/presentation/teacher_password.py
+++ b/backend/app/presentation/teacher_password.py
@@ -1,0 +1,55 @@
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from app.infrastructure.auth.password import hash_password, verify_password
+from app.infrastructure.config.settings import Settings
+from app.observability import log_teacher_password_event
+from app.presentation.deps import get_app_settings, get_current_user, get_database
+from app.presentation.errors import ApiError
+
+router = APIRouter(prefix="/teacher-password", tags=["teacher-password"])
+
+
+class VerifyTeacherPasswordRequest(BaseModel):
+    password: str = Field(min_length=1, max_length=1024)
+
+
+class VerifyTeacherPasswordResponse(BaseModel):
+    ok: bool
+
+
+@router.post("/verify", response_model=VerifyTeacherPasswordResponse)
+async def verify_teacher_password(
+    payload: VerifyTeacherPasswordRequest,
+    user=Depends(get_current_user),
+    database=Depends(get_database),
+    settings: Settings = Depends(get_app_settings),
+) -> VerifyTeacherPasswordResponse:
+    # Get or create teacherPasswordHash for user (handle existing users without it)
+    teacher_password_hash = user.get("teacherPasswordHash")
+    if teacher_password_hash is None:
+        # Auto-migrate existing user: set to default password hash
+        teacher_password_hash = hash_password(settings.teacher_password_default)
+        now = datetime.now(UTC)
+        await database["users"].update_one(
+            {"_id": user["_id"]},
+            {"$set": {"teacherPasswordHash": teacher_password_hash, "updatedAt": now}},
+        )
+        log_teacher_password_event(
+            "auto_migrate_existing_user",
+            user_id=str(user["_id"]),
+            username=user["username"],
+        )
+
+    ok = verify_password(payload.password, teacher_password_hash)
+    log_teacher_password_event(
+        "verify_attempt",
+        user_id=str(user["_id"]),
+        username=user["username"],
+        success=ok,
+    )
+    if not ok:
+        raise ApiError(401, "UNAUTHENTICATED", "Incorrect teacher password")
+    return VerifyTeacherPasswordResponse(ok=True)


### PR DESCRIPTION
This PR implements T02:

- Add log_teacher_password_event to observability
- Add teacher_password router with /verify endpoint
- Endpoint auto-migrates existing users without teacherPasswordHash by setting it to the hashed default password
- Verify password against stored hash, log all attempts
- Return 401 with generic error on incorrect password

Closes #71