### PR TITLE
T05: Add coaching data model (conversation, messages, whiteboard pages)

### DIFF
--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -6,6 +6,7 @@ from .models import (
     IngestionPreviewStatus,
     GradingStatus,
     SolutionGenerationStatus,
+    CoachingRole,
     CorrectAnswer,
     SourceImage,
     Extraction,
@@ -27,6 +28,8 @@ from .models import (
     Exam,
     SolutionGenerationTask,
     CanonicalSolution,
+    CoachingMessage,
+    CoachingConversation,
 )
 from .normalization import normalize_answer
 from .selection import select_problems
@@ -44,6 +47,7 @@ __all__ = [
     "IngestionPreviewStatus",
     "GradingStatus",
     "SolutionGenerationStatus",
+    "CoachingRole",
     "CorrectAnswer",
     "SourceImage",
     "Extraction",
@@ -65,6 +69,8 @@ __all__ = [
     "Exam",
     "SolutionGenerationTask",
     "CanonicalSolution",
+    "CoachingMessage",
+    "CoachingConversation",
     "normalize_answer",
     "recover_stale_preview",
     "select_problems",

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -46,6 +46,11 @@ class SolutionGenerationStatus(str, Enum):
     FAILED = "failed"
 
 
+class CoachingRole(str, Enum):
+    STUDENT = "student"
+    COACH = "coach"
+
+
 # Nested Models
 class CorrectAnswer(BaseModel):
     display: str
@@ -264,3 +269,31 @@ class CanonicalSolution(BaseModel):
     final_answer: str
     math_level_classification: str
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class CoachingMessage(BaseModel):
+    role: CoachingRole
+    content: str
+    whiteboard_dsl: Optional[str] = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class CoachingConversation(BaseModel):
+    id: Optional[str] = None
+    problem_id: str
+    user_id: str
+    messages: List[CoachingMessage] = Field(default_factory=list)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    def add_message(self, message: CoachingMessage) -> None:
+        """Add a message, enforcing the 20-message cap."""
+        if len(self.messages) >= 20:
+            raise ValueError("Conversation cannot have more than 20 messages")
+        self.messages.append(message)
+        self.updated_at = datetime.now(UTC)
+
+    def clear_messages(self) -> None:
+        """Clear all messages from the conversation."""
+        self.messages = []
+        self.updated_at = datetime.now(UTC)

--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -15,6 +15,7 @@ AsyncMongoClientFactory = Callable[[str], AsyncMongoClient[Document]]
 TAGS_COLLECTION = "tags"
 SOLUTION_GENERATION_TASKS_COLLECTION = "solution_generation_tasks"
 CANONICAL_SOLUTIONS_COLLECTION = "canonical_solutions"
+COACHING_CONVERSATIONS_COLLECTION = "coaching_conversations"
 
 
 class SupportsAsyncClose(Protocol):
@@ -89,6 +90,7 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
     for collection_name in (
         SOLUTION_GENERATION_TASKS_COLLECTION,
         CANONICAL_SOLUTIONS_COLLECTION,
+        COACHING_CONVERSATIONS_COLLECTION,
     ):
         if collection_name not in existing_collections and hasattr(database, "create_collection"):
             await database.create_collection(collection_name)
@@ -99,6 +101,14 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
             [("userId", ASCENDING), ("name", ASCENDING)],
             unique=True,
             name="user_tag_unique",
+        )
+
+    create_coaching_index = getattr(database[COACHING_CONVERSATIONS_COLLECTION], "create_index", None)
+    if callable(create_coaching_index):
+        await create_coaching_index(
+            [("problem_id", ASCENDING), ("user_id", ASCENDING)],
+            unique=True,
+            name="problem_user_conversation_unique",
         )
 
 

--- a/backend/tests/domain/test_coaching_models.py
+++ b/backend/tests/domain/test_coaching_models.py
@@ -1,0 +1,169 @@
+from datetime import datetime, UTC
+
+import pytest
+from pydantic import ValidationError
+
+from app.domain import (
+    CoachingConversation,
+    CoachingMessage,
+    CoachingRole,
+)
+
+
+def test_coaching_message_validates_required_fields() -> None:
+    message = CoachingMessage(
+        role=CoachingRole.STUDENT,
+        content="I don't understand this problem.",
+    )
+
+    assert message.role == CoachingRole.STUDENT
+    assert message.content == "I don't understand this problem."
+    assert message.whiteboard_dsl is None
+    assert isinstance(message.created_at, datetime)
+
+
+def test_coaching_message_accepts_whiteboard_dsl() -> None:
+    message = CoachingMessage(
+        role=CoachingRole.COACH,
+        content="Let's draw this out.",
+        whiteboard_dsl="board line 10 10 100 100",
+    )
+
+    assert message.whiteboard_dsl == "board line 10 10 100 100"
+
+
+def test_coaching_message_rejects_invalid_role() -> None:
+    with pytest.raises(ValidationError):
+        CoachingMessage(
+            role="teacher",
+            content="Hello!",
+        )
+
+
+def test_coaching_conversation_validates_required_fields() -> None:
+    conversation = CoachingConversation(
+        problem_id="problem-1",
+        user_id="user-1",
+    )
+
+    assert conversation.problem_id == "problem-1"
+    assert conversation.user_id == "user-1"
+    assert conversation.messages == []
+    assert isinstance(conversation.created_at, datetime)
+    assert isinstance(conversation.updated_at, datetime)
+
+
+def test_coaching_conversation_adds_messages() -> None:
+    conversation = CoachingConversation(
+        problem_id="problem-1",
+        user_id="user-1",
+    )
+
+    message1 = CoachingMessage(
+        role=CoachingRole.STUDENT,
+        content="Hello!",
+    )
+    message2 = CoachingMessage(
+        role=CoachingRole.COACH,
+        content="Hi there!",
+    )
+
+    conversation.add_message(message1)
+    conversation.add_message(message2)
+
+    assert len(conversation.messages) == 2
+    assert conversation.messages[0].content == "Hello!"
+    assert conversation.messages[1].content == "Hi there!"
+
+
+def test_coaching_conversation_enforces_message_cap() -> None:
+    conversation = CoachingConversation(
+        problem_id="problem-1",
+        user_id="user-1",
+    )
+
+    # Add 20 messages
+    for i in range(20):
+        conversation.add_message(
+            CoachingMessage(
+                role=CoachingRole.STUDENT,
+                content=f"Message {i}",
+            )
+        )
+
+    assert len(conversation.messages) == 20
+
+    # Adding 21st message should fail
+    with pytest.raises(ValueError, match="Conversation cannot have more than 20 messages"):
+        conversation.add_message(
+            CoachingMessage(
+                role=CoachingRole.STUDENT,
+                content="Message 21",
+            )
+        )
+
+
+def test_coaching_conversation_clears_messages() -> None:
+    conversation = CoachingConversation(
+        problem_id="problem-1",
+        user_id="user-1",
+    )
+
+    conversation.add_message(
+        CoachingMessage(
+            role=CoachingRole.STUDENT,
+            content="Hello!",
+        )
+    )
+
+    assert len(conversation.messages) == 1
+
+    conversation.clear_messages()
+
+    assert len(conversation.messages) == 0
+
+
+def test_coaching_conversation_updates_updated_at_on_add() -> None:
+    conversation = CoachingConversation(
+        problem_id="problem-1",
+        user_id="user-1",
+    )
+
+    original_updated_at = conversation.updated_at
+
+    # Wait a tiny bit to ensure different timestamp
+    import time
+    time.sleep(0.001)
+
+    conversation.add_message(
+        CoachingMessage(
+            role=CoachingRole.STUDENT,
+            content="Hello!",
+        )
+    )
+
+    assert conversation.updated_at > original_updated_at
+
+
+def test_coaching_conversation_updates_updated_at_on_clear() -> None:
+    conversation = CoachingConversation(
+        problem_id="problem-1",
+        user_id="user-1",
+    )
+
+    conversation.add_message(
+        CoachingMessage(
+            role=CoachingRole.STUDENT,
+            content="Hello!",
+        )
+    )
+
+    original_updated_at = conversation.updated_at
+
+    # Wait a tiny bit to ensure different timestamp
+    import time
+    time.sleep(0.001)
+
+    conversation.clear_messages()
+
+    assert conversation.updated_at > original_updated_at

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -10,6 +10,7 @@ from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import (
     AsyncMongoClientFactory,
     CANONICAL_SOLUTIONS_COLLECTION,
+    COACHING_CONVERSATIONS_COLLECTION,
     MongoClientAdapter,
     SOLUTION_GENERATION_TASKS_COLLECTION,
     TAGS_COLLECTION,
@@ -134,10 +135,17 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
     assert database.created_collections == [
         SOLUTION_GENERATION_TASKS_COLLECTION,
         CANONICAL_SOLUTIONS_COLLECTION,
+        COACHING_CONVERSATIONS_COLLECTION,
     ]
     assert database[TAGS_COLLECTION].index_calls == [
         {
             "keys": [("userId", 1), ("name", 1)],
             "kwargs": {"unique": True, "name": "user_tag_unique"},
+        }
+    ]
+    assert database[COACHING_CONVERSATIONS_COLLECTION].index_calls == [
+        {
+            "keys": [("problem_id", 1), ("user_id", 1)],
+            "kwargs": {"unique": True, "name": "problem_user_conversation_unique"},
         }
     ]


### PR DESCRIPTION
Closes #104

## Summary
- Add CoachingRole enum (student | coach)
- Add CoachingMessage model with role, content, optional whiteboard_dsl, and created_at
- Add CoachingConversation model with problem_id, user_id, messages list, created_at, and updated_at
- Add add_message() method with 20-message cap enforcement
- Add clear_messages() method
- Add MongoDB collection setup for coaching_conversations
- Add unique index on (problem_id, user_id)
- Add comprehensive tests for coaching models and storage setup

## Verification
- All existing tests pass
- New coaching model tests pass
- Storage setup test updated and passing