### PR TITLE
fix: handle 204 No Content in API client (coaching E2E AC-11)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -29,6 +29,9 @@ async function handleResponse<T>(response: Response): Promise<T> {
     (error as Error & { code?: string; status?: number }).status = response.status;
     throw error;
   }
+  if (response.status === 204) {
+    return undefined as unknown as T;
+  }
   return response.json() as Promise<T>;
 }
 


### PR DESCRIPTION
## Problem

AC-11 (Clear conversation) was consistently failing with:

> `Locator: getByTestId('chat-log').getByText('No messages yet')`
> `Expected: visible`
> `Error: element(s) not found`

## Root Cause

The `DELETE /coaching/{problem_id}/conversation` endpoint returns HTTP **204 No Content** (no body). The generic `handleResponse<T>` function in `api/client.ts` unconditionally called `response.json()` on every successful response, which throws:

> `Failed to execute 'json' on 'Response': Unexpected end of JSON input`

This caused `clearConversationMutation` to invoke `onError` instead of `onSuccess`. Since `setQueryData` was only called in `onSuccess`, the React Query cache was never updated and the chat log stayed populated.

## Fix

Added a check in `handleResponse` to return `undefined` (for `void`-typed callers) when the response status is 204, skipping the JSON parse.

```ts
if (response.status === 204) {
  return undefined as unknown as T;
}
```

## Verification

All 6 E2E tests now pass consistently (verified 2 consecutive runs):
- ✅ AC-03, AC-06, AC-15
- ✅ AC-07, AC-08, AC-09
- ✅ AC-10
- ✅ **AC-11** (was failing)
- ✅ AC-05
- ✅ AC-14

Closes #110