### PR TITLE
fix: use correct exam state value in coaching guard

### DIFF
--- a/backend/app/domain/coaching/service.py
+++ b/backend/app/domain/coaching/service.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from bson import ObjectId
 
-from app.domain.models import CoachingConversation, CoachingMessage, CoachingRole
+from app.domain.models import CoachingConversation, CoachingMessage, CoachingRole, ExamState
 from app.infrastructure.llm.client import CoachingLLMClient, CoachingLLMRequest, LLMClientError
 from app.infrastructure.storage.mongo import (
     CANONICAL_SOLUTIONS_COLLECTION,
@@ -46,7 +46,7 @@ class CoachingService:
         # 1. Enforce exam safety
         active_exams = await self.db["exams"].count_documents({
             "userId": ObjectId(user_id) if isinstance(user_id, str) and len(user_id) == 24 else user_id,
-            "state": "in_progress",
+            "state": ExamState.IN_PROGRESS.value,
             "items.problemId": ObjectId(problem_id)
         })
         if active_exams > 0:

--- a/backend/tests/api/test_coaching.py
+++ b/backend/tests/api/test_coaching.py
@@ -190,7 +190,7 @@ async def test_send_message_active_exam_blocked(client: AsyncClient, coaching_ap
     
     db["exams"].seed({
         "userId": user_id,
-        "state": "in_progress",
+        "state": "in-progress",
         "items": [{"problemId": ObjectId(setup_problem)}]
     })
     

--- a/backend/tests/domain/test_coaching_service.py
+++ b/backend/tests/domain/test_coaching_service.py
@@ -122,7 +122,7 @@ async def test_send_message_active_exam_blocked():
     
     db.cols["exams"].seed({
         "userId": user_id,
-        "state": "in_progress",
+        "state": "in-progress",
         "items": [{"problemId": prob_id}]
     })
     


### PR DESCRIPTION
## Summary

Fixes the active-exam backend guard in the coaching service by replacing the hardcoded `"in_progress"` state string with `ExamState.IN_PROGRESS.value` which correctly resolves to `"in-progress"`.

## Implementation notes

- Import `ExamState` in `backend/app/domain/coaching/service.py`
- Replace `"state": "in_progress"` with `"state": ExamState.IN_PROGRESS.value`
- Update test fixtures in `test_coaching.py` and `test_coaching_service.py` to use the correct `"in-progress"` value

## Root cause

The `ExamState` enum defines `IN_PROGRESS = "in-progress"` (hyphen), but the coaching guard was checking for `"in_progress"` (underscore), causing the query to never match active exams.

## Test results

Backend tests have a pre-existing import error unrelated to this fix (FastAPI 204 status code assertion in `coaching.py` line 85). The fix itself is straightforward and testable once that import issue is resolved.

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)