### PR TITLE
fix: increase nginx proxy timeouts to prevent 504 on long LLM requests

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,6 +18,11 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
+    
+    # Align with backend LLM timeouts (default 60s, production up to 300s)
+    proxy_connect_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
   }
 
   location / {


### PR DESCRIPTION
## Summary

Fixed 504 Gateway Timeout errors when AI Coach generates drawings/illustrations by increasing nginx proxy timeouts to match backend LLM timeout configuration.

## Problem

When users requested drawings/illustrations from the AI Coach, the request would fail with a 504 Gateway Timeout after ~60 seconds. This happened because:

1. **nginx** uses default ~60s  (no explicit configuration)
2. **Backend** has configurable LLM timeouts (default 60s for coaching, but up to 300s in production)
3. Generating  (JSXGraph code) takes longer than plain text, pushing response time over nginx's timeout

The 504 status confirmed nginx was the bottleneck (not the backend, which returns 503 on its own timeouts).

## Solution

Added explicit timeout directives to :



This aligns nginx with the backend's maximum configurable timeout (300s), ensuring long-running LLM requests (like illustration generation) complete successfully.

## Changes

- ****: Added , , and  directives set to 300s

## Testing

After deploying this change:
1. Navigate to a coaching page
2. Click Draw or request an illustration
3. Verify the request completes successfully (even if LLM takes >60s)
4. Monitor logs: learnloop-frontend  | 192.168.65.1 - - [27/May/2026:06:33:51 +0000] "POST /api/v1/coaching/6a15b4efca4ca0b00100b254/messages HTTP/1.1" 504 569 "http://localhost:8080/coaching/6a15b4efca4ca0b00100b254" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36" "-"
learnloop-frontend  | 192.168.65.1 - - [27/May/2026:06:35:13 +0000] "POST /api/v1/coaching/6a15b4efca4ca0b00100b254/messages HTTP/1.1" 504 569 "http://localhost:8080/coaching/6a15b4efca4ca0b00100b254" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36" "-" should show no new 504 errors

## Related

This fix also benefits other long-running endpoints (ingestion VLM, solution generation) that have 300s backend timeouts but were previously limited by nginx's 60s default.

Fixes #141