### PR TITLE
Fix: Use correct API endpoint for teacher password change (issue #98)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -120,7 +120,7 @@ export const api = {
     newPassword: string,
     confirmPassword: string
   ): Promise<{ ok: boolean }> {
-    const response = await fetch(`${API_BASE}/auth/change-teacher-password`, {
+    const response = await fetch(`${API_BASE}/teacher-password/change`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Fixes issue #98 where teacher password change failed due to wrong API endpoint.

## Change

Update endpoint in frontend API client from:
- `/api/v1/auth/change-teacher-password` (wrong, didn't exist)
- `/api/v1/teacher-password/change` (correct, matches backend)

## Files Changed

- `frontend/src/api/client.ts:123`

## Linked Issue

Closes #98