### PR TITLE
T09: Exam detail — per-answer teacher password gate

### DIFF
--- a/frontend/src/pages/ExamDetailPage.test.tsx
+++ b/frontend/src/pages/ExamDetailPage.test.tsx
@@ -1,0 +1,290 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { ExamDetailPage } from "./ExamDetailPage";
+
+vi.mock("@/api/client", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    verifyTeacherPassword: vi.fn(),
+  },
+}));
+
+import { api } from "@/api/client";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function renderExamDetailPage(examId = "exam123") {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter initialEntries={[`/exams/${examId}`]}>
+        <Routes>
+          <Route path="/exams/:id" element={<ExamDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const baseExamItem = {
+  itemId: "item1",
+  order: 1,
+  problemId: "prob1",
+  problem: {
+    text: "What is 2+2?",
+    problemType: "single-choice",
+    correctAnswer: { display: "4", normalizedText: "4", normalizedSet: ["4"], format: "single" },
+  },
+  answer: { raw: "4", savedAt: "2024-01-01T00:00:00Z" },
+  grading: { status: "correct", retryCount: 0 },
+};
+
+const baseExam = {
+  id: "exam123",
+  state: "submitted",
+  configSnapshot: {
+    maxProblemCount: 5,
+    selectionPolicy: { recencyWeight: 1.0, failureWeight: 1.0 },
+    generatedAt: "2024-01-01T00:00:00Z",
+  },
+  items: [
+    { ...baseExamItem, itemId: "item1", order: 1, grading: { status: "correct", retryCount: 0 } },
+    { ...baseExamItem, itemId: "item2", order: 2, grading: { status: "incorrect", retryCount: 0 } },
+    { ...baseExamItem, itemId: "item3", order: 3, grading: { status: "pending-review", retryCount: 0 } },
+  ],
+  summary: {
+    totalProblems: 3,
+    answeredProblems: 3,
+    gradedProblems: 2,
+    pendingProblems: 1,
+    correctProblems: 1,
+    failedProblems: 1,
+    score: 0.5,
+  },
+  createdAt: "2024-01-01T00:00:00Z",
+  submittedAt: "2024-01-01T01:00:00Z",
+  updatedAt: "2024-01-01T01:00:00Z",
+};
+
+describe("ExamDetailPage", () => {
+  beforeEach(() => {
+    vi.mocked(api.get).mockReset();
+    vi.mocked(api.post).mockReset();
+    vi.mocked(api.verifyTeacherPassword).mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("renders exam details with summary", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Results")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    // Use getAllByText since "Correct" appears multiple times (summary + grading badge)
+    expect(screen.getAllByText("Correct").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Incorrect").length).toBeGreaterThan(0);
+  });
+
+  it("hides correct answers by default", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Question 1")).toBeInTheDocument();
+    });
+
+    // Correct answer should not be visible
+    expect(screen.queryByText("Correct Answer:")).not.toBeInTheDocument();
+
+    // Reveal Answer button should be visible for items with correct answers
+    expect(screen.getByTestId("reveal-answer-item1")).toBeInTheDocument();
+  });
+
+  it("shows Reveal Answer button for each item with correct answer", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reveal-answer-item1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("reveal-answer-item2")).toBeInTheDocument();
+    expect(screen.getByTestId("reveal-answer-item3")).toBeInTheDocument();
+  });
+
+  it("opens modal when clicking Reveal Answer button", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reveal-answer-item1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("reveal-answer-item1"));
+
+    expect(screen.getByTestId("teacher-password-modal")).toBeInTheDocument();
+  });
+
+  it("reveals only specific item's answer after verification", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+    vi.mocked(api.verifyTeacherPassword).mockResolvedValueOnce({ ok: true });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reveal-answer-item1")).toBeInTheDocument();
+    });
+
+    // Click reveal for item1
+    await user.click(screen.getByTestId("reveal-answer-item1"));
+
+    // Enter password and submit
+    await user.type(screen.getByTestId("teacher-password-input"), "teacher-password");
+    await user.click(screen.getByTestId("teacher-password-submit"));
+
+    // Item1's answer is revealed
+    await waitFor(() => {
+      expect(screen.getByText("Correct Answer:")).toBeInTheDocument();
+    });
+
+    // Other items' answers remain hidden
+    expect(screen.getByTestId("reveal-answer-item2")).toBeInTheDocument();
+    expect(screen.getByTestId("reveal-answer-item3")).toBeInTheDocument();
+  });
+
+  it("keeps other items' answers hidden after revealing one", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+    vi.mocked(api.verifyTeacherPassword).mockResolvedValueOnce({ ok: true });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reveal-answer-item1")).toBeInTheDocument();
+    });
+
+    // Reveal item1's answer
+    await user.click(screen.getByTestId("reveal-answer-item1"));
+    await user.type(screen.getByTestId("teacher-password-input"), "teacher-password");
+    await user.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("reveal-answer-item1")).not.toBeInTheDocument();
+    });
+
+    // Item2 and item3 still have Reveal Answer buttons
+    expect(screen.getByTestId("reveal-answer-item2")).toBeInTheDocument();
+    expect(screen.getByTestId("reveal-answer-item3")).toBeInTheDocument();
+  });
+
+  it("handles incorrect password for reveal", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+    vi.mocked(api.verifyTeacherPassword).mockRejectedValueOnce(
+      new Error("Incorrect teacher password")
+    );
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reveal-answer-item1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("reveal-answer-item1"));
+    await user.type(screen.getByTestId("teacher-password-input"), "wrong-password");
+    await user.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teacher-password-error")).toHaveTextContent(
+        "Incorrect teacher password"
+      );
+    });
+
+    // Answer remains hidden
+    expect(screen.queryByText("Correct Answer:")).not.toBeInTheDocument();
+  });
+
+  it("shows pending review items with self-report buttons", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Question 3")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("I was correct")).toBeInTheDocument();
+    expect(screen.getByText("I was incorrect")).toBeInTheDocument();
+  });
+
+  it("shows pending review notice when items need review", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Pending Review:")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates back when clicking Back to History", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Back to History" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Back to History" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/exams");
+  });
+
+  it("shows loading state", async () => {
+    vi.mocked(api.get).mockImplementation(() => new Promise(() => {}));
+
+    renderExamDetailPage();
+
+    expect(screen.getByText("Loading exam details...")).toBeInTheDocument();
+  });
+
+  it("shows error state", async () => {
+    vi.mocked(api.get).mockRejectedValueOnce(new Error("Failed to load"));
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Error loading exam: Failed to load")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/ExamDetailPage.tsx
+++ b/frontend/src/pages/ExamDetailPage.tsx
@@ -1,9 +1,11 @@
+import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { LatexText } from "@/components/LatexText";
+import { TeacherPasswordModal } from "@/components/TeacherPasswordModal";
 import type { ExamItem, ExamResponse, SelfReportRequest, SelfReportResponse } from "@/types/exam";
 
 async function fetchExam(examId: string): Promise<ExamResponse> {
@@ -50,9 +52,11 @@ interface ExamItemReviewProps {
   item: ExamItem;
   onSelfReport: (itemId: string, isCorrect: boolean) => void;
   isSelfReporting: boolean;
+  isAnswerRevealed: boolean;
+  onRevealAnswer: (itemId: string) => void;
 }
 
-function ExamItemReview({ item, onSelfReport, isSelfReporting }: ExamItemReviewProps) {
+function ExamItemReview({ item, onSelfReport, isSelfReporting, isAnswerRevealed, onRevealAnswer }: ExamItemReviewProps) {
   const isPendingReview = item.grading.status === "pending-review";
 
   return (
@@ -87,10 +91,27 @@ function ExamItemReview({ item, onSelfReport, isSelfReporting }: ExamItemReviewP
       </div>
 
       {item.problem.correctAnswer && (
-        <div style={{ marginTop: "1rem", padding: "0.75rem", backgroundColor: "#ecfdf5", borderRadius: "0.25rem" }}>
-          <div style={{ fontSize: "0.875rem", color: "#065f46", marginBottom: "0.25rem" }}>Correct Answer:</div>
-          <div>{item.problem.correctAnswer.display}</div>
-        </div>
+        isAnswerRevealed ? (
+          <div style={{ marginTop: "1rem", padding: "0.75rem", backgroundColor: "#ecfdf5", borderRadius: "0.25rem" }}>
+            <div style={{ fontSize: "0.875rem", color: "#065f46", marginBottom: "0.25rem" }}>Correct Answer:</div>
+            <div>{item.problem.correctAnswer.display}</div>
+          </div>
+        ) : (
+          <button
+            onClick={() => onRevealAnswer(item.itemId)}
+            style={{
+              marginTop: "1rem",
+              padding: "0.5rem 1rem",
+              backgroundColor: "#e0f2fe",
+              border: "1px solid #bae6fd",
+              borderRadius: "0.25rem",
+              cursor: "pointer",
+            }}
+            data-testid={`reveal-answer-${item.itemId}`}
+          >
+            Reveal Answer
+          </button>
+        )
       )}
 
       {item.grading.feedback && (
@@ -145,6 +166,9 @@ export function ExamDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [revealedAnswers, setRevealedAnswers] = useState<Set<string>>(new Set());
+  const [pendingRevealItemId, setPendingRevealItemId] = useState<string | null>(null);
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
 
   const {
     data: examData,
@@ -273,9 +297,26 @@ export function ExamDetailPage() {
             item={item}
             onSelfReport={handleSelfReport}
             isSelfReporting={selfReportMutation.isPending}
+            isAnswerRevealed={revealedAnswers.has(item.itemId)}
+            onRevealAnswer={(itemId) => {
+              setPendingRevealItemId(itemId);
+              setShowPasswordModal(true);
+            }}
           />
         ))}
       </div>
+
+      <TeacherPasswordModal
+        isOpen={showPasswordModal}
+        onClose={() => setShowPasswordModal(false)}
+        onVerified={() => {
+          if (pendingRevealItemId) {
+            setRevealedAnswers((prev) => new Set(prev).add(pendingRevealItemId));
+          }
+          setShowPasswordModal(false);
+          setPendingRevealItemId(null);
+        }}
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- Add per-answer teacher password gate to exam detail page
- Correct answers hidden by default with "Reveal Answer" button for each item
- Clicking button opens TeacherPasswordModal
- On successful verification: only that specific item's answer is revealed
- Track revealed state per item (using Set<string> of itemIds)

## Implementation Notes

- Added `revealedAnswers` state (Set<string>) to track which items are revealed
- Added `pendingRevealItemId` state to track which item is pending password verification
- Modified `ExamItemReview` component to accept `isAnswerRevealed` and `onRevealAnswer` props
- Replaced direct answer display with conditional render: if revealed show answer, else show button
- Uses existing `TeacherPasswordModal` component (no changes needed)

## Test Results

- Frontend: 151 tests pass (12 new in ExamDetailPage)
- Backend: 157 passed, 1 skipped

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)