### PR TITLE
T09: add solution and coaching LLM clients

### DIFF
--- a/backend/app/infrastructure/llm/__init__.py
+++ b/backend/app/infrastructure/llm/__init__.py
@@ -1,0 +1,33 @@
+"""LLM provider integration namespace."""
+
+from app.infrastructure.llm.client import (
+    FAILURE_CODE_INVALID_RESPONSE,
+    FAILURE_CODE_NETWORK,
+    FAILURE_CODE_PROVIDER,
+    FAILURE_CODE_PROVIDER_REJECTED,
+    FAILURE_CODE_TIMEOUT,
+    CoachingLLMClient,
+    CoachingLLMRequest,
+    CoachingLLMResult,
+    CoachingMessage,
+    LLMClientError,
+    SolutionLLMClient,
+    SolutionLLMRequest,
+    SolutionLLMResult,
+)
+
+__all__ = [
+    "FAILURE_CODE_INVALID_RESPONSE",
+    "FAILURE_CODE_NETWORK",
+    "FAILURE_CODE_PROVIDER",
+    "FAILURE_CODE_PROVIDER_REJECTED",
+    "FAILURE_CODE_TIMEOUT",
+    "CoachingLLMClient",
+    "CoachingLLMRequest",
+    "CoachingLLMResult",
+    "CoachingMessage",
+    "LLMClientError",
+    "SolutionLLMClient",
+    "SolutionLLMRequest",
+    "SolutionLLMResult",
+]

--- a/backend/app/infrastructure/llm/client.py
+++ b/backend/app/infrastructure/llm/client.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
+
+from app.infrastructure.config.settings import Settings, get_settings
+from app.infrastructure.llm.prompts import (
+    COACHING_PROMPT_VERSION,
+    SOLUTION_PROMPT_VERSION,
+    build_coaching_prompt,
+    build_solution_prompt,
+)
+
+FAILURE_CODE_TIMEOUT = "llm-timeout"
+FAILURE_CODE_NETWORK = "llm-network-error"
+FAILURE_CODE_PROVIDER = "llm-provider-error"
+FAILURE_CODE_PROVIDER_REJECTED = "llm-provider-rejected"
+FAILURE_CODE_INVALID_RESPONSE = "llm-invalid-response"
+
+
+class LLMClientError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        retryable: bool,
+        status_code: int | None = None,
+        raw_provider_response: Any | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+        self.status_code = status_code
+        self.raw_provider_response = raw_provider_response
+
+
+class _ChatMessageContentText(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class _ChatMessageContentImageUrl(BaseModel):
+    type: Literal["image_url"]
+    image_url: dict[str, str]
+
+
+class _ChatMessage(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: list[_ChatMessageContentText | _ChatMessageContentImageUrl] | str
+
+
+class _ChatCompletionRequest(BaseModel):
+    model: str
+    messages: list[_ChatMessage]
+
+
+class _ChatCompletionMessage(BaseModel):
+    role: str
+    content: str | None = None
+
+
+class _ChatCompletionChoice(BaseModel):
+    index: int
+    message: _ChatCompletionMessage
+
+
+class _ChatCompletionResponse(BaseModel):
+    choices: list[_ChatCompletionChoice]
+
+
+class SolutionLLMRequest(BaseModel):
+    problem_text: str
+    correct_answer: str
+    graph_dsl: str | None = None
+    image_url: str | None = None
+    image_base64: str | None = None
+
+    @model_validator(mode="after")
+    def validate_image_reference(self) -> SolutionLLMRequest:
+        if not self.image_url and not self.image_base64:
+            raise ValueError("either image_url or image_base64 is required")
+        return self
+
+
+class SolutionLLMResult(BaseModel):
+    prompt_version: str
+    model: str
+    steps_markdown: str
+    final_answer: str
+    math_level_classification: str
+    raw_provider_response: dict[str, Any]
+
+
+class CoachingMessage(BaseModel):
+    role: Literal["student", "coach"]
+    text: str
+
+
+class CoachingLLMRequest(BaseModel):
+    problem_text: str
+    correct_answer: str
+    canonical_steps_markdown: str
+    canonical_final_answer: str
+    math_level_classification: str
+    conversation_history: list[CoachingMessage] = Field(default_factory=list)
+    new_message: str
+    student_answer: str | None = None
+    judgement: str | None = None
+
+
+class CoachingLLMResult(BaseModel):
+    prompt_version: str
+    model: str
+    text: str
+    whiteboard_dsl: str | None = None
+    raw_provider_response: dict[str, Any]
+
+
+class _SolutionProviderPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    steps_markdown: str
+    final_answer: str
+    math_level_classification: str
+
+
+class _CoachingProviderPayload(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    text: str
+    whiteboard_dsl: str | None = None
+
+
+class _BaseLLMClient:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        model: str,
+        api_key: str,
+        timeout_seconds: float,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._endpoint = endpoint
+        self._model = model
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+        self._http_client = http_client
+        self._owns_client = http_client is None
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                base_url=self._endpoint,
+                timeout=self._timeout_seconds,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+        return self._http_client
+
+    async def aclose(self) -> None:
+        if self._owns_client and self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def _send_chat_completion(self, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            response = await self.http_client.post("/chat/completions", json=payload)
+        except httpx.TimeoutException as exc:
+            raise LLMClientError(
+                "LLM request timed out",
+                code=FAILURE_CODE_TIMEOUT,
+                retryable=True,
+            ) from exc
+        except httpx.NetworkError as exc:
+            raise LLMClientError(
+                "LLM network request failed",
+                code=FAILURE_CODE_NETWORK,
+                retryable=True,
+            ) from exc
+
+        raw_body = self._decode_raw_response(response)
+
+        if 500 <= response.status_code:
+            raise LLMClientError(
+                f"LLM provider returned server error {response.status_code}",
+                code=FAILURE_CODE_PROVIDER,
+                retryable=True,
+                status_code=response.status_code,
+                raw_provider_response=raw_body,
+            )
+
+        if 400 <= response.status_code:
+            raise LLMClientError(
+                f"LLM provider rejected request with status {response.status_code}",
+                code=FAILURE_CODE_PROVIDER_REJECTED,
+                retryable=False,
+                status_code=response.status_code,
+                raw_provider_response=raw_body,
+            )
+
+        if not isinstance(raw_body, dict):
+            raise LLMClientError(
+                "LLM provider response must be a JSON object",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                status_code=response.status_code,
+                raw_provider_response=raw_body,
+            )
+
+        return self._parse_chat_completion_response(raw_body)
+
+    @staticmethod
+    def _decode_raw_response(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    @staticmethod
+    def _strip_json_code_fences(content: str) -> str:
+        stripped = content.strip()
+        if not stripped.startswith("```"):
+            return stripped
+
+        lines = stripped.splitlines()
+        if len(lines) < 2:
+            return stripped
+
+        if not lines[0].strip().startswith("```") or lines[-1].strip() != "```":
+            return stripped
+
+        return "\n".join(lines[1:-1]).strip()
+
+    @classmethod
+    def _load_json_content(cls, content: str) -> dict[str, Any]:
+        candidates = [cls._strip_json_code_fences(content), content.strip()]
+        raw = content.strip()
+        start = raw.find("{")
+        end = raw.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            candidates.append(raw[start : end + 1])
+
+        for candidate in candidates:
+            try:
+                parsed = json.loads(candidate)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+
+        raise LLMClientError(
+            "LLM provider response content was not valid JSON",
+            code=FAILURE_CODE_INVALID_RESPONSE,
+            retryable=False,
+            raw_provider_response=content,
+        )
+
+    @classmethod
+    def _parse_chat_completion_response(cls, raw_body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            completion = _ChatCompletionResponse.model_validate(raw_body)
+        except ValidationError as exc:
+            raise LLMClientError(
+                "LLM provider response failed chat completion validation",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_body,
+            ) from exc
+
+        if not completion.choices:
+            raise LLMClientError(
+                "LLM provider returned no choices",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_body,
+            )
+
+        content = completion.choices[0].message.content
+        if not content:
+            raise LLMClientError(
+                "LLM provider response content was empty",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_body,
+            )
+
+        return cls._load_json_content(content)
+
+
+class SolutionLLMClient(_BaseLLMClient):
+    def __init__(self, settings: Settings | None = None, http_client: httpx.AsyncClient | None = None) -> None:
+        self._settings = settings or get_settings()
+        super().__init__(
+            endpoint=self._settings.solution_llm_endpoint,
+            model=self._settings.solution_llm_model,
+            api_key=self._settings.solution_llm_api_key,
+            timeout_seconds=self._settings.vlm_timeout_seconds,
+            http_client=http_client,
+        )
+
+    async def generate_solution(self, request: SolutionLLMRequest) -> SolutionLLMResult:
+        prompt = build_solution_prompt(
+            problem_text=request.problem_text,
+            correct_answer=request.correct_answer,
+            graph_dsl=request.graph_dsl,
+        )
+        payload = self._build_payload(
+            prompt=prompt,
+            image_url=request.image_url,
+            image_base64=request.image_base64,
+        )
+        raw_provider_response = await self._send_chat_completion(payload)
+        parsed = self._validate_response(raw_provider_response, _SolutionProviderPayload)
+        return SolutionLLMResult(
+            prompt_version=SOLUTION_PROMPT_VERSION,
+            model=self._model,
+            steps_markdown=parsed.steps_markdown,
+            final_answer=parsed.final_answer,
+            math_level_classification=parsed.math_level_classification,
+            raw_provider_response=raw_provider_response,
+        )
+
+    def _build_payload(
+        self,
+        *,
+        prompt: str,
+        image_url: str | None,
+        image_base64: str | None,
+    ) -> dict[str, Any]:
+        content: list[_ChatMessageContentText | _ChatMessageContentImageUrl] = [
+            _ChatMessageContentText(type="text", text=prompt)
+        ]
+        if image_base64:
+            content.append(
+                _ChatMessageContentImageUrl(
+                    type="image_url",
+                    image_url={"url": f"data:image/png;base64,{image_base64}"},
+                )
+            )
+        elif image_url:
+            content.append(
+                _ChatMessageContentImageUrl(type="image_url", image_url={"url": image_url})
+            )
+
+        request = _ChatCompletionRequest(
+            model=self._model,
+            messages=[_ChatMessage(role="user", content=content)],
+        )
+        return request.model_dump(exclude_none=True)
+
+    @staticmethod
+    def _validate_response(
+        raw_provider_response: dict[str, Any],
+        model_class: type[_SolutionProviderPayload],
+    ) -> _SolutionProviderPayload:
+        try:
+            return model_class.model_validate(raw_provider_response)
+        except ValidationError as exc:
+            raise LLMClientError(
+                "Solution LLM response failed schema validation",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_provider_response,
+            ) from exc
+
+
+class CoachingLLMClient(_BaseLLMClient):
+    def __init__(self, settings: Settings | None = None, http_client: httpx.AsyncClient | None = None) -> None:
+        self._settings = settings or get_settings()
+        super().__init__(
+            endpoint=self._settings.coaching_llm_endpoint,
+            model=self._settings.coaching_llm_model,
+            api_key=self._settings.coaching_llm_api_key,
+            timeout_seconds=self._settings.vlm_timeout_seconds,
+            http_client=http_client,
+        )
+
+    async def send_message(self, request: CoachingLLMRequest) -> CoachingLLMResult:
+        history = self._format_history(request.conversation_history)
+        prompt = build_coaching_prompt(
+            problem_text=request.problem_text,
+            correct_answer=request.correct_answer,
+            canonical_steps_markdown=request.canonical_steps_markdown,
+            canonical_final_answer=request.canonical_final_answer,
+            math_level_classification=request.math_level_classification,
+            student_answer=request.student_answer,
+            judgement=request.judgement,
+            conversation_history=history,
+            new_message=request.new_message,
+        )
+        payload = _ChatCompletionRequest(
+            model=self._model,
+            messages=[_ChatMessage(role="user", content=prompt)],
+        ).model_dump(exclude_none=True)
+        raw_provider_response = await self._send_chat_completion(payload)
+        parsed = self._validate_response(raw_provider_response, _CoachingProviderPayload)
+        return CoachingLLMResult(
+            prompt_version=COACHING_PROMPT_VERSION,
+            model=self._model,
+            text=parsed.text,
+            whiteboard_dsl=parsed.whiteboard_dsl,
+            raw_provider_response=raw_provider_response,
+        )
+
+    @staticmethod
+    def _format_history(history: list[CoachingMessage]) -> str:
+        if not history:
+            return "无历史对话。"
+        return "\n".join(f"{message.role}: {message.text}" for message in history)
+
+    @staticmethod
+    def _validate_response(
+        raw_provider_response: dict[str, Any],
+        model_class: type[_CoachingProviderPayload],
+    ) -> _CoachingProviderPayload:
+        try:
+            return model_class.model_validate(raw_provider_response)
+        except ValidationError as exc:
+            raise LLMClientError(
+                "Coaching LLM response failed schema validation",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_provider_response,
+            ) from exc

--- a/backend/app/infrastructure/llm/prompts.py
+++ b/backend/app/infrastructure/llm/prompts.py
@@ -22,7 +22,7 @@ def build_solution_prompt(*, problem_text: str, correct_answer: str, graph_dsl: 
 {graph_section}
 
 要求：
-1. 以标准答案为准，不要编造新的结论。
+1. 把给定答案视为参考答案，要与题目条件和参考答案保持一致，不要编造无依据的新结论。对简答题要注意：参考答案可能只是多种正确表述中的一种。
 2. 优先给出适合学生理解的基础方法。
 3. 只返回 JSON，不要输出解释、前后缀或 Markdown 代码块。"""
 

--- a/backend/app/infrastructure/llm/prompts.py
+++ b/backend/app/infrastructure/llm/prompts.py
@@ -1,0 +1,81 @@
+SOLUTION_PROMPT_VERSION = "2026-05-25.solution.v1"
+COACHING_PROMPT_VERSION = "2026-05-25.coaching.v1"
+
+
+def build_solution_prompt(*, problem_text: str, correct_answer: str, graph_dsl: str | None = None) -> str:
+    graph_section = graph_dsl or "无图形 DSL。"
+    return f"""你是一名中国小学/初中数学解题老师。
+你必须只使用小学或初中阶段可接受的方法，严禁使用高等数学、大学数学、微积分、线性代数、抽象代数、向量空间、复数分析、矩阵求逆、导数、积分、极限等超纲方法。
+你的输出必须全部使用简体中文。
+请把标准解答整理成 JSON，对象必须包含以下字段：
+- steps_markdown: 字符串，分步骤讲解，可使用 Markdown
+- final_answer: 字符串，最终答案
+- math_level_classification: 字符串，标记所用方法所属学段，例如 `primary`、`middle-school`
+
+题目文本：
+{problem_text}
+
+标准答案：
+{correct_answer}
+
+图形 DSL（如果有）：
+{graph_section}
+
+要求：
+1. 以标准答案为准，不要编造新的结论。
+2. 优先给出适合学生理解的基础方法。
+3. 只返回 JSON，不要输出解释、前后缀或 Markdown 代码块。"""
+
+
+def build_coaching_prompt(
+    *,
+    problem_text: str,
+    correct_answer: str,
+    canonical_steps_markdown: str,
+    canonical_final_answer: str,
+    math_level_classification: str,
+    student_answer: str | None,
+    judgement: str | None,
+    conversation_history: str,
+    new_message: str,
+) -> str:
+    student_answer_section = student_answer or "无"
+    judgement_section = judgement or "无"
+    return f"""你是一名中国小学/初中数学辅导老师。
+你必须全部使用简体中文回复。
+你必须遵守以下规则：
+1. 把给定的标准解答当作唯一正确依据，不要与它冲突。
+2. 语气温和、鼓励、耐心。
+3. 如果学生问题与当前题目无关，礼貌拒绝并引导回到当前题目。
+4. 默认先启发、再提示、最后才可以在必要时明确揭示关键步骤，不要一上来直接把完整答案原样复述。
+5. 只能使用 {math_level_classification} 对应的小学/初中方法，不得使用高等数学或超纲技巧。
+
+请返回 JSON，对象字段如下：
+- text: 字符串，给学生的回复
+- whiteboard_dsl: 可选字符串，如需白板图示则提供，否则可省略或设为 null
+
+题目文本：
+{problem_text}
+
+标准答案：
+{correct_answer}
+
+标准解答步骤：
+{canonical_steps_markdown}
+
+标准解答最终答案：
+{canonical_final_answer}
+
+学生当前答案：
+{student_answer_section}
+
+当前判定结果：
+{judgement_section}
+
+历史对话：
+{conversation_history}
+
+学生新消息：
+{new_message}
+
+只返回 JSON，不要输出解释、前后缀或 Markdown 代码块。"""

--- a/backend/tests/infrastructure/test_llm_client.py
+++ b/backend/tests/infrastructure/test_llm_client.py
@@ -62,6 +62,7 @@ async def test_solution_llm_client_builds_policy_prompt_and_uses_solution_config
         prompt = payload["messages"][0]["content"][0]["text"]
         assert "全部使用简体中文" in prompt
         assert "严禁使用高等数学" in prompt
+        assert "参考答案可能只是多种正确表述中的一种" in prompt
         assert "已知 x + 3 = 5" in prompt
         assert "2" in prompt
         assert payload["messages"][0]["content"][1]["image_url"]["url"] == "https://example.com/problem.png"

--- a/backend/tests/infrastructure/test_llm_client.py
+++ b/backend/tests/infrastructure/test_llm_client.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.llm.client import (
+    FAILURE_CODE_INVALID_RESPONSE,
+    FAILURE_CODE_NETWORK,
+    FAILURE_CODE_PROVIDER,
+    CoachingLLMClient,
+    CoachingLLMRequest,
+    CoachingMessage,
+    LLMClientError,
+    SolutionLLMClient,
+    SolutionLLMRequest,
+)
+from app.infrastructure.llm.prompts import COACHING_PROMPT_VERSION, SOLUTION_PROMPT_VERSION
+
+
+def _build_solution_client(handler) -> SolutionLLMClient:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://solution.example/api",
+        timeout=5,
+        headers={"Authorization": "Bearer solution-key", "Content-Type": "application/json"},
+    )
+    settings = Settings(
+        solution_llm_endpoint="https://solution.example/api",
+        solution_llm_model="solution-model",
+        solution_llm_api_key="solution-key",
+    )
+    return SolutionLLMClient(settings=settings, http_client=http_client)
+
+
+def _build_coaching_client(handler) -> CoachingLLMClient:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://coaching.example/api",
+        timeout=5,
+        headers={"Authorization": "Bearer coaching-key", "Content-Type": "application/json"},
+    )
+    settings = Settings(
+        coaching_llm_endpoint="https://coaching.example/api",
+        coaching_llm_model="coaching-model",
+        coaching_llm_api_key="coaching-key",
+    )
+    return CoachingLLMClient(settings=settings, http_client=http_client)
+
+
+@pytest.mark.asyncio
+async def test_solution_llm_client_builds_policy_prompt_and_uses_solution_config() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/chat/completions"
+        assert request.headers["Authorization"] == "Bearer solution-key"
+        payload = json.loads(await request.aread())
+        assert payload["model"] == "solution-model"
+        prompt = payload["messages"][0]["content"][0]["text"]
+        assert "全部使用简体中文" in prompt
+        assert "严禁使用高等数学" in prompt
+        assert "已知 x + 3 = 5" in prompt
+        assert "2" in prompt
+        assert payload["messages"][0]["content"][1]["image_url"]["url"] == "https://example.com/problem.png"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "steps_markdown": "1. 两边同时减 3。\n2. 得到 x = 2。",
+                                    "final_answer": "x = 2",
+                                    "math_level_classification": "middle-school",
+                                }
+                            ),
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_solution_client(handler)
+    result = await client.generate_solution(
+        SolutionLLMRequest(
+            problem_text="已知 x + 3 = 5，求 x。",
+            correct_answer="2",
+            image_url="https://example.com/problem.png",
+        )
+    )
+    await client.aclose()
+
+    assert result.prompt_version == SOLUTION_PROMPT_VERSION
+    assert result.model == "solution-model"
+    assert result.final_answer == "x = 2"
+    assert result.math_level_classification == "middle-school"
+
+
+@pytest.mark.asyncio
+async def test_solution_llm_client_accepts_fenced_json_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "```json\n{\"steps_markdown\":\"步骤\",\"final_answer\":\"42\",\"math_level_classification\":\"primary\"}\n```",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_solution_client(handler)
+    result = await client.generate_solution(
+        SolutionLLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+    )
+    await client.aclose()
+
+    assert result.steps_markdown == "步骤"
+    assert result.final_answer == "42"
+
+
+@pytest.mark.asyncio
+async def test_solution_llm_client_rejects_malformed_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"index": 0, "message": {"role": "assistant", "content": "not-json"}}]},
+        )
+
+    client = _build_solution_client(handler)
+
+    with pytest.raises(LLMClientError) as exc_info:
+        await client.generate_solution(
+            SolutionLLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+        )
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_solution_llm_client_classifies_provider_failure_as_retryable() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "overloaded"})
+
+    client = _build_solution_client(handler)
+
+    with pytest.raises(LLMClientError) as exc_info:
+        await client.generate_solution(
+            SolutionLLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+        )
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_PROVIDER
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_coaching_llm_client_builds_context_prompt_and_uses_coaching_config() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/chat/completions"
+        assert request.headers["Authorization"] == "Bearer coaching-key"
+        payload = json.loads(await request.aread())
+        assert payload["model"] == "coaching-model"
+        prompt = payload["messages"][0]["content"]
+        assert "全部使用简体中文" in prompt
+        assert "语气温和、鼓励、耐心" in prompt
+        assert "标准解答步骤" in prompt
+        assert "student: 我想先看第一步" in prompt
+        assert "coach: 先看已知条件" in prompt
+        assert "tracking" not in prompt
+        assert "exposureCount" not in prompt
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps({"text": "先看等式两边同时减 3。"}),
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingLLMRequest(
+            problem_text="已知 x + 3 = 5，求 x。",
+            correct_answer="2",
+            canonical_steps_markdown="1. 两边同时减 3。\n2. 得到 x = 2。",
+            canonical_final_answer="x = 2",
+            math_level_classification="middle-school",
+            student_answer="x = 1",
+            judgement="incorrect",
+            conversation_history=[
+                CoachingMessage(role="student", text="我想先看第一步"),
+                CoachingMessage(role="coach", text="先看已知条件"),
+            ],
+            new_message="可以给我一个提示吗？",
+        )
+    )
+    await client.aclose()
+
+    assert result.prompt_version == COACHING_PROMPT_VERSION
+    assert result.model == "coaching-model"
+    assert result.text == "先看等式两边同时减 3。"
+
+
+@pytest.mark.asyncio
+async def test_coaching_llm_client_parses_optional_whiteboard_dsl() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {"text": "看图示。", "whiteboard_dsl": "board.create('point', [0, 0]);"}
+                            ),
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingLLMRequest(
+            problem_text="题目",
+            correct_answer="答案",
+            canonical_steps_markdown="步骤",
+            canonical_final_answer="答案",
+            math_level_classification="primary",
+            new_message="请画图",
+        )
+    )
+    await client.aclose()
+
+    assert result.whiteboard_dsl == "board.create('point', [0, 0]);"
+
+
+@pytest.mark.asyncio
+async def test_coaching_llm_client_extracts_json_from_wrapped_markdown() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "下面是回复：\n```json\n{\"text\":\"先想想已知条件。\",\"whiteboard_dsl\":null}\n```",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingLLMRequest(
+            problem_text="题目",
+            correct_answer="答案",
+            canonical_steps_markdown="步骤",
+            canonical_final_answer="答案",
+            math_level_classification="primary",
+            new_message="请提示一下",
+        )
+    )
+    await client.aclose()
+
+    assert result.text == "先想想已知条件。"
+    assert result.whiteboard_dsl is None
+
+
+@pytest.mark.asyncio
+async def test_coaching_llm_client_network_failure_is_catchable() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    client = _build_coaching_client(handler)
+
+    with pytest.raises(LLMClientError) as exc_info:
+        await client.send_message(
+            CoachingLLMRequest(
+                problem_text="题目",
+                correct_answer="答案",
+                canonical_steps_markdown="步骤",
+                canonical_final_answer="答案",
+                math_level_classification="primary",
+                new_message="你好",
+            )
+        )
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_NETWORK
+    assert exc_info.value.retryable is True


### PR DESCRIPTION
## Summary
- add a new `backend/app/infrastructure/llm` module with separate solution and coaching provider clients
- add Chinese prompt builders for solution generation and coaching with the required math-level and behavior policies
- add focused unit tests for prompt construction, response parsing, config separation, and provider failure handling

## Implementation Notes
- mirrored the existing VLM transport/error-handling shape so downstream worker and coaching API tasks can consume the new clients consistently
- solution responses are normalized from JSON into `steps_markdown`, `final_answer`, and `math_level_classification`; coaching responses are normalized into `text` plus optional `whiteboard_dsl`
- added fallback parsing for fenced or wrapped JSON responses because provider outputs are not always clean
- reused the existing `vlm_timeout_seconds` setting as the HTTP timeout for both new clients because T01 introduced separate endpoint/model/api-key settings but not separate timeout settings

## Test Results
- `cd backend && uv run pytest` ✅ `181 passed, 1 skipped`
- `cd backend && uv run pytest tests/ -k "llm_client or solution_llm or coaching_llm"` ✅ `8 passed`
- `cd frontend && npm test -- --run` ✅ `17 passed, 168 tests`
- `cd frontend && npm run test:ui` ❌ existing failures in `tests/practice.spec.ts` and `tests/teacher-password.spec.ts`; this issue only adds backend infrastructure and does not touch those flows

Closes #102