### PR TITLE
T05: Reusable teacher password modal dialog component

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -98,6 +98,21 @@ export const api = {
   },
 
   /**
+   * Verify teacher password
+   */
+  async verifyTeacherPassword(password: string): Promise<{ ok: boolean }> {
+    const response = await fetch(`${API_BASE}/teacher-password/verify`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({ password }),
+    });
+    return handleResponse<{ ok: boolean }>(response);
+  },
+
+  /**
    * Generic GET request
    */
   async get<T>(path: string): Promise<T> {

--- a/frontend/src/components/TeacherPasswordModal.test.tsx
+++ b/frontend/src/components/TeacherPasswordModal.test.tsx
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { TeacherPasswordModal } from "./TeacherPasswordModal";
+
+// Mock the API client
+vi.mock("@/api/client", () => ({
+  api: {
+    verifyTeacherPassword: vi.fn(),
+  },
+}));
+
+import { api } from "@/api/client";
+
+describe("TeacherPasswordModal", () => {
+  const mockOnClose = vi.fn();
+  const mockOnVerified = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not render when isOpen is false", () => {
+    render(
+      <TeacherPasswordModal
+        isOpen={false}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+    expect(screen.queryByTestId("teacher-password-modal")).not.toBeInTheDocument();
+  });
+
+  it("renders modal with password input and submit button when open", () => {
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+    expect(screen.getByTestId("teacher-password-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("teacher-password-input")).toBeInTheDocument();
+    expect(screen.getByTestId("teacher-password-submit")).toBeInTheDocument();
+    expect(screen.getByTestId("teacher-password-cancel")).toBeInTheDocument();
+  });
+
+  it("successful verification calls onVerified and closes", async () => {
+    vi.mocked(api.verifyTeacherPassword).mockResolvedValueOnce({ ok: true });
+
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("teacher-password-input"), {
+      target: { value: "correct-password" },
+    });
+    fireEvent.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(api.verifyTeacherPassword).toHaveBeenCalledWith("correct-password");
+      expect(mockOnVerified).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  it("failed verification shows error message", async () => {
+    vi.mocked(api.verifyTeacherPassword).mockRejectedValueOnce(
+      new Error("Incorrect teacher password")
+    );
+
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("teacher-password-input"), {
+      target: { value: "wrong-password" },
+    });
+    fireEvent.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teacher-password-error")).toHaveTextContent(
+        "Incorrect teacher password"
+      );
+    });
+
+    expect(mockOnVerified).not.toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it("empty submission shows client-side error", async () => {
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teacher-password-error")).toHaveTextContent(
+        "Password cannot be empty"
+      );
+    });
+
+    expect(api.verifyTeacherPassword).not.toHaveBeenCalled();
+  });
+
+  it("network error shows network error message", async () => {
+    vi.mocked(api.verifyTeacherPassword).mockRejectedValueOnce(
+      new Error("Network failure")
+    );
+
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    fireEvent.change(screen.getByTestId("teacher-password-input"), {
+      target: { value: "some-password" },
+    });
+    fireEvent.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teacher-password-error")).toHaveTextContent(
+        "Network error. Please try again."
+      );
+    });
+  });
+
+  it("retry after failure allows resubmission", async () => {
+    vi.mocked(api.verifyTeacherPassword)
+      .mockRejectedValueOnce(new Error("Incorrect teacher password"))
+      .mockResolvedValueOnce({ ok: true });
+
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    // First attempt fails
+    fireEvent.change(screen.getByTestId("teacher-password-input"), {
+      target: { value: "wrong-password" },
+    });
+    fireEvent.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teacher-password-error")).toBeInTheDocument();
+    });
+
+    // Retry with correct password
+    fireEvent.change(screen.getByTestId("teacher-password-input"), {
+      target: { value: "correct-password" },
+    });
+    fireEvent.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(mockOnVerified).toHaveBeenCalled();
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    expect(api.verifyTeacherPassword).toHaveBeenCalledTimes(2);
+  });
+
+  it("Escape key closes modal", () => {
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it("Cancel button closes modal", () => {
+    render(
+      <TeacherPasswordModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onVerified={mockOnVerified}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId("teacher-password-cancel"));
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/TeacherPasswordModal.tsx
+++ b/frontend/src/components/TeacherPasswordModal.tsx
@@ -1,0 +1,157 @@
+import { useState, useEffect, useRef } from "react";
+import { api } from "@/api/client";
+
+interface TeacherPasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onVerified: () => void;
+}
+
+export function TeacherPasswordModal({
+  isOpen,
+  onClose,
+  onVerified,
+}: TeacherPasswordModalProps) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setPassword("");
+      setError(null);
+      setIsSubmitting(false);
+      inputRef.current?.focus();
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!password.trim()) {
+      setError("Password cannot be empty");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await api.verifyTeacherPassword(password);
+      onVerified();
+      onClose();
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.message.includes("Incorrect teacher password")) {
+          setError("Incorrect teacher password");
+        } else {
+          setError("Network error. Please try again.");
+        }
+      } else {
+        setError("Network error. Please try again.");
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 1000,
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="teacher-password-title"
+      data-testid="teacher-password-modal"
+    >
+      <div
+        style={{
+          backgroundColor: "white",
+          padding: "1.5rem",
+          borderRadius: "8px",
+          maxWidth: "400px",
+          width: "100%",
+        }}
+      >
+        <h2 id="teacher-password-title" style={{ marginTop: 0 }}>
+          Enter Teacher Password
+        </h2>
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: "1rem" }}>
+            <label htmlFor="teacher-password-input" style={{ display: "block", marginBottom: "0.5rem" }}>
+              Teacher Password
+            </label>
+            <input
+              ref={inputRef}
+              id="teacher-password-input"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={isSubmitting}
+              style={{
+                width: "100%",
+                padding: "0.5rem",
+                border: "1px solid #ccc",
+                borderRadius: "4px",
+              }}
+              data-testid="teacher-password-input"
+            />
+          </div>
+          {error && (
+            <div
+              style={{
+                color: "red",
+                marginBottom: "1rem",
+                fontSize: "0.875rem",
+              }}
+              role="alert"
+              data-testid="teacher-password-error"
+            >
+              {error}
+            </div>
+          )}
+          <div style={{ display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}>
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isSubmitting}
+              data-testid="teacher-password-cancel"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              data-testid="teacher-password-submit"
+            >
+              {isSubmitting ? "Verifying..." : "Submit"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the reusable TeacherPasswordModal component for gating answer access behind teacher password verification.

## Implementation

- **`TeacherPasswordModal.tsx`**: Reusable modal with password input, submit/cancel buttons, error display, and escape key handling. Follows the existing inline fixed-position overlay pattern from `ActiveExamPage.tsx`.
- **`api/client.ts`**: Added `verifyTeacherPassword(password)` method calling `POST /api/v1/teacher-password/verify`.
- **`TeacherPasswordModal.test.tsx`**: 9 component tests covering all specified behaviors.

### Key design decisions
- Props: `isOpen`, `onClose`, `onVerified` — matches the issue spec
- On successful verification: calls `onVerified()` then `onClose()`
- On failure: shows error inline, allows retry without closing
- Empty input rejected client-side before API call
- Escape key and Cancel button both close the modal
- `role="dialog"` and `aria-modal="true"` for accessibility

## Test Results

```
$ cd frontend && npx vitest run src/components/TeacherPasswordModal.test.tsx
 ✓ src/components/TeacherPasswordModal.test.tsx (9 tests) 133ms
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ cd frontend && npx vitest run
 Test Files  15 passed (15)
      Tests  138 passed (138)
```

No regressions. All existing tests continue to pass.

## Linked Issue

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)