### PR TITLE
Update frontend SettingsPage for explicit AI profile settings response

### DIFF
--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -32,7 +32,27 @@ const mockSettings = {
   app: { env: "development", host: "0.0.0.0", port: 8000, log_level: "INFO" },
   database: { name: "learnloop" },
   storage: { endpoint: "http://localhost:9000", bucket: "media", region: "us-east-1", force_path_style: true },
-  vlm: { endpoint: "https://example.com", model: "test", timeout_seconds: 120, preview_extracting_window_seconds: 150 },
+  ingestion_vlm: {
+    endpoint: "https://ingestion.example.com",
+    model: "ingestion-model",
+    timeout_seconds: 120,
+    preview_extracting_window_seconds: 150,
+  },
+  grading_vlm: {
+    endpoint: "https://grading.example.com",
+    model: "grading-model",
+    timeout_seconds: 60,
+  },
+  solution_llm: {
+    endpoint: "https://solution.example.com",
+    model: "solution-model",
+    timeout_seconds: 90,
+  },
+  coaching_llm: {
+    endpoint: "https://coaching.example.com",
+    model: "coaching-model",
+    timeout_seconds: 45,
+  },
   session: { cookie_name: "ll_session", secure: false, samesite: "lax" },
   practice: { cooldown_days: 7, last_wrong_weight: 1.0, failure_rate_weight: 1.0, recency_weight: 1.0 },
 };
@@ -73,10 +93,16 @@ describe("SettingsPage", () => {
     expect(await screen.findByText("http://localhost:9000")).toBeInTheDocument();
   });
 
-  it("renders VLM settings section", async () => {
+  it("renders explicit AI settings sections", async () => {
     renderWithProviders();
-    expect(await screen.findByText("Vision Language Model")).toBeInTheDocument();
-    expect(await screen.findByText("test")).toBeInTheDocument();
+    expect(await screen.findByText("Ingestion VLM")).toBeInTheDocument();
+    expect(await screen.findByText("Grading VLM")).toBeInTheDocument();
+    expect(await screen.findByText("Solution LLM")).toBeInTheDocument();
+    expect(await screen.findByText("Coaching LLM")).toBeInTheDocument();
+    expect(await screen.findByText("ingestion-model")).toBeInTheDocument();
+    expect(await screen.findByText("grading-model")).toBeInTheDocument();
+    expect(await screen.findByText("solution-model")).toBeInTheDocument();
+    expect(await screen.findByText("coaching-model")).toBeInTheDocument();
   });
 
   it("renders session settings section", async () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -20,11 +20,26 @@ interface SettingsResponse {
     region: string;
     force_path_style: boolean;
   };
-  vlm: {
+  ingestion_vlm: {
     endpoint: string;
     model: string;
     timeout_seconds: number;
     preview_extracting_window_seconds: number;
+  };
+  grading_vlm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
+  };
+  solution_llm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
+  };
+  coaching_llm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
   };
   session: {
     cookie_name: string;
@@ -342,16 +357,43 @@ export function SettingsPage() {
         />
       </SettingSection>
 
-      <SettingSection title="Vision Language Model">
-        <SettingRow label="Endpoint" value={data.vlm.endpoint} />
-        <SettingRow label="Model" value={data.vlm.model} />
+      <SettingSection title="Ingestion VLM">
+        <SettingRow label="Endpoint" value={data.ingestion_vlm.endpoint} />
+        <SettingRow label="Model" value={data.ingestion_vlm.model} />
         <SettingRow
           label="Timeout (seconds)"
-          value={data.vlm.timeout_seconds}
+          value={data.ingestion_vlm.timeout_seconds}
         />
         <SettingRow
           label="Preview Window (seconds)"
-          value={data.vlm.preview_extracting_window_seconds}
+          value={data.ingestion_vlm.preview_extracting_window_seconds}
+        />
+      </SettingSection>
+
+      <SettingSection title="Grading VLM">
+        <SettingRow label="Endpoint" value={data.grading_vlm.endpoint} />
+        <SettingRow label="Model" value={data.grading_vlm.model} />
+        <SettingRow
+          label="Timeout (seconds)"
+          value={data.grading_vlm.timeout_seconds}
+        />
+      </SettingSection>
+
+      <SettingSection title="Solution LLM">
+        <SettingRow label="Endpoint" value={data.solution_llm.endpoint} />
+        <SettingRow label="Model" value={data.solution_llm.model} />
+        <SettingRow
+          label="Timeout (seconds)"
+          value={data.solution_llm.timeout_seconds}
+        />
+      </SettingSection>
+
+      <SettingSection title="Coaching LLM">
+        <SettingRow label="Endpoint" value={data.coaching_llm.endpoint} />
+        <SettingRow label="Model" value={data.coaching_llm.model} />
+        <SettingRow
+          label="Timeout (seconds)"
+          value={data.coaching_llm.timeout_seconds}
         />
       </SettingSection>
 


### PR DESCRIPTION
Closes #136

## Summary
- update `SettingsPage` to read the explicit AI capability profile blocks introduced by the backend settings contract
- replace the single VLM section with separate ingestion, grading, solution, and coaching sections
- update the settings page test fixture and assertions to cover the new response shape

## Implementation Notes
- `ingestion_vlm` remains the only section that renders `preview_extracting_window_seconds`
- the frontend response contract no longer depends on `data.vlm`
- this PR is intended to align with the backend contract in #134

## Test Results
- `cd backend && uv run pytest` ✅ (216 passed, 1 skipped)
- `cd frontend && npm test -- --run` ✅ (18 passed, 186 passed)
- `cd frontend && npm run test:ui` ❌ fails in existing stale Playwright harness scenarios covered by #135, including auth redirects to login and stale seeding helpers in `practice.spec.ts`, `coaching.spec.ts`, and `teacher-password.spec.ts`
