### PR TITLE
feat(coaching): AI coaching page with interactive whiteboard (#109)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { TagsPage } from "@/pages/TagsPage";
 import { PracticePage } from "@/pages/PracticePage";
 import { ActivePracticePage } from "@/pages/ActivePracticePage";
 import { SettingsPage } from "@/pages/SettingsPage";
+import { CoachingPage } from "@/pages/CoachingPage";
 
 function AppShell({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
@@ -190,6 +191,14 @@ export function AppRoutes() {
         element={
           <ProtectedPage>
             <SettingsPage />
+          </ProtectedPage>
+        }
+      />
+      <Route
+        path="/coaching/:problemId"
+        element={
+          <ProtectedPage>
+            <CoachingPage />
           </ProtectedPage>
         }
       />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,6 +1,8 @@
 // API client wrapper for cookie-based authentication
 // Uses fetch with credentials: 'include' to send HttpOnly cookies automatically
 
+import type { CoachingConversation } from "@/types/coaching";
+
 const API_BASE = "/api/v1";
 
 export interface User {
@@ -35,6 +37,27 @@ async function handleResponse<T>(response: Response): Promise<T> {
  * Uses cookie-based auth with credentials: 'include'.
  */
 export const api = {
+  /**
+   * Get the coaching conversation for a problem
+   */
+  async getCoachingConversation(problemId: string): Promise<CoachingConversation> {
+    return this.get<CoachingConversation>(`/coaching/${problemId}/conversation`);
+  },
+
+  /**
+   * Send a coaching message for a problem
+   */
+  async sendCoachingMessage(problemId: string, message: string): Promise<CoachingConversation> {
+    return this.post<CoachingConversation>(`/coaching/${problemId}/messages`, { message });
+  },
+
+  /**
+   * Clear the coaching conversation for a problem
+   */
+  async clearCoachingConversation(problemId: string): Promise<void> {
+    return this.delete<void>(`/coaching/${problemId}/conversation`);
+  },
+
   /**
    * Get the current authenticated user session
    */

--- a/frontend/src/pages/CoachingPage.test.tsx
+++ b/frontend/src/pages/CoachingPage.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { api } from "@/api/client";
-import { CoachingPage } from "./CoachingPage";
+import { CoachingPage, type PracticeHistoryResponse, type ExamResponse } from "./CoachingPage";
 import type { CoachingConversation, CoachingMessage } from "@/types/coaching";
 
 // Mock GraphSandbox component to easily verify DSL and trigger errors

--- a/frontend/src/pages/CoachingPage.test.tsx
+++ b/frontend/src/pages/CoachingPage.test.tsx
@@ -1,0 +1,385 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { api } from "@/api/client";
+import { CoachingPage } from "./CoachingPage";
+import type { CoachingConversation, CoachingMessage } from "@/types/coaching";
+
+// Mock GraphSandbox component to easily verify DSL and trigger errors
+vi.mock("@/components/GraphSandbox", () => ({
+  GraphSandbox: ({ dsl, onError }: { dsl: string; onError?: (err: string) => void }) => (
+    <div data-testid="graph-sandbox" data-dsl={dsl}>
+      GraphSandbox: {dsl}
+      <button
+        type="button"
+        onClick={() => onError?.("JSXGraph compile error")}
+        data-testid="trigger-sandbox-error"
+      >
+        Trigger Sandbox Error
+      </button>
+    </div>
+  ),
+}));
+
+// Mock CollapsibleImage component
+vi.mock("@/components/CollapsibleImage", () => ({
+  CollapsibleImage: ({ src, alt }: { src: string; alt: string }) => (
+    <img src={src} alt={alt} data-testid="collapsible-image" />
+  ),
+}));
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function renderCoachingPage(
+  problemId: string,
+  fromRoute: string = "/practice"
+) {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter
+        initialEntries={[{ pathname: `/coaching/${problemId}`, state: { from: fromRoute } }]}
+      >
+        <Routes>
+          <Route path="/coaching/:problemId" element={<CoachingPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+const mockProblem = {
+  id: "prob-123",
+  text: "Given $x^2 = 4$, find $x$.",
+  problemType: "short-answer",
+  graphDsl: "board.create('point', [1, 2]);",
+  imageUrl: "/api/v1/problems/prob-123/image",
+  tags: ["algebra"],
+  isDeleted: false,
+  createdAt: "2026-05-25T12:00:00Z",
+  updatedAt: "2026-05-25T12:00:00Z",
+};
+
+const mockConversationEmpty: CoachingConversation = {
+  problem_id: "prob-123",
+  user_id: "user-456",
+  messages: [],
+  created_at: "2026-05-25T12:30:00Z",
+  updated_at: "2026-05-25T12:30:00Z",
+};
+
+const mockConversationWithMessages: CoachingConversation = {
+  problem_id: "prob-123",
+  user_id: "user-456",
+  messages: [
+    {
+      role: "student",
+      content: "Can you help me solve $x^2 = 4$?",
+      created_at: "2026-05-25T12:31:00Z",
+    },
+    {
+      role: "coach",
+      content: "Sure! Take the square root of both sides. We get $x = \\pm 2$. Here is a drawing.",
+      whiteboard_dsl: "board.create('point', [0, 2]);",
+      created_at: "2026-05-25T12:32:00Z",
+    },
+  ],
+  created_at: "2026-05-25T12:30:00Z",
+  updated_at: "2026-05-25T12:32:00Z",
+};
+
+const mockPracticeHistory: PracticeHistoryResponse = {
+  items: [
+    {
+      problemId: "prob-123",
+      attempts: [
+        {
+          submittedAnswer: "3",
+          gradingStatus: "incorrect",
+          gradingMethod: "normalized-match",
+          createdAt: "2026-05-25T12:15:00Z",
+        },
+      ],
+    },
+  ],
+};
+
+const mockExamData: ExamResponse = {
+  exam: {
+    id: "exam-789",
+    items: [
+      {
+        problemId: "prob-123",
+        answer: {
+          raw: "2",
+        },
+        grading: {
+          status: "correct",
+          isCorrect: true,
+        },
+      },
+    ],
+  },
+};
+
+describe("CoachingPage", () => {
+  beforeEach(() => {
+    // Mock scrollIntoView in jsdom
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+    vi.restoreAllMocks();
+
+    // Standard mocks for API Client
+    vi.spyOn(api, "get").mockImplementation(async (path: string) => {
+      if (path === "/problems/prob-123") {
+        return { problem: mockProblem };
+      }
+      if (path === "/practice/history") {
+        return mockPracticeHistory;
+      }
+      if (path === "/exams/exam-789") {
+        return mockExamData;
+      }
+      throw new Error(`Unexpected GET path: ${path}`);
+    });
+
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationEmpty);
+    vi.spyOn(api, "sendCoachingMessage").mockResolvedValue(mockConversationWithMessages);
+    vi.spyOn(api, "clearCoachingConversation").mockResolvedValue(undefined);
+  });
+
+  it("renders context bar with problem text, original figure, student answer, and grading judgement (from practice)", async () => {
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("context-bar")).toBeInTheDocument();
+    });
+
+    // Check problem text LaTeX is rendered
+    expect(screen.getByTestId("context-bar").textContent).toContain("Given");
+    expect(screen.getByTestId("context-bar").textContent).toContain("find x");
+
+    // Check original figure via GraphSandbox is displayed
+    const originalFigure = screen.getByTestId("context-original-figure");
+    expect(originalFigure).toBeInTheDocument();
+    expect(originalFigure.querySelector('[data-testid="graph-sandbox"]')).toHaveAttribute(
+      "data-dsl",
+      mockProblem.graphDsl
+    );
+
+    // Check student answer and status from practice history
+    expect(screen.getByText("Incorrect")).toBeInTheDocument();
+    expect(screen.getByTestId("student-answer")).toHaveTextContent("3");
+  });
+
+  it("renders context bar with student answer and grading judgement (from exam)", async () => {
+    renderCoachingPage("prob-123", "/exams/exam-789");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("context-bar")).toBeInTheDocument();
+    });
+
+    // Check student answer and status from exam data
+    expect(screen.getByText("Correct")).toBeInTheDocument();
+    expect(screen.getByTestId("student-answer")).toHaveTextContent("2");
+  });
+
+  it("displays conversation messages in chronological order and renders LaTeX", async () => {
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationWithMessages);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-log")).toBeInTheDocument();
+    });
+
+    const chatLog = screen.getByTestId("chat-log");
+    expect(chatLog.textContent).toContain("Can you help me solve");
+    expect(chatLog.textContent).toContain("Take the square root of both sides");
+  });
+
+  it("submits text input, sends message, and shows loading state", async () => {
+    const user = userEvent.setup();
+    const sendSpy = vi.spyOn(api, "sendCoachingMessage").mockResolvedValue(mockConversationWithMessages);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-input")).toBeInTheDocument();
+    });
+
+    const input = screen.getByTestId("chat-input");
+    await user.type(input, "What is the next step?");
+    await user.click(screen.getByTestId("send-button"));
+
+    expect(sendSpy).toHaveBeenCalledWith("prob-123", "What is the next step?");
+  });
+
+  it("sends predefined messages via mode shortcuts", async () => {
+    const user = userEvent.setup();
+    const sendSpy = vi.spyOn(api, "sendCoachingMessage").mockResolvedValue(mockConversationWithMessages);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("shortcuts-bar")).toBeInTheDocument();
+    });
+
+    // Test Explain shortcut
+    await user.click(screen.getByTestId("shortcut-explain"));
+    expect(sendSpy).toHaveBeenLastCalledWith("prob-123", "Please explain this problem.");
+
+    // Test Hint shortcut
+    await user.click(screen.getByTestId("shortcut-hint"));
+    expect(sendSpy).toHaveBeenLastCalledWith("prob-123", "Can you give me a hint?");
+
+    // Test Steps shortcut
+    await user.click(screen.getByTestId("shortcut-steps"));
+    expect(sendSpy).toHaveBeenLastCalledWith("prob-123", "What are the steps to solve this?");
+
+    // Test Draw shortcut
+    await user.click(screen.getByTestId("shortcut-draw"));
+    expect(sendSpy).toHaveBeenLastCalledWith("prob-123", "Can you show me a drawing or visualization?");
+  });
+
+  it("renders whiteboard in empty state when no whiteboard drawings are present", async () => {
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("whiteboard-empty")).toBeInTheDocument();
+    expect(screen.getByText("Whiteboard Canvas Empty")).toBeInTheDocument();
+  });
+
+  it("renders whiteboard DSL pages with navigation controls and page indicators", async () => {
+    // Return a conversation with two distinct whiteboard drawings
+    const conversationWithMultipleWhiteboards: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: [
+        {
+          role: "coach",
+          content: "Drawing 1",
+          whiteboard_dsl: "board.create('circle', [[0,0], 2]);",
+          created_at: "2026-05-25T12:31:00Z",
+        },
+        {
+          role: "coach",
+          content: "Drawing 2",
+          whiteboard_dsl: "board.create('circle', [[1,1], 3]);",
+          created_at: "2026-05-25T12:32:00Z",
+        },
+      ],
+      created_at: "2026-05-25T12:30:00Z",
+      updated_at: "2026-05-25T12:32:00Z",
+    };
+
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationWithMultipleWhiteboards);
+
+    const user = userEvent.setup();
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard")).toBeInTheDocument();
+    });
+
+    // Should render active page (latest page is 2)
+    const getWhiteboardCanvas = () => within(screen.getByTestId("whiteboard")).getByTestId("graph-sandbox");
+    expect(getWhiteboardCanvas()).toHaveAttribute("data-dsl", "board.create('circle', [[1,1], 3]);");
+    expect(screen.getByTestId("whiteboard-page-indicator")).toHaveTextContent("2 / 2");
+
+    // Click Prev to see first drawing
+    await user.click(screen.getByTestId("whiteboard-prev"));
+    expect(getWhiteboardCanvas()).toHaveAttribute("data-dsl", "board.create('circle', [[0,0], 2]);");
+    expect(screen.getByTestId("whiteboard-page-indicator")).toHaveTextContent("1 / 2");
+  });
+
+  it("shows error indicator on whiteboard rendering failure while keeping the text in chat", async () => {
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationWithMessages);
+
+    const user = userEvent.setup();
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(within(screen.getByTestId("whiteboard")).getByTestId("graph-sandbox")).toBeInTheDocument();
+    });
+
+    // Trigger mocked GraphSandbox onError callback
+    await user.click(within(screen.getByTestId("whiteboard")).getByTestId("trigger-sandbox-error"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard-error")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("whiteboard-error")).toHaveTextContent(
+      "Whiteboard Rendering Error: JSXGraph compile error"
+    );
+
+    // Verify chat text remains displayed
+    expect(screen.getByTestId("chat-log").textContent).toContain(
+      "Sure! Take the square root of both sides. We get"
+    );
+  });
+
+  it("clears conversation resets the UI", async () => {
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationWithMessages);
+    const clearSpy = vi.spyOn(api, "clearCoachingConversation");
+
+    const user = userEvent.setup();
+    // Mock window.confirm to return true
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("clear-button")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("clear-button"));
+
+    expect(clearSpy).toHaveBeenCalledWith("prob-123");
+  });
+
+  it("disables message inputs and shows warning when the 20-message limit is reached", async () => {
+    // Generate 20 mock messages to trigger limit
+    const messagesArray: CoachingMessage[] = Array.from({ length: 20 }, (_, i) => ({
+      role: i % 2 === 0 ? "student" : "coach",
+      content: `Message ${i + 1}`,
+      created_at: new Date(Date.now() + i * 1000).toISOString(),
+    }));
+
+    const conversationAtLimit: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: messagesArray,
+      created_at: "2026-05-25T12:00:00Z",
+      updated_at: "2026-05-25T12:20:00Z",
+    };
+
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationAtLimit);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("cap-warning")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("cap-warning")).toHaveTextContent(
+      "Message cap of 20 reached. Clear conversation to start over."
+    );
+
+    // Verify inputs are disabled
+    expect(screen.getByTestId("chat-input")).toBeDisabled();
+    expect(screen.getByTestId("send-button")).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -1,0 +1,702 @@
+import { useState, useEffect, useRef } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/api/client";
+import { GraphSandbox } from "@/components/GraphSandbox";
+import { CollapsibleImage } from "@/components/CollapsibleImage";
+import { LatexText } from "@/components/LatexText";
+import type { CoachingConversation } from "@/types/coaching";
+
+interface CorrectAnswer {
+  display: string;
+  normalizedText: string;
+  normalizedSet: string[];
+  format: string;
+}
+
+interface Problem {
+  id: string;
+  problemType: string;
+  text: string;
+  tags: string[];
+  graphDsl?: string;
+  imageUrl?: string;
+  correctAnswer?: CorrectAnswer;
+  isDeleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ProblemResponse {
+  problem: Problem;
+}
+
+interface PracticeAttemptDetail {
+  submittedAnswer: string;
+  gradingStatus: string;
+  gradingMethod: string;
+  createdAt: string;
+}
+
+interface PracticeHistoryItem {
+  problemId: string;
+  attempts: PracticeAttemptDetail[];
+}
+
+interface PracticeHistoryResponse {
+  items: PracticeHistoryItem[];
+}
+
+interface ExamItem {
+  problemId: string;
+  answer: {
+    raw?: string;
+  };
+  grading: {
+    status: string;
+    isCorrect?: boolean;
+  };
+}
+
+interface ExamResponse {
+  exam: {
+    id: string;
+    items: ExamItem[];
+  };
+}
+
+export function CoachingPage() {
+  const { problemId = "" } = useParams<{ problemId: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Dynamic back navigation route
+  const fromRoute = (location.state as { from?: string } | null)?.from ?? "/practice";
+
+  // Form input state
+  const [messageText, setMessageText] = useState("");
+  const [whiteboardError, setWhiteboardError] = useState<string | null>(null);
+  const [chatError, setChatError] = useState<string | null>(null);
+
+  // Active whiteboard page index
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+
+  // 1. Fetch Problem Details
+  const { data: problem, isLoading: isLoadingProblem } = useQuery({
+    queryKey: ["problem", problemId],
+    queryFn: async () => {
+      const data = await api.get<ProblemResponse>(`/problems/${problemId}`);
+      return data.problem;
+    },
+    enabled: !!problemId,
+  });
+
+  // 2. Fetch Practice History (if referrer is practice)
+  const isFromPractice = fromRoute === "/practice" || fromRoute.startsWith("/practice");
+  const { data: practiceHistory } = useQuery({
+    queryKey: ["practice-history"],
+    queryFn: () => api.get<PracticeHistoryResponse>("/practice/history"),
+    enabled: !!problemId && isFromPractice,
+  });
+
+  // 3. Fetch Exam Details (if referrer is an exam)
+  const isFromExam = fromRoute.startsWith("/exams/");
+  const examId = isFromExam ? fromRoute.split("/")[2] : "";
+  const { data: examData } = useQuery({
+    queryKey: ["exam", examId],
+    queryFn: () => api.get<ExamResponse>(`/exams/${examId}`),
+    enabled: !!problemId && !!examId,
+  });
+
+  // Extract student answer & judgement dynamically
+  let studentAnswer = "";
+  let gradingStatus = "";
+
+  if (isFromPractice && practiceHistory) {
+    const matchedProblem = practiceHistory.items?.find((item) => item.problemId === problemId);
+    if (matchedProblem && matchedProblem.attempts?.length > 0) {
+      studentAnswer = matchedProblem.attempts[0].submittedAnswer;
+      gradingStatus = matchedProblem.attempts[0].gradingStatus;
+    }
+  } else if (isFromExam && examData) {
+    const matchedItem = examData.exam?.items?.find((item) => item.problemId === problemId);
+    if (matchedItem) {
+      studentAnswer = matchedItem.answer.raw || "";
+      gradingStatus = matchedItem.grading.status;
+    }
+  }
+
+  // 4. Fetch Coaching Conversation
+  const { data: conversation, isLoading: isLoadingConversation } = useQuery<CoachingConversation>({
+    queryKey: ["coaching-conversation", problemId],
+    queryFn: () => api.getCoachingConversation(problemId),
+    enabled: !!problemId,
+  });
+
+  // Extract whiteboard pages (unique whiteboard_dsl codes in order)
+  const dslPages = conversation?.messages
+    ?.filter((m) => m.role === "coach" && m.whiteboard_dsl)
+    ?.map((m) => m.whiteboard_dsl as string) || [];
+
+
+
+  // Keep index within boundaries when pages change
+  useEffect(() => {
+    if (dslPages.length > 0) {
+      setCurrentPageIndex(dslPages.length - 1);
+      setWhiteboardError(null);
+    } else {
+      setCurrentPageIndex(0);
+    }
+  }, [dslPages.length]);
+
+  // Scroll to bottom of chat when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView?.({ behavior: "smooth" });
+  }, [conversation?.messages?.length]);
+
+  // Mutations
+  const sendMessageMutation = useMutation({
+    mutationFn: (text: string) => api.sendCoachingMessage(problemId, text),
+    onSuccess: (updatedConversation) => {
+      queryClient.setQueryData(["coaching-conversation", problemId], updatedConversation);
+      setMessageText("");
+      setChatError(null);
+    },
+    onError: (err) => {
+      setChatError(err instanceof Error ? err.message : "Failed to send message");
+    },
+  });
+
+  const clearConversationMutation = useMutation({
+    mutationFn: () => api.clearCoachingConversation(problemId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["coaching-conversation", problemId] });
+      setCurrentPageIndex(0);
+      setWhiteboardError(null);
+      setChatError(null);
+    },
+    onError: (err) => {
+      setChatError(err instanceof Error ? err.message : "Failed to clear conversation");
+    },
+  });
+
+  const handleSendMessage = (text: string) => {
+    if (!text.trim() || sendMessageMutation.isPending) return;
+    sendMessageMutation.mutate(text);
+  };
+
+  const handleShortcutClick = (shortcutType: "Explain" | "Hint" | "Steps" | "Draw") => {
+    const predefinedMessages = {
+      Explain: "Please explain this problem.",
+      Hint: "Can you give me a hint?",
+      Steps: "What are the steps to solve this?",
+      Draw: "Can you show me a drawing or visualization?",
+    };
+    handleSendMessage(predefinedMessages[shortcutType]);
+  };
+
+  if (isLoadingProblem || isLoadingConversation) {
+    return (
+      <main style={{ padding: "2rem", display: "flex", justifyContent: "center", alignItems: "center", minHeight: "80vh" }}>
+        <div style={{ fontSize: "1.25rem", color: "#4f46e5", fontWeight: 600, display: "flex", alignItems: "center", gap: "0.5rem" }}>
+          <div style={{ width: "24px", height: "24px", borderRadius: "50%", border: "3px solid #e0e7ff", borderTopColor: "#4f46e5", animation: "spin 1s linear infinite" }} />
+          Loading coaching page...
+          <style>{`@keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }`}</style>
+        </div>
+      </main>
+    );
+  }
+
+  if (!problem) {
+    return (
+      <main style={{ padding: "2rem", maxWidth: "600px", margin: "2rem auto" }}>
+        <div style={{ padding: "1.5rem", backgroundColor: "#fef2f2", border: "1px solid #fecaca", borderRadius: "0.5rem", textAlign: "center" }}>
+          <div style={{ color: "#dc2626", fontWeight: 600, fontSize: "1.125rem", marginBottom: "0.5rem" }}>Problem Not Found</div>
+          <p style={{ color: "#7f1d1d", margin: "0 0 1.5rem 0" }}>The problem you are trying to access does not exist or has been deleted.</p>
+          <button onClick={() => navigate(fromRoute)} style={{ padding: "0.5rem 1.5rem", backgroundColor: "#dc2626", color: "white", border: "none", borderRadius: "0.25rem", cursor: "pointer", fontWeight: 600 }}>
+            Go Back
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  const messageCount = conversation?.messages?.length || 0;
+  const isCapped = messageCount >= 20;
+
+  return (
+    <main style={{ padding: "1.5rem", minHeight: "calc(100vh - 60px)", display: "flex", flexDirection: "column", gap: "1rem", backgroundColor: "#f8fafc" }}>
+      {/* Header controls */}
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: "1rem" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+          <button
+            onClick={() => navigate(fromRoute)}
+            data-testid="back-button"
+            style={{
+              padding: "0.5rem 1rem",
+              borderRadius: "0.375rem",
+              border: "1px solid #e2e8f0",
+              backgroundColor: "white",
+              color: "#334155",
+              cursor: "pointer",
+              fontWeight: 600,
+              fontSize: "0.875rem",
+              display: "flex",
+              alignItems: "center",
+              gap: "0.25rem",
+              boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
+            }}
+          >
+            ← Back to Review
+          </button>
+          <h1 style={{ margin: 0, fontSize: "1.5rem", color: "#0f172a", fontWeight: 700 }}>AI Coach</h1>
+        </div>
+
+        <button
+          onClick={() => {
+            if (window.confirm("Are you sure you want to clear this entire conversation history? This will also empty the whiteboard.")) {
+              clearConversationMutation.mutate();
+            }
+          }}
+          disabled={clearConversationMutation.isPending || messageCount === 0}
+          data-testid="clear-button"
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "0.375rem",
+            backgroundColor: "#fff1f2",
+            color: messageCount === 0 ? "#cbd5e1" : "#e11d48",
+            border: "1px solid #ffe4e6",
+            cursor: messageCount === 0 || clearConversationMutation.isPending ? "not-allowed" : "pointer",
+            fontWeight: 600,
+            fontSize: "0.875rem",
+            boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
+            transition: "all 0.15s ease",
+          }}
+        >
+          {clearConversationMutation.isPending ? "Clearing..." : "Clear Conversation"}
+        </button>
+      </div>
+
+      {/* Main split layout container */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1.2fr", gap: "1.5rem", flex: 1, minHeight: "650px", alignItems: "stretch" }}>
+        
+        {/* Left side: Context + Chat Area */}
+        <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+          
+          {/* 1. Context Bar */}
+          <div
+            data-testid="context-bar"
+            style={{
+              padding: "1rem 1.25rem",
+              backgroundColor: "white",
+              borderRadius: "0.75rem",
+              border: "1px solid #e2e8f0",
+              boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+              display: "flex",
+              flexDirection: "column",
+              gap: "0.75rem",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid #f1f5f9", paddingBottom: "0.5rem" }}>
+              <strong style={{ fontSize: "0.875rem", color: "#475569" }}>Problem Snapshot</strong>
+              {gradingStatus && (
+                <span
+                  style={{
+                    fontSize: "0.75rem",
+                    fontWeight: 600,
+                    padding: "0.25rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    backgroundColor: gradingStatus === "correct" ? "#dcfce7" : gradingStatus === "incorrect" ? "#fee2e2" : "#fef3c7",
+                    color: gradingStatus === "correct" ? "#166534" : gradingStatus === "incorrect" ? "#991b1b" : "#854d0e",
+                  }}
+                >
+                  {gradingStatus.charAt(0).toUpperCase() + gradingStatus.slice(1)}
+                </span>
+              )}
+            </div>
+
+            <div style={{ display: "flex", gap: "1rem", flexWrap: "wrap", alignItems: "flex-start" }}>
+              <div style={{ flex: 1, minWidth: "200px" }}>
+                <LatexText text={problem.text} style={{ fontSize: "0.925rem", color: "#1e293b", lineHeight: 1.5, whiteSpace: "pre-wrap" }} />
+              </div>
+              
+              {/* Problem figure displayed in context bar only, NOT in whiteboard (FR-32) */}
+              {problem.graphDsl && (
+                <div style={{ width: "200px" }} data-testid="context-original-figure">
+                  <GraphSandbox dsl={problem.graphDsl} height={140} />
+                </div>
+              )}
+              {problem.imageUrl && !problem.graphDsl && (
+                <div style={{ width: "150px" }}>
+                  <CollapsibleImage src={problem.imageUrl} alt="Original Figure" style={{ maxWidth: "100%", maxHeight: "120px", borderRadius: "0.375rem" }} />
+                </div>
+              )}
+            </div>
+
+            {studentAnswer && (
+              <div style={{ padding: "0.5rem 0.75rem", backgroundColor: "#f8fafc", borderRadius: "0.375rem", borderLeft: "3px solid #cbd5e1", fontSize: "0.875rem" }}>
+                <span style={{ color: "#64748b", fontWeight: 500, marginRight: "0.5rem" }}>Your Answer:</span>
+                <strong data-testid="student-answer" style={{ color: "#334155" }}>{studentAnswer}</strong>
+              </div>
+            )}
+          </div>
+
+          {/* 2. Chat Interface */}
+          <div
+            style={{
+              flex: 1,
+              backgroundColor: "white",
+              borderRadius: "0.75rem",
+              border: "1px solid #e2e8f0",
+              boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+            }}
+          >
+            {/* Scrollable messages log */}
+            <div
+              data-testid="chat-log"
+              style={{
+                flex: 1,
+                padding: "1.25rem",
+                overflowY: "auto",
+                display: "flex",
+                flexDirection: "column",
+                gap: "1rem",
+                maxHeight: "450px",
+              }}
+            >
+              {conversation?.messages?.length === 0 ? (
+                <div style={{ margin: "auto", textAlign: "center", color: "#94a3b8", padding: "2rem" }}>
+                  <div style={{ fontSize: "2.5rem", marginBottom: "0.5rem" }}>💬</div>
+                  <strong>No messages yet</strong>
+                  <p style={{ margin: "0.25rem 0 0 0", fontSize: "0.875rem" }}>Ask the coach to explain the problem or start with a shortcut below.</p>
+                </div>
+              ) : (
+                conversation?.messages?.map((msg, index) => {
+                  const isStudent = msg.role === "student";
+                  return (
+                    <div
+                      key={index}
+                      style={{
+                        display: "flex",
+                        justifyContent: isStudent ? "flex-end" : "flex-start",
+                        width: "100%",
+                      }}
+                    >
+                      <div
+                        style={{
+                          maxWidth: "85%",
+                          padding: "0.75rem 1rem",
+                          borderRadius: "0.75rem",
+                          borderBottomRightRadius: isStudent ? "0px" : "0.75rem",
+                          borderBottomLeftRadius: isStudent ? "0.75rem" : "0px",
+                          backgroundColor: isStudent ? "#e0e7ff" : "#f1f5f9",
+                          color: isStudent ? "#312e81" : "#1e293b",
+                          border: isStudent ? "1px solid #c7d2fe" : "1px solid #e2e8f0",
+                          fontSize: "0.925rem",
+                          lineHeight: 1.5,
+                        }}
+                      >
+                        <LatexText text={msg.content} />
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+
+              {sendMessageMutation.isPending && (
+                <div style={{ display: "flex", justifyContent: "flex-start" }}>
+                  <div
+                    style={{
+                      padding: "0.75rem 1rem",
+                      borderRadius: "0.75rem",
+                      borderBottomLeftRadius: "0px",
+                      backgroundColor: "#f8fafc",
+                      color: "#64748b",
+                      border: "1px dashed #cbd5e1",
+                      fontSize: "0.875rem",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "0.5rem",
+                    }}
+                  >
+                    <div style={{ display: "flex", gap: "3px" }}>
+                      <div style={{ width: "6px", height: "6px", backgroundColor: "#94a3b8", borderRadius: "50%", animation: "bounce 1.4s infinite ease-in-out both" }} />
+                      <div style={{ width: "6px", height: "6px", backgroundColor: "#94a3b8", borderRadius: "50%", animation: "bounce 1.4s infinite ease-in-out both 0.2s" }} />
+                      <div style={{ width: "6px", height: "6px", backgroundColor: "#94a3b8", borderRadius: "50%", animation: "bounce 1.4s infinite ease-in-out both 0.4s" }} />
+                    </div>
+                    Coach is thinking...
+                    <style>{`
+                      @keyframes bounce {
+                        0%, 80%, 100% { transform: scale(0); }
+                        40% { transform: scale(1.0); }
+                      }
+                    `}</style>
+                  </div>
+                </div>
+              )}
+
+              {chatError && (
+                <div style={{ display: "flex", justifyContent: "flex-start" }} data-testid="chat-error">
+                  <div
+                    style={{
+                      padding: "0.75rem 1rem",
+                      borderRadius: "0.75rem",
+                      borderBottomLeftRadius: "0px",
+                      backgroundColor: "#fff1f2",
+                      color: "#b91c1c",
+                      border: "1px solid #fecaca",
+                      fontSize: "0.875rem",
+                    }}
+                  >
+                    <strong>Error:</strong> {chatError}
+                  </div>
+                </div>
+              )}
+
+              <div ref={messagesEndRef} />
+            </div>
+
+            {/* Chat bottom control panel */}
+            <div style={{ padding: "1rem", borderTop: "1px solid #e2e8f0", backgroundColor: "#f8fafc", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+              
+              {/* Shortcut buttons */}
+              <div style={{ display: "flex", gap: "0.5rem", flexWrap: "wrap" }} data-testid="shortcuts-bar">
+                {(["Explain", "Hint", "Steps", "Draw"] as const).map((shortcut) => (
+                  <button
+                    key={shortcut}
+                    onClick={() => handleShortcutClick(shortcut)}
+                    disabled={isCapped || sendMessageMutation.isPending}
+                    data-testid={`shortcut-${shortcut.toLowerCase()}`}
+                    style={{
+                      padding: "0.375rem 0.75rem",
+                      borderRadius: "0.25rem",
+                      border: "1px solid #cbd5e1",
+                      backgroundColor: "white",
+                      color: "#475569",
+                      cursor: isCapped || sendMessageMutation.isPending ? "not-allowed" : "pointer",
+                      fontSize: "0.75rem",
+                      fontWeight: 600,
+                      boxShadow: "0 1px 2px rgba(0, 0, 0, 0.02)",
+                      transition: "all 0.15s ease",
+                    }}
+                  >
+                    {shortcut === "Explain" && "💡 Explain"}
+                    {shortcut === "Hint" && "🔑 Hint"}
+                    {shortcut === "Steps" && "📋 Steps"}
+                    {shortcut === "Draw" && "🎨 Draw"}
+                  </button>
+                ))}
+              </div>
+
+              {/* Chat Input form */}
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  handleSendMessage(messageText);
+                }}
+                style={{ display: "flex", gap: "0.5rem" }}
+              >
+                <input
+                  type="text"
+                  value={messageText}
+                  onChange={(e) => setMessageText(e.target.value)}
+                  disabled={isCapped || sendMessageMutation.isPending}
+                  placeholder={
+                    isCapped
+                      ? "Message limit reached"
+                      : "Type your question here (e.g. Can you explain step 2?)..."
+                  }
+                  data-testid="chat-input"
+                  style={{
+                    flex: 1,
+                    padding: "0.625rem 0.875rem",
+                    borderRadius: "0.375rem",
+                    border: "1px solid #cbd5e1",
+                    fontSize: "0.875rem",
+                    outline: "none",
+                    boxShadow: "inset 0 1px 2px rgba(0, 0, 0, 0.05)",
+                    backgroundColor: isCapped || sendMessageMutation.isPending ? "#f1f5f9" : "white",
+                    cursor: isCapped || sendMessageMutation.isPending ? "not-allowed" : "text",
+                  }}
+                />
+                <button
+                  type="submit"
+                  disabled={isCapped || !messageText.trim() || sendMessageMutation.isPending}
+                  data-testid="send-button"
+                  style={{
+                    padding: "0.625rem 1.25rem",
+                    borderRadius: "0.375rem",
+                    backgroundColor: isCapped || !messageText.trim() || sendMessageMutation.isPending ? "#a5b4fc" : "#4f46e5",
+                    color: "white",
+                    border: "none",
+                    cursor: isCapped || !messageText.trim() || sendMessageMutation.isPending ? "not-allowed" : "pointer",
+                    fontWeight: 600,
+                    fontSize: "0.875rem",
+                    boxShadow: "0 1px 2px rgba(79, 70, 229, 0.2)",
+                  }}
+                >
+                  Send
+                </button>
+              </form>
+
+              {/* Message capacity warning */}
+              {isCapped && (
+                <div data-testid="cap-warning" style={{ fontSize: "0.75rem", color: "#e11d48", fontWeight: 500, textAlign: "center", marginTop: "0.25rem" }}>
+                  ⚠️ Message cap of 20 reached. Clear conversation to start over.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Right side: Interactive Whiteboard Area */}
+        <div
+          data-testid="whiteboard"
+          style={{
+            backgroundColor: "white",
+            borderRadius: "0.75rem",
+            border: "1px solid #e2e8f0",
+            boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+            padding: "1.25rem",
+            display: "flex",
+            flexDirection: "column",
+            gap: "1rem",
+            alignItems: "stretch",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid #f1f5f9", paddingBottom: "0.75rem" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <span style={{ fontSize: "1.25rem" }}>🎨</span>
+              <strong style={{ fontSize: "1rem", color: "#0f172a", fontWeight: 700 }}>Interactive Whiteboard</strong>
+            </div>
+            
+            {/* Whiteboard pagination controls */}
+            {dslPages.length > 0 && (
+              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+                <button
+                  onClick={() => {
+                    setCurrentPageIndex((prev) => Math.max(0, prev - 1));
+                    setWhiteboardError(null);
+                  }}
+                  disabled={currentPageIndex === 0}
+                  data-testid="whiteboard-prev"
+                  style={{
+                    padding: "0.25rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    border: "1px solid #e2e8f0",
+                    backgroundColor: "white",
+                    cursor: currentPageIndex === 0 ? "not-allowed" : "pointer",
+                    fontSize: "0.875rem",
+                    fontWeight: 600,
+                  }}
+                >
+                  ◀
+                </button>
+                
+                <span data-testid="whiteboard-page-indicator" style={{ fontSize: "0.875rem", fontWeight: 600, color: "#475569" }}>
+                  {currentPageIndex + 1} / {dslPages.length}
+                </span>
+
+                <button
+                  onClick={() => {
+                    setCurrentPageIndex((prev) => Math.min(dslPages.length - 1, prev + 1));
+                    setWhiteboardError(null);
+                  }}
+                  disabled={currentPageIndex === dslPages.length - 1}
+                  data-testid="whiteboard-next"
+                  style={{
+                    padding: "0.25rem 0.5rem",
+                    borderRadius: "0.25rem",
+                    border: "1px solid #e2e8f0",
+                    backgroundColor: "white",
+                    cursor: currentPageIndex === dslPages.length - 1 ? "not-allowed" : "pointer",
+                    fontSize: "0.875rem",
+                    fontWeight: 600,
+                  }}
+                >
+                  ▶
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Canvas area wrapper */}
+          <div style={{ flex: 1, position: "relative", minHeight: "400px" }}>
+            {dslPages.length === 0 ? (
+              
+              /* Whiteboard empty state (FR-30) */
+              <div
+                data-testid="whiteboard-empty"
+                style={{
+                  position: "absolute",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  backgroundColor: "#f8fafc",
+                  borderRadius: "0.5rem",
+                  border: "2px dashed #cbd5e1",
+                  color: "#94a3b8",
+                  padding: "2rem",
+                  textAlign: "center",
+                }}
+              >
+                <div style={{ fontSize: "3.5rem", marginBottom: "1rem" }}>✏️</div>
+                <strong style={{ fontSize: "1.125rem", color: "#64748b" }}>Whiteboard Canvas Empty</strong>
+                <p style={{ margin: "0.5rem 0 0 0", fontSize: "0.875rem", maxWidth: "320px", lineHeight: 1.4 }}>
+                  No whiteboard drawings have been loaded yet. Ask the coach to generate a drawing or click a shortcut like "Draw"!
+                </p>
+              </div>
+            ) : (
+              
+              /* Renders DSL pages with JSXGraph GraphSandbox */
+              <div style={{ width: "100%", height: "100%" }}>
+                {whiteboardError && (
+                  
+                  /* Custom error indicator shown when JSXGraph fails (FR-31) */
+                  <div
+                    data-testid="whiteboard-error"
+                    style={{
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      right: 0,
+                      zIndex: 20,
+                      padding: "1rem",
+                      backgroundColor: "#fef2f2",
+                      border: "1px solid #fecaca",
+                      borderRadius: "0.375rem",
+                      color: "#b91c1c",
+                      fontSize: "0.875rem",
+                      boxShadow: "0 2px 4px rgba(0, 0, 0, 0.05)",
+                    }}
+                  >
+                    <strong>Whiteboard Rendering Error:</strong> {whiteboardError}
+                  </div>
+                )}
+                
+                <GraphSandbox
+                  key={`whiteboard-canvas-${currentPageIndex}`}
+                  dsl={dslPages[currentPageIndex]}
+                  onError={(error) => setWhiteboardError(error)}
+                  onRender={() => setWhiteboardError(null)}
+                  height="100%"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -43,7 +43,7 @@ interface PracticeHistoryItem {
   attempts: PracticeAttemptDetail[];
 }
 
-interface PracticeHistoryResponse {
+export interface PracticeHistoryResponse {
   items: PracticeHistoryItem[];
 }
 
@@ -58,7 +58,7 @@ interface ExamItem {
   };
 }
 
-interface ExamResponse {
+export interface ExamResponse {
   exam: {
     id: string;
     items: ExamItem[];

--- a/frontend/src/types/coaching.ts
+++ b/frontend/src/types/coaching.ts
@@ -1,0 +1,17 @@
+export type CoachingRole = "student" | "coach";
+
+export interface CoachingMessage {
+  role: CoachingRole;
+  content: string;
+  whiteboard_dsl?: string | null;
+  created_at: string;
+}
+
+export interface CoachingConversation {
+  id?: string;
+  problem_id: string;
+  user_id: string;
+  messages: CoachingMessage[];
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
Resolves #109

### Summary
Implements a fully interactive split-screen Coaching Page UI at route `/coaching/:problemId`.

### Implementation Notes
- **Split-screen Layout**: Dedicated 1fr / 1.2fr split screen separating coaching context/chat from the interactive whiteboard.
- **Context Bar**: Dynamic problem snapshot rendering, original figure representation (via `<GraphSandbox />` or `<CollapsibleImage />`), student's submitted answer, and grading judgement (correct/incorrect/pending-review) populated from either Practice History or Exam data.
- **Chat UI**: Chronological messages log supporting LaTeX rendering using `<LatexText />`. Displays inline API error messages, thinking spinner, text input, and quick-action predefined shortcuts ("Explain", "Hint", "Steps", "Draw"). Enforces a strict 20-message limit with warning message.
- **Interactive Whiteboard**: Detects and extracts `whiteboard_dsl` blocks from conversation, provides page-by-page whiteboard pagination, displays a clean placeholder empty state, and handles rendering compiler errors cleanly without affecting the chat thread.
- **Header Controls**: "Clear Conversation" calling DELETE, and a dynamic "Back" button navigating to the correct referrer (`/practice` or `/exams/:examId`).

### Verification & Test Results
- Created a comprehensive test suite in [CoachingPage.test.tsx](file:///Users/rlan/projects/worktrees/issue-109-coaching-page/frontend/src/pages/CoachingPage.test.tsx) covering all 10 component requirements.
- All 10 tests execute and pass successfully.