### PR TITLE
Fix: Make Docker registries configurable for CI reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,9 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
+      args:
+        ALPINE_MIRROR: ${ALPINE_MIRROR:-http://dl-cdn.alpinelinux.org}
+        NPM_REGISTRY: ${NPM_REGISTRY:-https://registry.npmjs.org}
     container_name: learnloop-frontend
     restart: unless-stopped
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,15 @@
 FROM node:20-alpine AS build
 
+ARG ALPINE_MIRROR=http://dl-cdn.alpinelinux.org
+ARG NPM_REGISTRY=https://registry.npmjs.org
+
 WORKDIR /app
 
-RUN sed -i 's|http://dl-cdn.alpinelinux.org|http://mirrors.bfsu.edu.cn|g' /etc/apk/repositories \
+RUN sed -i "s|http://dl-cdn.alpinelinux.org|${ALPINE_MIRROR}|g" /etc/apk/repositories \
     && apk update
 
 COPY package.json package-lock.json ./
-RUN npm ci --registry=https://registry.npmmirror.com
+RUN npm ci --registry=${NPM_REGISTRY}
 
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary

Make Alpine and npm registries configurable via Docker build args to fix intermittent CI timeouts caused by slow Chinese mirrors from US-based GitHub Actions runners.

## Problem

The Docker Compose Smoke Test intermittently times out (15 min) because:
- `frontend/Dockerfile` hardcoded `registry.npmmirror.com` (Chinese npm mirror)
- GitHub Actions runners are US-based; when the Chinese mirror is slow/unreachable, `npm ci` hangs
- Same issue with Alpine mirror on line 5-6

## Solution

- Add `ARG NPM_REGISTRY` and `ARG ALPINE_MIRROR` to `frontend/Dockerfile`
- Default to global registries (`registry.npmjs.org`, `dl-cdn.alpinelinux.org`)
- Support Chinese mirrors via environment variables in `docker-compose.yml`

## Changes

- `frontend/Dockerfile`: Use ARG for configurable registries with global defaults
- `docker-compose.yml`: Add build args with env var support for developers in China

## Usage for Developers in China

```bash
export ALPINE_MIRROR=http://mirrors.bfsu.edu.cn
export NPM_REGISTRY=https://registry.npmmirror.com
docker compose up --build
```

## Test Results

- **Backend Tests**: 157 passed, 1 skipped
- **Frontend Tests**: 158 passed

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)