### PR TITLE
Use process_after for solution worker backoff

### DIFF
--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -258,6 +258,7 @@ class SolutionGenerationTask(BaseModel):
     failure_reason: Optional[str] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    process_after: datetime = Field(default_factory=lambda: datetime.now(UTC))
     started_at: Optional[datetime] = None
 
 

--- a/backend/app/infrastructure/worker/solution_worker.py
+++ b/backend/app/infrastructure/worker/solution_worker.py
@@ -19,6 +19,11 @@ from app.presentation.solution_generation import _safe_get_collection
 
 logger = logging.getLogger(__name__)
 
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
 async def process_task(
     task: dict[str, Any],
     client: SolutionLLMClient,
@@ -33,10 +38,18 @@ async def process_task(
     
     problem = await problems_col.find_one({"_id": ObjectId(problem_id)})
     if not problem:
+        now = _utc_now()
         logger.warning(f"Problem {problem_id} not found for task {task['_id']}")
         await tasks_col.update_one(
             {"_id": task["_id"]},
-            {"$set": {"status": SolutionGenerationStatus.FAILED.value, "failure_reason": "Problem not found", "updated_at": datetime.now(UTC)}}
+            {
+                "$set": {
+                    "status": SolutionGenerationStatus.FAILED.value,
+                    "failure_reason": "Problem not found",
+                    "updated_at": now,
+                    "process_after": now,
+                }
+            }
         )
         return
         
@@ -68,15 +81,23 @@ async def process_task(
         await solutions_col.insert_one(solution)
         
         # Update task status to ready
+        now = _utc_now()
         await tasks_col.update_one(
             {"_id": task["_id"]},
-            {"$set": {"status": SolutionGenerationStatus.READY.value, "updated_at": datetime.now(UTC)}}
+            {
+                "$set": {
+                    "status": SolutionGenerationStatus.READY.value,
+                    "updated_at": now,
+                    "process_after": now,
+                }
+            }
         )
         
     except LLMClientError as exc:
         retry_count = int(task.get("retry_count", 0)) + 1
         logger.warning(f"LLM error for task {task['_id']}: {exc}")
         if retry_count > max_retries:
+            now = _utc_now()
             await tasks_col.update_one(
                 {"_id": task["_id"]},
                 {
@@ -84,12 +105,14 @@ async def process_task(
                         "status": SolutionGenerationStatus.FAILED.value,
                         "failure_reason": str(exc),
                         "retry_count": retry_count,
-                        "updated_at": datetime.now(UTC)
+                        "updated_at": now,
+                        "process_after": now,
                     }
                 }
             )
         else:
             # Exponential backoff: 30s, 60s, 120s
+            now = _utc_now()
             backoff_seconds = 30 * (2 ** (retry_count - 1))
             await tasks_col.update_one(
                 {"_id": task["_id"]},
@@ -97,11 +120,13 @@ async def process_task(
                     "$set": {
                         "status": SolutionGenerationStatus.PENDING.value,
                         "retry_count": retry_count,
-                        "updated_at": datetime.now(UTC) + timedelta(seconds=backoff_seconds)
+                        "updated_at": now,
+                        "process_after": now + timedelta(seconds=backoff_seconds),
                     }
                 }
             )
     except Exception as exc:
+        now = _utc_now()
         logger.exception(f"Unexpected error processing task {task['_id']}")
         await tasks_col.update_one(
             {"_id": task["_id"]},
@@ -109,7 +134,8 @@ async def process_task(
                 "$set": {
                     "status": SolutionGenerationStatus.FAILED.value,
                     "failure_reason": str(exc),
-                    "updated_at": datetime.now(UTC)
+                    "updated_at": now,
+                    "process_after": now,
                 }
             }
         )
@@ -137,7 +163,7 @@ async def run_solution_worker(database: Any, stop_event: asyncio.Event | None = 
             if stop_event and stop_event.is_set():
                 break
 
-            now = datetime.now(UTC)
+            now = _utc_now()
             
             # 1. Stuck task recovery
             stuck_threshold = now - timedelta(minutes=timeout_minutes)
@@ -149,7 +175,8 @@ async def run_solution_worker(database: Any, stop_event: asyncio.Event | None = 
                 {
                     "$set": {
                         "status": SolutionGenerationStatus.PENDING.value,
-                        "updated_at": now
+                        "updated_at": now,
+                        "process_after": now,
                     }
                 }
             )
@@ -158,13 +185,17 @@ async def run_solution_worker(database: Any, stop_event: asyncio.Event | None = 
             task = await tasks_col.find_one_and_update(
                 {
                     "status": SolutionGenerationStatus.PENDING.value,
-                    "updated_at": {"$lte": now}
+                    "$or": [
+                        {"process_after": {"$lte": now}},
+                        {"process_after": {"$exists": False}, "updated_at": {"$lte": now}},
+                    ],
                 },
                 {
                     "$set": {
                         "status": SolutionGenerationStatus.GENERATING.value,
                         "started_at": now,
-                        "updated_at": now
+                        "updated_at": now,
+                        "process_after": now,
                     }
                 },
                 sort=[("created_at", 1)],

--- a/backend/app/presentation/solution_generation.py
+++ b/backend/app/presentation/solution_generation.py
@@ -40,6 +40,7 @@ def _build_solution_task_document(
         status=SolutionGenerationStatus.PENDING,
         created_at=now,
         updated_at=now,
+        process_after=now,
     )
     document = task.model_dump()
     document["_id"] = ObjectId(task.id)

--- a/backend/tests/domain/test_solution_models.py
+++ b/backend/tests/domain/test_solution_models.py
@@ -21,6 +21,7 @@ def test_solution_generation_task_validates_required_fields_and_defaults() -> No
     assert task.started_at is None
     assert isinstance(task.created_at, datetime)
     assert isinstance(task.updated_at, datetime)
+    assert isinstance(task.process_after, datetime)
 
 
 def test_solution_generation_task_rejects_invalid_status() -> None:

--- a/backend/tests/worker/test_solution_worker.py
+++ b/backend/tests/worker/test_solution_worker.py
@@ -19,33 +19,25 @@ class FakeCollection:
 
     async def find_one(self, query):
         for doc in self._documents:
-            if all(doc.get(k) == v for k, v in query.items()):
+            if _matches(doc, query):
                 return deepcopy(doc)
         return None
 
     async def update_one(self, query, update):
         for doc in self._documents:
-            if all(doc.get(k) == v for k, v in query.items()):
+            if _matches(doc, query):
                 for k, v in update.get("$set", {}).items():
                     doc[k] = v
                 return
 
     async def update_many(self, query, update):
         for doc in self._documents:
-            match = True
-            for k, v in query.items():
-                if isinstance(v, dict):
-                    if "$in" in v and doc.get(k) not in v["$in"]: match = False
-                    if "$lt" in v and not (doc.get(k) < v["$lt"]): match = False
-                    if "$lte" in v and not (doc.get(k) <= v["$lte"]): match = False
-                elif doc.get(k) != v:
-                    match = False
-            if match:
+            if _matches(doc, query):
                 for k, v in update.get("$set", {}).items():
                     doc[k] = v
 
     async def find_one_and_update(self, query, update, sort=None, return_document=None):
-        docs = [d for d in self._documents if all(d.get(k) == v or (isinstance(v, dict) and "$lte" in v and d.get(k) <= v["$lte"]) for k, v in query.items())]
+        docs = [d for d in self._documents if _matches(d, query)]
         if not docs:
             return None
         if sort:
@@ -60,6 +52,30 @@ class FakeCollection:
         d = deepcopy(doc)
         if "_id" not in d: d["_id"] = ObjectId()
         self._documents.append(d)
+
+
+def _matches(document, query):
+    for key, value in query.items():
+        if key == "$or":
+            if not any(_matches(document, clause) for clause in value):
+                return False
+            continue
+
+        actual = document.get(key)
+        if isinstance(value, dict):
+            if "$in" in value and actual not in value["$in"]:
+                return False
+            if "$lt" in value and (actual is None or not (actual < value["$lt"])):
+                return False
+            if "$lte" in value and (actual is None or not (actual <= value["$lte"])):
+                return False
+            if "$exists" in value and (key in document) != value["$exists"]:
+                return False
+            continue
+
+        if actual != value:
+            return False
+    return True
 
 class FakeLLMClient:
     def __init__(self):
@@ -131,6 +147,8 @@ async def test_process_task_retry_and_fail():
     updated = await tasks_col.find_one({"_id": task_id})
     assert updated["status"] == "pending"
     assert updated["retry_count"] == 1
+    assert updated["updated_at"] <= updated["process_after"]
+    assert updated["process_after"] - updated["updated_at"] == timedelta(seconds=30)
     
     # 2. Fourth failure -> failed
     task["retry_count"] = 3
@@ -185,6 +203,57 @@ async def test_run_worker_stuck_task_recovery():
     # But since problem doesn't exist, it will be marked failed.
     updated = await db.cols["solution_generation_tasks"].find_one({"_id": stuck_task["_id"]})
     assert updated["status"] == "failed" # because it found the task, couldn't find problem
+
+
+@pytest.mark.asyncio
+async def test_run_worker_skips_pending_task_until_process_after() -> None:
+    class FakeSettings:
+        solution_worker_poll_interval_seconds = 0.01
+        solution_task_timeout_minutes = 10
+        solution_max_retries = 3
+        solution_llm_endpoint = "http"
+        solution_llm_model = "m"
+        solution_llm_api_key = "k"
+        vlm_timeout_seconds = 10
+        s3_bucket = "b"
+        s3_region = "r"
+        s3_endpoint_url = "u"
+        s3_access_key = "a"
+        s3_secret_key = "s"
+
+    from app.infrastructure.config import settings
+    settings.get_settings = lambda: FakeSettings()
+
+    class FakeDatabase:
+        def __init__(self):
+            self.cols = {"solution_generation_tasks": FakeCollection(), "canonical_solutions": FakeCollection(), "problems": FakeCollection()}
+        def __getitem__(self, k):
+            return self.cols[k]
+        def get_collection(self, k):
+            return self.cols[k]
+
+    db = FakeDatabase()
+    now = datetime.now(UTC)
+    pending_task = {
+        "_id": ObjectId(),
+        "problem_id": str(ObjectId()),
+        "user_id": str(ObjectId()),
+        "status": "pending",
+        "updated_at": now,
+        "process_after": now + timedelta(minutes=1),
+    }
+    db.cols["solution_generation_tasks"].seed(pending_task)
+
+    stop_event = asyncio.Event()
+
+    async def stop_soon():
+        await asyncio.sleep(0.05)
+        stop_event.set()
+
+    await asyncio.gather(run_solution_worker(db, stop_event), stop_soon())
+
+    updated = await db.cols["solution_generation_tasks"].find_one({"_id": pending_task["_id"]})
+    assert updated["status"] == "pending"
 
 @pytest.mark.asyncio
 async def test_process_task_no_image():


### PR DESCRIPTION
## Summary
- add a dedicated process_after timestamp to solution generation tasks
- keep updated_at as an actual last-modified timestamp instead of using it for retry scheduling
- keep the worker backward-compatible with older pending tasks that do not yet have process_after

## Implementation Notes
- solution task creation now initializes process_after alongside the existing timestamps
- retryable worker failures schedule the next pickup through process_after, while success and failure paths update updated_at normally
- worker tests cover the new scheduling behavior and verify future process_after tasks are not claimed early

## Test Results
- cd backend && uv run pytest tests/domain/test_solution_models.py tests/worker/test_solution_worker.py ✅
- cd backend && uv run pytest ✅
- cd frontend && npm test -- --run ✅
- cd frontend && npm run test:ui ⚠️ fails before test execution because Playwright waits for http://127.0.0.1:5173, but the configured Vite dev server is reachable at http://localhost:5173 and not at 127.0.0.1

Closes #118