### PR TITLE
fix: add defense-in-depth DSL validation for whiteboard_dsl path

### DIFF
--- a/backend/app/infrastructure/llm/client.py
+++ b/backend/app/infrastructure/llm/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Literal
 
 import httpx
@@ -365,6 +366,30 @@ class SolutionLLMClient(_BaseLLMClient):
             ) from exc
 
 
+def _sanitize_whiteboard_dsl(dsl: str | None) -> str | None:
+    if dsl is None:
+        return None
+
+    stripped = dsl.strip()
+    if not stripped:
+        return None
+
+    # Remove markdown code fences: ```js ... ``` or ``` ... ```
+    fence_match = re.match(r"^```(?:\w*)\n?(.*?)\n?```$", stripped, re.DOTALL)
+    if fence_match:
+        stripped = fence_match.group(1).strip()
+
+    # Strip initBoard calls — board already exists in the sandbox
+    stripped = re.sub(r"var\s+\w+\s*=\s*JXG\.JSXGraph\.initBoard\([^)]*\)\s*;?", "", stripped)
+    stripped = stripped.strip()
+
+    # Basic validation: must contain board.create or be empty
+    if stripped and "board.create" not in stripped:
+        return None
+
+    return stripped if stripped else None
+
+
 class CoachingLLMClient(_BaseLLMClient):
     def __init__(self, settings: Settings | None = None, http_client: httpx.AsyncClient | None = None) -> None:
         self._settings = settings or get_settings()
@@ -397,7 +422,7 @@ class CoachingLLMClient(_BaseLLMClient):
             prompt_version=COACHING_PROMPT_VERSION,
             model=self._model,
             text=parsed.text,
-            whiteboard_dsl=parsed.whiteboard_dsl,
+            whiteboard_dsl=_sanitize_whiteboard_dsl(parsed.whiteboard_dsl),
             raw_provider_response=raw_provider_response,
         )
 

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -30,7 +30,7 @@ export interface GraphSandboxProps {
 }
 
 /**
- * Validates DSL code against security denylist.
+ * Validates DSL code against security denylist and JavaScript syntax.
  * Returns null if valid, error message if invalid.
  */
 function validateDsl(dsl: string): string | null {
@@ -39,6 +39,15 @@ function validateDsl(dsl: string): string | null {
       return `DSL contains forbidden pattern: ${pattern.source}`;
     }
   }
+
+  try {
+    new Function("board", dsl);
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      return `DSL syntax error: ${e.message}`;
+    }
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Added server-side `_sanitize_whiteboard_dsl()` that strips markdown code fences and `initBoard` calls from LLM-generated DSL before storage
- Added client-side JavaScript syntax pre-validation in `validateDsl()` using `new Function()` try/catch to catch `SyntaxError` before reaching the iframe sandbox

## Changes
- **`backend/app/infrastructure/llm/client.py`**: New `_sanitize_whiteboard_dsl()` function with fence stripping, initBoard removal, and board.create presence check; applied in `CoachingLLMClient.send_message()`
- **`frontend/src/components/GraphSandbox.tsx`**: Extended `validateDsl()` with syntax check via `new Function('board', dsl)` to provide meaningful error messages instead of opaque "Invalid or unexpected token"

## Test results
- Backend: 218 passed, 1 skipped, 0 failures
- Frontend: 186 passed (18 test files), 0 failures (including 6 GraphSandbox tests)

## Linked issue
- Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)