### PR TITLE
T01: add solution generation models and config

### DIFF
--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -5,6 +5,7 @@ from .models import (
     ExamState,
     IngestionPreviewStatus,
     GradingStatus,
+    SolutionGenerationStatus,
     CorrectAnswer,
     SourceImage,
     Extraction,
@@ -24,6 +25,8 @@ from .models import (
     IngestionPreview,
     Problem,
     Exam,
+    SolutionGenerationTask,
+    CanonicalSolution,
 )
 from .normalization import normalize_answer
 from .selection import select_problems
@@ -40,6 +43,7 @@ __all__ = [
     "ExamState",
     "IngestionPreviewStatus",
     "GradingStatus",
+    "SolutionGenerationStatus",
     "CorrectAnswer",
     "SourceImage",
     "Extraction",
@@ -59,6 +63,8 @@ __all__ = [
     "IngestionPreview",
     "Problem",
     "Exam",
+    "SolutionGenerationTask",
+    "CanonicalSolution",
     "normalize_answer",
     "recover_stale_preview",
     "select_problems",
@@ -67,4 +73,3 @@ __all__ = [
     "InvalidStateTransitionError",
     "compute_summary",
 ]
-

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -39,6 +39,13 @@ class GradingMethod(str, Enum):
     VLM = "vlm"
 
 
+class SolutionGenerationStatus(str, Enum):
+    PENDING = "pending"
+    GENERATING = "generating"
+    READY = "ready"
+    FAILED = "failed"
+
+
 # Nested Models
 class CorrectAnswer(BaseModel):
     display: str
@@ -235,3 +242,25 @@ class PracticeAttempt(BaseModel):
     gradingStatus: GradingStatus = GradingStatus.UNGRADED
     gradingMethod: Optional[GradingMethod] = None
     createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class SolutionGenerationTask(BaseModel):
+    id: Optional[str] = None
+    problem_id: str
+    user_id: str
+    status: SolutionGenerationStatus
+    retry_count: int = 0
+    failure_reason: Optional[str] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    started_at: Optional[datetime] = None
+
+
+class CanonicalSolution(BaseModel):
+    id: Optional[str] = None
+    problem_id: str
+    user_id: str
+    steps_markdown: str
+    final_answer: str
+    math_level_classification: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -38,6 +38,18 @@ class Settings(BaseSettings):
     vlm_timeout_seconds: float = Field(default=120.0, gt=0)
     preview_extracting_window_seconds: float = Field(default=150.0, gt=0)
 
+    solution_llm_endpoint: str = Field(default="https://example-solution-provider.invalid/api")
+    solution_llm_model: str = Field(default="replace-me")
+    solution_llm_api_key: str = Field(default="replace-me")
+
+    coaching_llm_endpoint: str = Field(default="https://example-coaching-provider.invalid/api")
+    coaching_llm_model: str = Field(default="replace-me")
+    coaching_llm_api_key: str = Field(default="replace-me")
+
+    solution_worker_poll_interval_seconds: int = Field(default=5, gt=0)
+    solution_task_timeout_minutes: int = Field(default=10, gt=0)
+    solution_max_retries: int = Field(default=3, ge=0)
+
     session_cookie_name: str = Field(default="ll_session")
     session_secure: bool = Field(default=False)
     session_samesite: Literal["lax", "strict", "none"] = Field(default="lax")

--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -2,6 +2,7 @@ from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import Any, Protocol, cast
 
+from pymongo import ASCENDING
 from pymongo import AsyncMongoClient
 from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.asynchronous.database import AsyncDatabase
@@ -10,6 +11,10 @@ from app.infrastructure.config.settings import Settings, get_settings
 
 Document = dict[str, Any]
 AsyncMongoClientFactory = Callable[[str], AsyncMongoClient[Document]]
+
+TAGS_COLLECTION = "tags"
+SOLUTION_GENERATION_TASKS_COLLECTION = "solution_generation_tasks"
+CANONICAL_SOLUTIONS_COLLECTION = "canonical_solutions"
 
 
 class SupportsAsyncClose(Protocol):
@@ -73,6 +78,23 @@ def get_client(settings: Settings | None = None) -> AsyncMongoClient[Document]:
 
 def get_database(settings: Settings | None = None) -> AsyncDatabase[Document]:
     return get_mongo_adapter(settings).get_database()
+
+
+async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
+    existing_collections = set(await database.list_collection_names())
+
+    for collection_name in (
+        SOLUTION_GENERATION_TASKS_COLLECTION,
+        CANONICAL_SOLUTIONS_COLLECTION,
+    ):
+        if collection_name not in existing_collections:
+            await database.create_collection(collection_name)
+
+    await database[TAGS_COLLECTION].create_index(
+        [("userId", ASCENDING), ("name", ASCENDING)],
+        unique=True,
+        name="user_tag_unique",
+    )
 
 
 @asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,11 +3,10 @@ from typing import cast
 
 from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
-from pymongo import ASCENDING
 from starlette.types import ExceptionHandler
 
 from app.infrastructure.config.settings import get_settings
-from app.infrastructure.storage.mongo import get_database
+from app.infrastructure.storage.mongo import ensure_database_setup, get_database
 from app.observability import configure_logging
 from app.presentation.auth import router as auth_router
 from app.presentation.exams import router as exams_router
@@ -24,11 +23,7 @@ from app.presentation.teacher_password import router as teacher_password_router
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     database = get_database()
-    await database["tags"].create_index(
-        [("userId", ASCENDING), ("name", ASCENDING)],
-        unique=True,
-        name="user_tag_unique",
-    )
+    await ensure_database_setup(database)
     yield
 
 

--- a/backend/tests/domain/test_solution_models.py
+++ b/backend/tests/domain/test_solution_models.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.domain import CanonicalSolution, SolutionGenerationTask, SolutionGenerationStatus
+
+
+def test_solution_generation_task_validates_required_fields_and_defaults() -> None:
+    task = SolutionGenerationTask(
+        problem_id="problem-1",
+        user_id="user-1",
+        status=SolutionGenerationStatus.PENDING,
+    )
+
+    assert task.problem_id == "problem-1"
+    assert task.user_id == "user-1"
+    assert task.status == SolutionGenerationStatus.PENDING
+    assert task.retry_count == 0
+    assert task.failure_reason is None
+    assert task.started_at is None
+    assert isinstance(task.created_at, datetime)
+    assert isinstance(task.updated_at, datetime)
+
+
+def test_solution_generation_task_rejects_invalid_status() -> None:
+    with pytest.raises(ValidationError):
+        SolutionGenerationTask(
+            problem_id="problem-1",
+            user_id="user-1",
+            status="queued",
+        )
+
+
+def test_canonical_solution_stores_markdown_content() -> None:
+    solution = CanonicalSolution(
+        problem_id="problem-1",
+        user_id="user-1",
+        steps_markdown="1. Start with **x + 2 = 4**.\n2. Subtract 2 from both sides.",
+        final_answer="x = 2",
+        math_level_classification="algebra-1",
+    )
+
+    assert solution.steps_markdown.startswith("1. Start with **x + 2 = 4**.")
+    assert solution.final_answer == "x = 2"
+    assert solution.math_level_classification == "algebra-1"
+    assert isinstance(solution.created_at, datetime)
+
+
+def test_canonical_solution_requires_core_fields() -> None:
+    with pytest.raises(ValidationError):
+        CanonicalSolution(
+            problem_id="problem-1",
+            user_id="user-1",
+            steps_markdown="step",
+            final_answer="answer",
+        )

--- a/backend/tests/infrastructure/test_config.py
+++ b/backend/tests/infrastructure/test_config.py
@@ -24,6 +24,15 @@ def test_settings_load_from_environment(monkeypatch) -> None:
     monkeypatch.setenv("VLM_API_KEY", "demo-key")
     monkeypatch.setenv("VLM_TIMEOUT_SECONDS", "12")
     monkeypatch.setenv("PREVIEW_EXTRACTING_WINDOW_SECONDS", "18")
+    monkeypatch.setenv("SOLUTION_LLM_ENDPOINT", "https://solution.example/api")
+    monkeypatch.setenv("SOLUTION_LLM_MODEL", "solution-model")
+    monkeypatch.setenv("SOLUTION_LLM_API_KEY", "solution-key")
+    monkeypatch.setenv("COACHING_LLM_ENDPOINT", "https://coaching.example/api")
+    monkeypatch.setenv("COACHING_LLM_MODEL", "coaching-model")
+    monkeypatch.setenv("COACHING_LLM_API_KEY", "coaching-key")
+    monkeypatch.setenv("SOLUTION_WORKER_POLL_INTERVAL_SECONDS", "9")
+    monkeypatch.setenv("SOLUTION_TASK_TIMEOUT_MINUTES", "15")
+    monkeypatch.setenv("SOLUTION_MAX_RETRIES", "4")
     monkeypatch.setenv("SESSION_COOKIE_NAME", "cookie")
     monkeypatch.setenv("SESSION_SECURE", "true")
     monkeypatch.setenv("SESSION_SAMESITE", "strict")
@@ -47,6 +56,15 @@ def test_settings_load_from_environment(monkeypatch) -> None:
     assert settings.vlm_api_key == "demo-key"
     assert settings.vlm_timeout_seconds == 12
     assert settings.preview_extracting_window_seconds == 18
+    assert settings.solution_llm_endpoint == "https://solution.example/api"
+    assert settings.solution_llm_model == "solution-model"
+    assert settings.solution_llm_api_key == "solution-key"
+    assert settings.coaching_llm_endpoint == "https://coaching.example/api"
+    assert settings.coaching_llm_model == "coaching-model"
+    assert settings.coaching_llm_api_key == "coaching-key"
+    assert settings.solution_worker_poll_interval_seconds == 9
+    assert settings.solution_task_timeout_minutes == 15
+    assert settings.solution_max_retries == 4
     assert settings.session_cookie_name == "cookie"
     assert settings.session_secure is True
     assert settings.session_samesite == "strict"
@@ -71,6 +89,15 @@ def test_settings_defaults_when_environment_missing(monkeypatch) -> None:
         "VLM_API_KEY",
         "VLM_TIMEOUT_SECONDS",
         "PREVIEW_EXTRACTING_WINDOW_SECONDS",
+        "SOLUTION_LLM_ENDPOINT",
+        "SOLUTION_LLM_MODEL",
+        "SOLUTION_LLM_API_KEY",
+        "COACHING_LLM_ENDPOINT",
+        "COACHING_LLM_MODEL",
+        "COACHING_LLM_API_KEY",
+        "SOLUTION_WORKER_POLL_INTERVAL_SECONDS",
+        "SOLUTION_TASK_TIMEOUT_MINUTES",
+        "SOLUTION_MAX_RETRIES",
         "SESSION_COOKIE_NAME",
         "SESSION_SECURE",
         "SESSION_SAMESITE",
@@ -82,4 +109,13 @@ def test_settings_defaults_when_environment_missing(monkeypatch) -> None:
     assert settings.mongodb_uri == "mongodb://localhost:27017/learnloop?replicaSet=rs0&directConnection=true"
     assert settings.s3_force_path_style is True
     assert settings.preview_extracting_window_seconds == 150
+    assert settings.solution_llm_endpoint == "https://example-solution-provider.invalid/api"
+    assert settings.solution_llm_model == "replace-me"
+    assert settings.solution_llm_api_key == "replace-me"
+    assert settings.coaching_llm_endpoint == "https://example-coaching-provider.invalid/api"
+    assert settings.coaching_llm_model == "replace-me"
+    assert settings.coaching_llm_api_key == "replace-me"
+    assert settings.solution_worker_poll_interval_seconds == 5
+    assert settings.solution_task_timeout_minutes == 10
+    assert settings.solution_max_retries == 3
     assert settings.session_samesite == "lax"

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -9,7 +9,11 @@ import pytest
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import (
     AsyncMongoClientFactory,
+    CANONICAL_SOLUTIONS_COLLECTION,
     MongoClientAdapter,
+    SOLUTION_GENERATION_TASKS_COLLECTION,
+    TAGS_COLLECTION,
+    ensure_database_setup,
     get_client,
     get_database,
 )
@@ -18,6 +22,28 @@ from app.infrastructure.storage.mongo import (
 class FakeDatabase:
     def __init__(self, name: str) -> None:
         self.name = name
+        self.created_collections: list[str] = []
+        self.collection_names: list[str] = []
+        self.collections: dict[str, FakeCollection] = {}
+
+    async def list_collection_names(self) -> list[str]:
+        return list(self.collection_names)
+
+    async def create_collection(self, name: str) -> None:
+        self.created_collections.append(name)
+        self.collection_names.append(name)
+        self.collections.setdefault(name, FakeCollection())
+
+    def __getitem__(self, name: str) -> "FakeCollection":
+        return self.collections.setdefault(name, FakeCollection())
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self.index_calls: list[dict[str, Any]] = []
+
+    async def create_index(self, keys, **kwargs) -> None:
+        self.index_calls.append({"keys": list(keys), "kwargs": kwargs})
 
 
 class FakeSession:
@@ -95,3 +121,23 @@ def test_module_helpers_return_client_and_database() -> None:
 
     assert client.options._options["document_class"] is dict
     assert database.name == "helper-db"
+
+
+@pytest.mark.asyncio
+async def test_ensure_database_setup_creates_solution_collections_and_tag_index() -> None:
+    database = FakeDatabase("learnloop-test")
+    database.collection_names = [TAGS_COLLECTION]
+    database.collections[TAGS_COLLECTION] = FakeCollection()
+
+    await ensure_database_setup(database)
+
+    assert database.created_collections == [
+        SOLUTION_GENERATION_TASKS_COLLECTION,
+        CANONICAL_SOLUTIONS_COLLECTION,
+    ]
+    assert database[TAGS_COLLECTION].index_calls == [
+        {
+            "keys": [("userId", 1), ("name", 1)],
+            "kwargs": {"unique": True, "name": "user_tag_unique"},
+        }
+    ]


### PR DESCRIPTION
## Summary
- add `SolutionGenerationStatus`, `SolutionGenerationTask`, and `CanonicalSolution` domain models for the solution-generation lifecycle
- add separate solution/coaching LLM settings plus solution worker defaults
- register solution collections in MongoDB startup setup and add focused model/config/storage tests

## Implementation Notes
- kept the new solution records in snake_case to match issue `#101` field names; existing API-facing models remain unchanged
- centralized MongoDB startup setup in `ensure_database_setup()` so the new collections are created alongside the existing tag index
- exported the new domain types from `app.domain` for downstream worker/API issues

## Test Results
- `cd backend && uv run pytest` ✅ `173 passed, 1 skipped`
- `cd backend && uv run pytest tests/ -k "solution or config"` ✅ `8 passed`
- `cd frontend && npm test -- --run` ✅ `17 passed, 168 tests`
- `cd frontend && npm run test:ui` ❌ existing frontend E2E failures in `tests/practice.spec.ts` and `tests/teacher-password.spec.ts`; this backend-only change does not touch those flows

Closes #101