### PR TITLE
T04: Add solution status API endpoint

### DIFF
--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -84,6 +84,10 @@ class ProblemTagsResponse(BaseModel):
     items: list[str]
 
 
+class SolutionStatusResponse(BaseModel):
+    status: str
+
+
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 
 
@@ -263,6 +267,32 @@ async def soft_delete_problem(
         {"$set": {"isDeleted": True, "deletedAt": now, "updatedAt": now}},
     )
     return ProblemDeleteResponse(ok=True)
+
+
+@router.get("/{problem_id}/solution-status", response_model=SolutionStatusResponse)
+async def get_solution_status(
+    problem_id: str,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> SolutionStatusResponse:
+    problem = await get_owned_problem(
+        database,
+        problem_id,
+        current_user["_id"],
+        allow_deleted=False,
+    )
+    
+    solutions = database.get_collection("canonical_solutions") if hasattr(database, "get_collection") else database["canonical_solutions"]
+    existing_solution = await solutions.find_one({"problem_id": problem_id})
+    if existing_solution is not None:
+        return SolutionStatusResponse(status="ready")
+        
+    tasks = database.get_collection("solution_generation_tasks") if hasattr(database, "get_collection") else database["solution_generation_tasks"]
+    existing_task = await tasks.find_one({"problem_id": problem_id})
+    if existing_task is not None:
+        return SolutionStatusResponse(status=str(existing_task.get("status", "pending")))
+        
+    return SolutionStatusResponse(status="none")
 
 
 @router.get("/{problem_id}/tracking", response_model=ProblemTrackingResponse)

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -513,3 +513,66 @@ async def test_problem_routes_require_authentication(problems_app: FastAPI) -> N
     assert response.json() == {
         "error": {"code": "UNAUTHENTICATED", "message": "Authentication required"}
     }
+
+
+@pytest.mark.asyncio
+async def test_solution_status(problems_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    problem_id_str = str(problem["_id"])
+    database["problems"].seed(problem)
+
+    # 1. returns 'none' when no task or solution exists
+    response = await client.get(f"/api/v1/problems/{problem_id_str}/solution-status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "none"}
+
+    # 2. returns 'pending' when task is pending
+    task_pending = {
+        "_id": ObjectId(),
+        "problem_id": problem_id_str,
+        "user_id": str(user_id),
+        "status": "pending",
+        "created_at": datetime.now(UTC)
+    }
+    database["solution_generation_tasks"].seed(task_pending)
+    response = await client.get(f"/api/v1/problems/{problem_id_str}/solution-status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "pending"}
+
+    # 3. returns 'generating' when task is generating
+    database["solution_generation_tasks"]._documents.clear()
+    task_generating = {**task_pending, "_id": ObjectId(), "status": "generating"}
+    database["solution_generation_tasks"].seed(task_generating)
+    response = await client.get(f"/api/v1/problems/{problem_id_str}/solution-status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "generating"}
+
+    # 4. returns 'failed' when task is failed
+    database["solution_generation_tasks"]._documents.clear()
+    task_failed = {**task_pending, "_id": ObjectId(), "status": "failed"}
+    database["solution_generation_tasks"].seed(task_failed)
+    response = await client.get(f"/api/v1/problems/{problem_id_str}/solution-status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "failed"}
+
+    # 5. returns 'ready' when solution exists
+    solution = {
+        "_id": ObjectId(),
+        "problem_id": problem_id_str,
+        "user_id": str(user_id),
+        "steps_markdown": "step 1",
+        "final_answer": "4",
+        "math_level_classification": "basic",
+    }
+    database["canonical_solutions"].seed(solution)
+    response = await client.get(f"/api/v1/problems/{problem_id_str}/solution-status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
+
+    # 6. returns 403 for other user problem
+    other_problem = make_problem(problems_app.state.secondary_user["_id"])
+    database["problems"].seed(other_problem)
+    response = await client.get(f"/api/v1/problems/{str(other_problem['_id'])}/solution-status")
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
Adds `GET /api/v1/problems/{problem_id}/solution-status` endpoint to retrieve the solution generation status. 

## Implementation Notes
- Added `SolutionStatusResponse` model in `problems.py`
- Added endpoint that checks `canonical_solutions` and `solution_generation_tasks` collections respectively to return the appropriate status (ready, pending, generating, failed, none).
- Secured with existing `get_owned_problem` dependency to ensure users can only see statuses for their own problems.

## Test Results
- ✅ `cd backend && uv run pytest tests/api/test_problems.py -k "solution_status"` passed successfully
- ✅ `cd backend && uv run pytest` passed successfully (193 passed, 1 skipped)
- Added 6 test cases for status resolution (`none`, `pending`, `generating`, `failed`, `ready`, and 403 fallback).

Fixes #106