### PR TITLE
feat(observability): add structured logging and task count utility query (#111)

### DIFF
--- a/backend/app/domain/coaching/service.py
+++ b/backend/app/domain/coaching/service.py
@@ -42,6 +42,7 @@ class CoachingService:
         })
 
     async def send_message(self, problem_id: str, user_id: str, message: str) -> CoachingConversation:
+        start_time = datetime.now(UTC)
         # 1. Enforce exam safety
         active_exams = await self.db["exams"].count_documents({
             "userId": ObjectId(user_id) if isinstance(user_id, str) and len(user_id) == 24 else user_id,
@@ -158,4 +159,16 @@ class CoachingService:
         result = await self.get_conversation(problem_id, user_id)
         if result is None:
             raise CoachingError("Failed to save conversation.", code="INTERNAL_ERROR", status_code=500)
+            
+        end_time = datetime.now(UTC)
+        response_time_ms = (end_time - start_time).total_seconds() * 1000
+        
+        from app.observability import log_coaching_event
+        log_coaching_event(
+            event="request",
+            conversation_id=result.id,
+            message_count=len(result.messages),
+            response_time_ms=response_time_ms
+        )
+        
         return result

--- a/backend/app/infrastructure/worker/solution_worker.py
+++ b/backend/app/infrastructure/worker/solution_worker.py
@@ -18,6 +18,7 @@ from app.presentation.helpers import load_source_image_base64
 from app.presentation.solution_generation import _safe_get_collection
 
 logger = logging.getLogger(__name__)
+from app.observability import log_solution_generation_event
 
 
 def _utc_now() -> datetime:
@@ -35,6 +36,7 @@ async def process_task(
 ) -> None:
     problem_id = task["problem_id"]
     user_id = task["user_id"]
+    log_solution_generation_event("started", problem_id)
     
     problem = await problems_col.find_one({"_id": ObjectId(problem_id)})
     if not problem:
@@ -51,6 +53,7 @@ async def process_task(
                 }
             }
         )
+        log_solution_generation_event("failed", problem_id, failure_reason="Problem not found")
         return
         
     try:
@@ -92,6 +95,7 @@ async def process_task(
                 }
             }
         )
+        log_solution_generation_event("succeeded", problem_id)
         
     except LLMClientError as exc:
         retry_count = int(task.get("retry_count", 0)) + 1
@@ -110,6 +114,7 @@ async def process_task(
                     }
                 }
             )
+            log_solution_generation_event("failed", problem_id, failure_reason=str(exc))
         else:
             # Exponential backoff: 30s, 60s, 120s
             now = _utc_now()
@@ -125,6 +130,7 @@ async def process_task(
                     }
                 }
             )
+            log_solution_generation_event("retry", problem_id, retry_count=retry_count)
     except Exception as exc:
         now = _utc_now()
         logger.exception(f"Unexpected error processing task {task['_id']}")
@@ -139,6 +145,7 @@ async def process_task(
                 }
             }
         )
+        log_solution_generation_event("failed", problem_id, failure_reason=str(exc))
 
 async def run_solution_worker(database: Any, stop_event: asyncio.Event | None = None) -> None:
     settings = get_settings()

--- a/backend/app/observability.py
+++ b/backend/app/observability.py
@@ -82,3 +82,45 @@ def log_teacher_password_event(event: str, **fields: Any) -> None:
         f"teacher_password:{event}",
         extra={"teacher_password_event": event, **fields},
     )
+
+
+def log_solution_generation_event(event: str, problem_id: str, **fields: Any) -> None:
+    get_logger("learnloop.solution_generation").info(
+        f"solution_generation:{event}",
+        extra={"solution_generation_event": event, "problem_id": problem_id, **fields},
+    )
+
+
+def log_coaching_event(
+    event: str,
+    conversation_id: str,
+    message_count: int,
+    response_time_ms: float,
+    **fields: Any,
+) -> None:
+    get_logger("learnloop.coaching").info(
+        f"coaching:{event}",
+        extra={
+            "coaching_event": event,
+            "conversation_id": conversation_id,
+            "message_count": message_count,
+            "response_time_ms": response_time_ms,
+            **fields,
+        },
+    )
+
+
+async def get_solution_task_counts(database: Any) -> dict[str, int]:
+    from app.infrastructure.storage.mongo import SOLUTION_GENERATION_TASKS_COLLECTION
+
+    collection = database[SOLUTION_GENERATION_TASKS_COLLECTION]
+    pipeline = [{"$group": {"_id": "$status", "count": {"$sum": 1}}}]
+    cursor = collection.aggregate(pipeline)
+    counts = {"pending": 0, "generating": 0, "ready": 0, "failed": 0}
+    async for doc in cursor:
+        status = doc["_id"]
+        if status in counts:
+            counts[status] = doc["count"]
+        elif isinstance(status, str) and status.lower() in counts:
+            counts[status.lower()] = doc["count"]
+    return counts

--- a/backend/app/presentation/solution_generation.py
+++ b/backend/app/presentation/solution_generation.py
@@ -12,6 +12,7 @@ from app.infrastructure.storage.mongo import (
     Document,
     SOLUTION_GENERATION_TASKS_COLLECTION,
 )
+from app.observability import log_solution_generation_event
 
 SOLUTION_BACKFILL_BATCH_SIZE = 100
 
@@ -77,6 +78,7 @@ async def enqueue_solution_generation_task_for_problem(
             now=current_time,
         )
     )
+    log_solution_generation_event("enqueued", problem_id)
     return True
 
 
@@ -114,6 +116,9 @@ async def backfill_solution_generation_tasks(
         )
 
     for start in range(0, len(missing_documents), max(batch_size, 1)):
-        await tasks.insert_many(missing_documents[start : start + max(batch_size, 1)], ordered=False)
+        batch = missing_documents[start : start + max(batch_size, 1)]
+        await tasks.insert_many(batch, ordered=False)
+        for doc in batch:
+            log_solution_generation_event("enqueued", doc["problem_id"])
 
     return len(missing_documents)

--- a/backend/tests/domain/test_observability.py
+++ b/backend/tests/domain/test_observability.py
@@ -1,0 +1,249 @@
+import logging
+from datetime import datetime, UTC
+import pytest
+from bson import ObjectId
+
+from app.domain.models import SolutionGenerationStatus
+from app.observability import (
+    log_solution_generation_event,
+    log_coaching_event,
+    get_solution_task_counts,
+)
+
+
+def test_log_solution_generation_event(caplog):
+    with caplog.at_level(logging.INFO):
+        log_solution_generation_event("enqueued", "prob-123", extra_field="test")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.name == "learnloop.solution_generation"
+    assert record.levelname == "INFO"
+    assert record.message == "solution_generation:enqueued"
+    assert getattr(record, "solution_generation_event") == "enqueued"
+    assert getattr(record, "problem_id") == "prob-123"
+    assert getattr(record, "extra_field") == "test"
+
+
+def test_log_coaching_event(caplog):
+    with caplog.at_level(logging.INFO):
+        log_coaching_event("request", "conv-456", 2, 120.5, extra_field="test")
+
+    assert len(caplog.records) == 1
+    record = caplog.records[0]
+    assert record.name == "learnloop.coaching"
+    assert record.levelname == "INFO"
+    assert record.message == "coaching:request"
+    assert getattr(record, "coaching_event") == "request"
+    assert getattr(record, "conversation_id") == "conv-456"
+    assert getattr(record, "message_count") == 2
+    assert getattr(record, "response_time_ms") == 120.5
+    assert getattr(record, "extra_field") == "test"
+
+
+@pytest.mark.asyncio
+async def test_get_solution_task_counts():
+    class FakeCursor:
+        def __init__(self, items):
+            self.items = items
+            self.index = 0
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self.index >= len(self.items):
+                raise StopAsyncIteration
+            item = self.items[self.index]
+            self.index += 1
+            return item
+
+    class FakeTasksCollection:
+        def __init__(self, aggregate_result):
+            self.result = aggregate_result
+            self.calls = []
+
+        def aggregate(self, pipeline):
+            self.calls.append(pipeline)
+            return FakeCursor(self.result)
+
+    class FakeDb:
+        def __init__(self, collection):
+            self.collection = collection
+
+        def __getitem__(self, name):
+            return self.collection
+
+    aggregate_data = [
+        {"_id": "pending", "count": 5},
+        {"_id": "generating", "count": 2},
+        {"_id": "ready", "count": 10},
+        {"_id": "failed", "count": 1},
+    ]
+
+    col = FakeTasksCollection(aggregate_data)
+    db = FakeDb(col)
+
+    counts = await get_solution_task_counts(db)
+    assert counts == {
+        "pending": 5,
+        "generating": 2,
+        "ready": 10,
+        "failed": 1
+    }
+    assert len(col.calls) == 1
+    assert col.calls[0] == [{"$group": {"_id": "$status", "count": {"$sum": 1}}}]
+
+    # Test case-insensitivity and status casing normalization
+    aggregate_data_caps = [
+        {"_id": "PENDING", "count": 3},
+        {"_id": "Generating", "count": 1},
+        {"_id": "ready", "count": 4},
+        {"_id": "FAILED", "count": 2},
+    ]
+    col = FakeTasksCollection(aggregate_data_caps)
+    db = FakeDb(col)
+
+    counts = await get_solution_task_counts(db)
+    assert counts == {
+        "pending": 3,
+        "generating": 1,
+        "ready": 4,
+        "failed": 2
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_message_logs_observability(caplog):
+    from app.domain.coaching.service import CoachingService
+    from tests.domain.test_coaching_service import FakeDatabase, FakeCoachingLLMClient
+
+    db = FakeDatabase()
+    client = FakeCoachingLLMClient()
+    service = CoachingService(db, client)
+
+    prob_id = ObjectId()
+    user_id = ObjectId()
+
+    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+
+    with caplog.at_level(logging.INFO):
+        conv = await service.send_message(str(prob_id), str(user_id), "help me")
+
+    coaching_logs = [r for r in caplog.records if r.name == "learnloop.coaching"]
+    assert len(coaching_logs) == 1
+    record = coaching_logs[0]
+    assert record.message == "coaching:request"
+    assert getattr(record, "coaching_event") == "request"
+    assert getattr(record, "conversation_id") == conv.id
+    assert getattr(record, "message_count") == len(conv.messages)
+    assert isinstance(getattr(record, "response_time_ms"), float)
+    assert getattr(record, "response_time_ms") >= 0
+
+
+@pytest.mark.asyncio
+async def test_enqueue_solution_logs_observability(caplog):
+    from app.presentation.solution_generation import enqueue_solution_generation_task_for_problem
+
+    class FakeCol:
+        def __init__(self):
+            self.docs = []
+
+        async def find_one(self, query):
+            return None
+
+        async def insert_one(self, doc):
+            self.docs.append(doc)
+
+    class FakeDb:
+        def __init__(self):
+            self.cols = {
+                "solution_generation_tasks": FakeCol(),
+                "canonical_solutions": FakeCol(),
+            }
+        def __getitem__(self, name):
+            return self.cols[name]
+
+    db = FakeDb()
+    problem = {"_id": ObjectId(), "userId": ObjectId()}
+
+    with caplog.at_level(logging.INFO):
+        success = await enqueue_solution_generation_task_for_problem(db, problem)
+
+    assert success is True
+    sg_logs = [r for r in caplog.records if r.name == "learnloop.solution_generation"]
+    assert len(sg_logs) == 1
+    record = sg_logs[0]
+    assert record.message == "solution_generation:enqueued"
+    assert getattr(record, "solution_generation_event") == "enqueued"
+    assert getattr(record, "problem_id") == str(problem["_id"])
+
+
+@pytest.mark.asyncio
+async def test_worker_process_task_logs_observability(caplog):
+    from app.infrastructure.worker.solution_worker import process_task
+
+    class FakeSolutionsCol:
+        def __init__(self):
+            self.docs = []
+        async def insert_one(self, doc):
+            self.docs.append(doc)
+
+    class FakeTasksCol:
+        def __init__(self):
+            self.updates = []
+        async def update_one(self, query, update):
+            self.updates.append((query, update))
+
+    class FakeProblemsCol:
+        def __init__(self, prob):
+            self.prob = prob
+        async def find_one(self, query):
+            return self.prob
+
+    class FakeLLMResult:
+        def __init__(self):
+            self.steps_markdown = "steps"
+            self.final_answer = "ans"
+            self.math_level_classification = "level"
+
+    class FakeLLMClient:
+        async def generate_solution(self, req):
+            return FakeLLMResult()
+
+    class FakeStorage:
+        pass
+
+    prob_id = ObjectId()
+    user_id = ObjectId()
+    task = {"_id": ObjectId(), "problem_id": str(prob_id), "user_id": str(user_id)}
+    prob = {"_id": prob_id, "text": "text", "correctAnswer": {"display": "ans"}}
+
+    tasks_col = FakeTasksCol()
+    solutions_col = FakeSolutionsCol()
+    problems_col = FakeProblemsCol(prob)
+    client = FakeLLMClient()
+    storage = FakeStorage()
+
+    import app.infrastructure.worker.solution_worker as sw
+    original_load = sw.load_source_image_base64
+    sw.load_source_image_base64 = lambda img, store: None
+
+    try:
+        with caplog.at_level(logging.INFO):
+            await process_task(task, client, storage, tasks_col, solutions_col, problems_col, max_retries=3)
+    finally:
+        sw.load_source_image_base64 = original_load
+
+    sg_logs = [r for r in caplog.records if r.name == "learnloop.solution_generation"]
+    assert len(sg_logs) >= 2
+
+    started_log = sg_logs[0]
+    assert started_log.message == "solution_generation:started"
+    assert getattr(started_log, "solution_generation_event") == "started"
+    assert getattr(started_log, "problem_id") == str(prob_id)
+
+    succeeded_log = sg_logs[1]
+    assert succeeded_log.message == "solution_generation:succeeded"
+    assert getattr(succeeded_log, "solution_generation_event") == "succeeded"
+    assert getattr(succeeded_log, "problem_id") == str(prob_id)


### PR DESCRIPTION
Resolves #111

### Summary
Adds comprehensive structured logging and operational visibility for the solution generation lifecycle (worker & presenter) and coaching request events (domain service).

### Implementation Notes
- **Structured Logging Core**: Added `log_solution_generation_event` and `log_coaching_event` helper functions in `backend/app/observability.py` to support structured JSON metadata log payloads.
- **Presenter Logging**: Captures task `"enqueued"` events during single-problem generation and bulk-backfill task creation steps.
- **Worker Logging**: Tracks task `"started"`, `"succeeded"`, `"retry"`, and `"failed"` lifecycle events with `problem_id` and extra execution details (like `failure_reason` and `retry_count`).
- **Coaching Request Logging**: Measures request execution duration and logs a `"request"` event before returning, populated with `conversation_id`, `message_count`, and `response_time_ms`.
- **Operational Query**: Implemented `get_solution_task_counts` which aggregates tasks by status (`pending`, `generating`, `ready`, `failed`), normalizing casing properly.

### Verification & Test Results
- Created a comprehensive test suite in [test_observability.py](file:///Users/rlan/projects/worktrees/issue-111-observability-logging/backend/tests/domain/test_observability.py) verifying logging record capturing, metadata accuracy, and status aggregation normalization.
- Verified that all 217 tests in the backend test suite executed and passed successfully without any regressions.