### PR TITLE
feat: support comma-separated batch input in TagInput

### DIFF
--- a/frontend/src/components/TagInput.test.tsx
+++ b/frontend/src/components/TagInput.test.tsx
@@ -139,6 +139,113 @@ describe("TagInput", () => {
     expect(onChange).toHaveBeenNthCalledWith(2, ["math", "geometry"]);
   });
 
+  describe("comma-separated batch input", () => {
+    it("creates multiple tags from comma-separated input", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={["math"]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "algebra, linear algebra, matrices{enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["math", "algebra", "linear algebra", "matrices"]);
+    });
+
+    it("ignores empty segments from trailing commas", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "algebra, {enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["algebra"]);
+    });
+
+    it("ignores empty segments from double commas", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "algebra,,matrices{enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["algebra", "matrices"]);
+    });
+
+    it("skips duplicate tags already in the list", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={["math"]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "math, algebra{enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["math", "algebra"]);
+    });
+
+    it("deduplicates within comma-separated input", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "algebra, algebra, matrices{enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["algebra", "matrices"]);
+    });
+
+    it("selects highlighted suggestion instead of splitting when dropdown is open", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(
+        <TagInput tags={[]} onChange={onChange} suggestions={["algebra"]} testId="tags-input" />,
+      );
+
+      await user.type(screen.getByTestId("tags-input-field"), "al");
+      await user.type(screen.getByTestId("tags-input-field"), "{enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["algebra"]);
+    });
+
+    it("splits on commas when no suggestion is highlighted", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "trigonometry, calculus{enter}");
+
+      expect(onChange).toHaveBeenCalledWith(["trigonometry", "calculus"]);
+    });
+
+    it("clicking a suggestion adds only that tag, leaving remaining text in input", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(
+        <TagInput tags={[]} onChange={onChange} suggestions={["geometry"]} testId="tags-input" />,
+      );
+
+      await user.type(screen.getByTestId("tags-input-field"), "geo");
+      await user.click(screen.getByTestId("tags-input-suggestion-geometry"));
+
+      expect(onChange).toHaveBeenCalledWith(["geometry"]);
+    });
+
+    it("clears input after adding comma-separated tags", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "a, b, c{enter}");
+
+      expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+    });
+  });
+
   describe("accessibility", () => {
     it("has combobox role on the input", () => {
       render(<TagInput tags={[]} onChange={vi.fn()} testId="tags-input" />);

--- a/frontend/src/components/TagInput.tsx
+++ b/frontend/src/components/TagInput.tsx
@@ -72,21 +72,23 @@ export function TagInput({
   };
 
   const addTag = (value: string) => {
-    const trimmedValue = value.trim();
+    const segments = value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
 
-    if (!trimmedValue) {
+    if (segments.length === 0) {
       setInputValue("");
       closeSuggestions();
       return;
     }
 
-    if (tags.includes(trimmedValue)) {
-      setInputValue("");
-      closeSuggestions();
-      return;
+    const uniqueSegments = segments.filter((s) => !tags.includes(s));
+    const newTags = uniqueSegments.filter(
+      (s, index) => uniqueSegments.indexOf(s) === index,
+    );
+
+    if (newTags.length > 0) {
+      onChange([...tags, ...newTags]);
     }
 
-    onChange([...tags, trimmedValue]);
     setInputValue("");
     closeSuggestions();
   };


### PR DESCRIPTION
## Summary

- Enables comma-separated batch input in `TagInput` component
- Typing `algebra, linear algebra, matrices` and pressing Enter creates 3 separate tag bubbles
- Hybrid flow works: select a suggestion, then type comma-separated text
- Existing suggestion selection behavior unchanged (dropdown with match → single tag on Enter)
- Deduplicates against existing tags and within comma-separated input
- Ignores empty segments from trailing/double commas

## Implementation

Modified `addTag()` to split on commas, trim whitespace, filter empty segments, deduplicate, and add all valid tags.

## Test Results

```
✓ TagInput.test.tsx (24 tests) 536ms
  - 15 existing tests pass
  - 9 new tests covering comma-separated and hybrid scenarios
```

## Linked Issue

Closes #91