### PR TITLE
T03: Teacher password change API endpoint

### DIFF
--- a/backend/app/presentation/teacher_password.py
+++ b/backend/app/presentation/teacher_password.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.infrastructure.auth.password import hash_password, verify_password
 from app.infrastructure.config.settings import Settings
@@ -17,6 +17,23 @@ class VerifyTeacherPasswordRequest(BaseModel):
 
 
 class VerifyTeacherPasswordResponse(BaseModel):
+    ok: bool
+
+
+class ChangeTeacherPasswordRequest(BaseModel):
+    current_password: str = Field(min_length=1, max_length=1024)
+    new_password: str = Field(min_length=1, max_length=1024)
+    confirm_password: str = Field(min_length=1, max_length=1024)
+
+    @field_validator("confirm_password")
+    @classmethod
+    def passwords_match(cls, confirm_password: str, info) -> str:
+        if "new_password" in info.data and confirm_password != info.data["new_password"]:
+            raise ValueError("Passwords do not match")
+        return confirm_password
+
+
+class ChangeTeacherPasswordResponse(BaseModel):
     ok: bool
 
 
@@ -53,3 +70,53 @@ async def verify_teacher_password(
     if not ok:
         raise ApiError(401, "UNAUTHENTICATED", "Incorrect teacher password")
     return VerifyTeacherPasswordResponse(ok=True)
+
+
+@router.post("/change", response_model=ChangeTeacherPasswordResponse)
+async def change_teacher_password(
+    payload: ChangeTeacherPasswordRequest,
+    user=Depends(get_current_user),
+    database=Depends(get_database),
+    settings: Settings = Depends(get_app_settings),
+) -> ChangeTeacherPasswordResponse:
+    # Get or create teacherPasswordHash for user (handle existing users without it)
+    teacher_password_hash = user.get("teacherPasswordHash")
+    if teacher_password_hash is None:
+        # Auto-migrate existing user: set to default password hash
+        teacher_password_hash = hash_password(settings.teacher_password_default)
+        now = datetime.now(UTC)
+        await database["users"].update_one(
+            {"_id": user["_id"]},
+            {"$set": {"teacherPasswordHash": teacher_password_hash, "updatedAt": now}},
+        )
+        log_teacher_password_event(
+            "auto_migrate_existing_user",
+            user_id=str(user["_id"]),
+            username=user["username"],
+        )
+
+    # Verify current password
+    current_password_ok = verify_password(payload.current_password, teacher_password_hash)
+    log_teacher_password_event(
+        "change_verify_attempt",
+        user_id=str(user["_id"]),
+        username=user["username"],
+        success=current_password_ok,
+    )
+    if not current_password_ok:
+        raise ApiError(401, "UNAUTHENTICATED", "Incorrect teacher password")
+
+    # Hash and update new password
+    new_teacher_password_hash = hash_password(payload.new_password)
+    now = datetime.now(UTC)
+    await database["users"].update_one(
+        {"_id": user["_id"]},
+        {"$set": {"teacherPasswordHash": new_teacher_password_hash, "updatedAt": now}},
+    )
+    log_teacher_password_event(
+        "change_success",
+        user_id=str(user["_id"]),
+        username=user["username"],
+    )
+
+    return ChangeTeacherPasswordResponse(ok=True)

--- a/backend/tests/api/test_teacher_password.py
+++ b/backend/tests/api/test_teacher_password.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from copy import deepcopy
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.infrastructure.auth.password import hash_password
+from app.infrastructure.config.settings import Settings
+from app.main import create_app
+from app.presentation.deps import get_app_settings, get_current_user, get_database
+
+
+class FakeInsertOneResult:
+    def __init__(self, inserted_id: Any) -> None:
+        self.inserted_id = inserted_id
+
+
+class FakeUpdateResult:
+    def __init__(self, modified_count: int) -> None:
+        self.modified_count = modified_count
+
+
+class FakeDeleteResult:
+    def __init__(self, deleted_count: int) -> None:
+        self.deleted_count = deleted_count
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self._documents: list[dict[str, Any]] = []
+
+    async def find_one(self, query: dict[str, Any]) -> dict[str, Any] | None:
+        for document in self._documents:
+            if all(document.get(key) == value for key, value in query.items()):
+                return deepcopy(document)
+        return None
+
+    async def insert_one(self, document: dict[str, Any]) -> FakeInsertOneResult:
+        stored_document = deepcopy(document)
+        if "_id" not in stored_document:
+            stored_document["_id"] = ObjectId()
+        self._documents.append(stored_document)
+        return FakeInsertOneResult(stored_document["_id"])
+
+    async def update_one(self, query: dict[str, Any], update: dict[str, Any]) -> FakeUpdateResult:
+        for document in self._documents:
+            if all(document.get(key) == value for key, value in query.items()):
+                for key, value in update.get("$set", {}).items():
+                    document[key] = value
+                return FakeUpdateResult(1)
+        return FakeUpdateResult(0)
+
+    async def delete_one(self, query: dict[str, Any]) -> FakeDeleteResult:
+        for index, document in enumerate(self._documents):
+            if all(document.get(key) == value for key, value in query.items()):
+                del self._documents[index]
+                return FakeDeleteResult(1)
+        return FakeDeleteResult(0)
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self._collections = {
+            "users": FakeCollection(),
+            "sessions": FakeCollection(),
+        }
+
+    def __getitem__(self, name: str) -> FakeCollection:
+        return self._collections[name]
+
+
+@pytest_asyncio.fixture
+async def app() -> FastAPI:
+    application = create_app()
+    database = FakeDatabase()
+    settings = Settings()
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_app_settings] = lambda: settings
+    # Store database on app for tests that need direct access
+    application.state.test_database = database
+
+    @application.get("/api/v1/protected")
+    async def protected_route(_: dict[str, Any] = Depends(get_current_user)) -> dict[str, bool]:
+        return {"ok": True}
+
+    return application
+
+
+@pytest_asyncio.fixture
+async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+@pytest_asyncio.fixture
+async def authenticated_client(client: AsyncClient) -> AsyncIterator[AsyncClient]:
+    # Register and login a user
+    await client.post(
+        "/api/v1/auth/register",
+        json={"username": "student1", "password": "secret"},
+    )
+    await client.post(
+        "/api/v1/auth/login",
+        json={"username": "student1", "password": "secret"},
+    )
+    yield client
+
+
+@pytest.mark.asyncio
+async def test_verify_teacher_password_success(authenticated_client: AsyncClient) -> None:
+    response = await authenticated_client.post(
+        "/api/v1/teacher-password/verify",
+        json={"password": "default-teacher-password"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_verify_teacher_password_incorrect(authenticated_client: AsyncClient) -> None:
+    response = await authenticated_client.post(
+        "/api/v1/teacher-password/verify",
+        json={"password": "wrong-password"},
+    )
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {"code": "UNAUTHENTICATED", "message": "Incorrect teacher password"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_change_teacher_password_success(
+    authenticated_client: AsyncClient, app: FastAPI
+) -> None:
+    # First change the password
+    change_response = await authenticated_client.post(
+        "/api/v1/teacher-password/change",
+        json={
+            "current_password": "default-teacher-password",
+            "new_password": "new-teacher-password",
+            "confirm_password": "new-teacher-password",
+        },
+    )
+    assert change_response.status_code == 200
+    assert change_response.json() == {"ok": True}
+
+    # Verify the new password works
+    verify_response = await authenticated_client.post(
+        "/api/v1/teacher-password/verify",
+        json={"password": "new-teacher-password"},
+    )
+    assert verify_response.status_code == 200
+    assert verify_response.json() == {"ok": True}
+
+    # Verify the old password no longer works
+    old_verify_response = await authenticated_client.post(
+        "/api/v1/teacher-password/verify",
+        json={"password": "default-teacher-password"},
+    )
+    assert old_verify_response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_change_teacher_password_incorrect_current(authenticated_client: AsyncClient) -> None:
+    response = await authenticated_client.post(
+        "/api/v1/teacher-password/change",
+        json={
+            "current_password": "wrong-password",
+            "new_password": "new-teacher-password",
+            "confirm_password": "new-teacher-password",
+        },
+    )
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {"code": "UNAUTHENTICATED", "message": "Incorrect teacher password"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_change_teacher_password_mismatched_confirm(authenticated_client: AsyncClient) -> None:
+    response = await authenticated_client.post(
+        "/api/v1/teacher-password/change",
+        json={
+            "current_password": "default-teacher-password",
+            "new_password": "new-teacher-password",
+            "confirm_password": "different-password",
+        },
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
This PR implements T03:

- Add POST /teacher-password/change endpoint
- Verify current password before allowing change
- Check that new password and confirm password match
- Hash new password and update user document
- Add logging for change events
- Add test coverage for change endpoint

Closes #72