### PR TITLE
T03: enqueue and backfill solution generation tasks

### DIFF
--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -81,20 +81,25 @@ def get_database(settings: Settings | None = None) -> AsyncDatabase[Document]:
 
 
 async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
-    existing_collections = set(await database.list_collection_names())
+    try:
+        existing_collections = set(await database.list_collection_names())
+    except AttributeError:
+        existing_collections = set()
 
     for collection_name in (
         SOLUTION_GENERATION_TASKS_COLLECTION,
         CANONICAL_SOLUTIONS_COLLECTION,
     ):
-        if collection_name not in existing_collections:
+        if collection_name not in existing_collections and hasattr(database, "create_collection"):
             await database.create_collection(collection_name)
 
-    await database[TAGS_COLLECTION].create_index(
-        [("userId", ASCENDING), ("name", ASCENDING)],
-        unique=True,
-        name="user_tag_unique",
-    )
+    create_index = getattr(database[TAGS_COLLECTION], "create_index", None)
+    if callable(create_index):
+        await create_index(
+            [("userId", ASCENDING), ("name", ASCENDING)],
+            unique=True,
+            name="user_tag_unique",
+        )
 
 
 @asynccontextmanager

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from starlette.types import ExceptionHandler
 from app.infrastructure.config.settings import get_settings
 from app.infrastructure.storage.mongo import ensure_database_setup, get_database
 from app.observability import configure_logging
+from app.presentation.solution_generation import backfill_solution_generation_tasks
 from app.presentation.auth import router as auth_router
 from app.presentation.exams import router as exams_router
 from app.presentation.errors import ApiError, api_error_handler, validation_error_handler
@@ -24,6 +25,7 @@ from app.presentation.teacher_password import router as teacher_password_router
 async def lifespan(app: FastAPI):
     database = get_database()
     await ensure_database_setup(database)
+    await backfill_solution_generation_tasks(database)
     yield
 
 

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -341,7 +341,10 @@ async def confirm_preview(
     except Exception:
         delete_problem = getattr(database["problems"], "delete_one", None)
         if callable(delete_problem):
-            await delete_problem({"_id": problem["_id"]})
+            try:
+                await delete_problem({"_id": problem["_id"]})
+            except Exception:
+                pass
         await previews.update_one(
             {"_id": preview_oid},
             {"$set": {"status": claimed_preview["status"], "updatedAt": now}},

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -22,6 +22,7 @@ from app.presentation.errors import ApiError
 from app.presentation.helpers import normalize_tags, parse_object_id
 from app.presentation.ingestion_serialization import ProblemResponse, PreviewResponse, serialize_preview, serialize_problem, _enum_value
 from app.presentation.tags import _register_tags
+from app.presentation.solution_generation import enqueue_solution_generation_task_for_problem
 from app.presentation.ingestion_workflow import (
     DEFAULT_SYNC_WAIT_SECONDS,
     clean_optional_text,
@@ -336,7 +337,11 @@ async def confirm_preview(
     }
     try:
         await database["problems"].insert_one(problem)
+        await enqueue_solution_generation_task_for_problem(database, problem, now=now)
     except Exception:
+        delete_problem = getattr(database["problems"], "delete_one", None)
+        if callable(delete_problem):
+            await delete_problem({"_id": problem["_id"]})
         await previews.update_one(
             {"_id": preview_oid},
             {"$set": {"status": claimed_preview["status"], "updatedAt": now}},

--- a/backend/app/presentation/solution_generation.py
+++ b/backend/app/presentation/solution_generation.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import ObjectId
+
+from app.domain import SolutionGenerationStatus, SolutionGenerationTask
+from app.infrastructure.storage.mongo import (
+    CANONICAL_SOLUTIONS_COLLECTION,
+    Document,
+    SOLUTION_GENERATION_TASKS_COLLECTION,
+)
+
+SOLUTION_BACKFILL_BATCH_SIZE = 100
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _safe_get_collection(database: Any, name: str) -> Any | None:
+    try:
+        return database[name]
+    except (KeyError, TypeError, AttributeError):
+        return None
+
+
+def _build_solution_task_document(
+    *,
+    problem_id: str,
+    user_id: str,
+    now: datetime,
+) -> Document:
+    task = SolutionGenerationTask(
+        id=str(ObjectId()),
+        problem_id=problem_id,
+        user_id=user_id,
+        status=SolutionGenerationStatus.PENDING,
+        created_at=now,
+        updated_at=now,
+    )
+    document = task.model_dump()
+    document["_id"] = ObjectId(task.id)
+    return document
+
+
+async def enqueue_solution_generation_task_for_problem(
+    database: Any,
+    problem: Mapping[str, Any],
+    *,
+    now: datetime | None = None,
+) -> bool:
+    tasks = _safe_get_collection(database, SOLUTION_GENERATION_TASKS_COLLECTION)
+    solutions = _safe_get_collection(database, CANONICAL_SOLUTIONS_COLLECTION)
+    if tasks is None or solutions is None:
+        raise KeyError("solution generation collections are unavailable")
+
+    current_time = now or _utc_now()
+    problem_id = str(problem["_id"])
+    user_id = str(problem["userId"])
+
+    existing_task = await tasks.find_one({"problem_id": problem_id})
+    if existing_task is not None:
+        return False
+
+    existing_solution = await solutions.find_one({"problem_id": problem_id})
+    if existing_solution is not None:
+        return False
+
+    await tasks.insert_one(
+        _build_solution_task_document(
+            problem_id=problem_id,
+            user_id=user_id,
+            now=current_time,
+        )
+    )
+    return True
+
+
+async def backfill_solution_generation_tasks(
+    database: Any,
+    *,
+    batch_size: int = SOLUTION_BACKFILL_BATCH_SIZE,
+    now: datetime | None = None,
+) -> int:
+    problems = _safe_get_collection(database, "problems")
+    tasks = _safe_get_collection(database, SOLUTION_GENERATION_TASKS_COLLECTION)
+    solutions = _safe_get_collection(database, CANONICAL_SOLUTIONS_COLLECTION)
+    if problems is None or tasks is None or solutions is None:
+        return 0
+
+    current_time = now or _utc_now()
+    problem_documents = await problems.find({"isDeleted": False}).to_list(length=None)
+    task_documents = await tasks.find({}).to_list(length=None)
+    solution_documents = await solutions.find({}).to_list(length=None)
+
+    existing_task_problem_ids = {str(document.get("problem_id")) for document in task_documents}
+    existing_solution_problem_ids = {str(document.get("problem_id")) for document in solution_documents}
+
+    missing_documents: list[Document] = []
+    for problem in problem_documents:
+        problem_id = str(problem["_id"])
+        if problem_id in existing_task_problem_ids or problem_id in existing_solution_problem_ids:
+            continue
+        missing_documents.append(
+            _build_solution_task_document(
+                problem_id=problem_id,
+                user_id=str(problem["userId"]),
+                now=current_time,
+            )
+        )
+
+    for start in range(0, len(missing_documents), max(batch_size, 1)):
+        await tasks.insert_many(missing_documents[start : start + max(batch_size, 1)], ordered=False)
+
+    return len(missing_documents)

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -145,6 +145,8 @@ class FakeDatabase:
             "ingestion_previews": FakeCollection(),
             "problems": FakeCollection(),
             "tags": FakeCollection(),
+            "solution_generation_tasks": FakeCollection(),
+            "canonical_solutions": FakeCollection(),
         }
 
     def __getitem__(self, name: str) -> FakeCollection:
@@ -609,6 +611,13 @@ async def test_confirm_preview_creates_problem_from_confirmed_draft(
     updated_preview = await database["ingestion_previews"].find_one({"_id": preview["_id"]})
     assert updated_preview is not None
     assert updated_preview["status"] == "confirmed"
+    solution_task = await database["solution_generation_tasks"].find_one({"problem_id": body["id"]})
+    assert solution_task is not None
+    assert solution_task["user_id"] == str(owner["_id"])
+    assert solution_task["status"] == "pending"
+    assert solution_task["retry_count"] == 0
+    assert solution_task["failure_reason"] is None
+    assert solution_task["started_at"] is None
 
 
 @pytest.mark.asyncio
@@ -733,6 +742,88 @@ async def test_confirm_preview_rejects_double_confirmation(
 
     assert second_response.status_code == 409
     assert second_response.json()["error"]["code"] == "PREVIEW_ALREADY_CONFIRMED"
+    assert await database["solution_generation_tasks"].count_documents({}) == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_solution_generation_tasks_enqueues_only_missing_problems(
+    ingestion_app: FastAPI,
+) -> None:
+    from app.presentation.solution_generation import backfill_solution_generation_tasks
+
+    database: FakeDatabase = ingestion_app.state.fake_database
+    owner = {
+        "_id": ObjectId(),
+        "username": "student1",
+        "status": "active",
+        "createdAt": datetime.now(UTC),
+        "updatedAt": datetime.now(UTC),
+        "lastLoginAt": None,
+    }
+    database["users"].seed(owner)
+
+    now = datetime.now(UTC)
+    missing_problem = {
+        "_id": ObjectId(),
+        "userId": owner["_id"],
+        "isDeleted": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    problem_with_task = {
+        "_id": ObjectId(),
+        "userId": owner["_id"],
+        "isDeleted": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    problem_with_solution = {
+        "_id": ObjectId(),
+        "userId": owner["_id"],
+        "isDeleted": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    deleted_problem = {
+        "_id": ObjectId(),
+        "userId": owner["_id"],
+        "isDeleted": True,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+    database["problems"].seed(missing_problem, problem_with_task, problem_with_solution, deleted_problem)
+    database["solution_generation_tasks"].seed(
+        {
+            "_id": ObjectId(),
+            "problem_id": str(problem_with_task["_id"]),
+            "user_id": str(owner["_id"]),
+            "status": "pending",
+            "retry_count": 0,
+            "failure_reason": None,
+            "created_at": now,
+            "updated_at": now,
+            "started_at": None,
+        }
+    )
+    database["canonical_solutions"].seed(
+        {
+            "_id": ObjectId(),
+            "problem_id": str(problem_with_solution["_id"]),
+            "user_id": str(owner["_id"]),
+            "steps_markdown": "steps",
+            "final_answer": "answer",
+            "math_level_classification": "middle-school",
+            "created_at": now,
+        }
+    )
+
+    inserted = await backfill_solution_generation_tasks(database, now=now)
+
+    assert inserted == 1
+    assert await database["solution_generation_tasks"].count_documents({}) == 2
+    missing_task = await database["solution_generation_tasks"].find_one({"problem_id": str(missing_problem["_id"])})
+    assert missing_task is not None
+    assert await database["solution_generation_tasks"].find_one({"problem_id": str(deleted_problem["_id"])}) is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -75,6 +75,7 @@ class FakeCollection:
     def __init__(self) -> None:
         self._documents: list[dict[str, Any]] = []
         self._insert_one_error: Exception | None = None
+        self._delete_one_error: Exception | None = None
 
     def seed(self, *documents: dict[str, Any]) -> None:
         self._documents.extend(deepcopy(list(documents)))
@@ -123,6 +124,8 @@ class FakeCollection:
         return None
 
     async def delete_one(self, query: dict[str, Any]) -> FakeDeleteResult:
+        if self._delete_one_error is not None:
+            raise self._delete_one_error
         for index, document in enumerate(self._documents):
             if _matches(document, query):
                 del self._documents[index]
@@ -717,6 +720,43 @@ async def test_confirm_preview_rolls_back_status_when_problem_insert_fails(
 
     stored_problem = await database["problems"].find_one({"userId": owner["_id"]})
     assert stored_problem is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_preview_rolls_back_status_when_cleanup_delete_fails(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    database: FakeDatabase = ingestion_app.state.fake_database
+    owner = await database["users"].find_one({"username": "student1"})
+    assert owner is not None
+    original_status = "ready"
+    preview = make_preview(owner["_id"], status=original_status)
+    preview["editableDraft"] = {
+        "text": "Solve for x",
+        "problemType": "short-answer",
+        "graphDsl": None,
+        "correctAnswer": "42",
+        "tags": [],
+    }
+    database["ingestion_previews"].seed(preview)
+
+    database["solution_generation_tasks"]._insert_one_error = RuntimeError("simulated task insert error")
+    database["problems"]._delete_one_error = RuntimeError("simulated cleanup error")
+
+    response = await authenticated_client.post(
+        f"/api/v1/ingestion-previews/{preview['_id']}/confirm"
+    )
+
+    assert response.status_code == 500
+    assert response.json()["error"]["code"] == "PROBLEM_CREATION_FAILED"
+
+    stored_preview = await database["ingestion_previews"].find_one({"_id": preview["_id"]})
+    assert stored_preview is not None
+    assert stored_preview["status"] == original_status
+
+    stored_problem = await database["problems"].find_one({"userId": owner["_id"]})
+    assert stored_problem is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -124,6 +124,8 @@ class FakeDatabase:
             "ingestion_previews": FakeCollection(),
             "users": FakeCollection(),
             "sessions": FakeCollection(),
+            "solution_generation_tasks": FakeCollection(),
+            "canonical_solutions": FakeCollection(),
         }
 
     def __getitem__(self, name: str) -> FakeCollection:

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -202,6 +202,8 @@ class FakeDatabase:
             "problems": FakeCollection(),
             "exams": FakeCollection(),
             "tags": FakeCollection(),
+            "solution_generation_tasks": FakeCollection(),
+            "canonical_solutions": FakeCollection(),
         }
 
     def __getitem__(self, name: str) -> FakeCollection:


### PR DESCRIPTION
## Summary
- enqueue a pending `SolutionGenerationTask` when a problem is confirmed from an ingestion preview
- add startup backfill logic that creates missing pending tasks for existing non-deleted problems without a task or canonical solution
- add confirm/backfill test coverage and extend relevant fake databases with the new solution collections

## Implementation Notes
- added `backend/app/presentation/solution_generation.py` to keep task enqueue and backfill logic out of the route handler and reusable from both confirm and app startup
- backfill works in batches of 100 inserts per write call to avoid flooding the task collection while still processing all missing problems in one startup pass
- backfill skips deleted problems and any problem that already has either a solution-generation task or a canonical solution
- the Mongo setup helper now tolerates simpler test doubles that do not implement collection listing or index creation methods

## Test Results
- `cd backend && uv run pytest` ✅ `182 passed, 1 skipped`
- `cd backend && uv run pytest tests/ -k "confirm or backfill"` ✅ `10 passed`
- `cd frontend && npm test -- --run` ✅ `17 passed, 168 tests`
- `cd frontend && npm run test:ui` ❌ existing failures in `tests/practice.spec.ts` and `tests/teacher-password.spec.ts`; this backend-only change does not touch those flows

Closes #103