### PR TITLE
Hide discarded exams by default in exam history

### DIFF
--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -105,6 +105,7 @@ export function ExamsPage() {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [showActiveExamPrompt, setShowActiveExamPrompt] = useState(false);
+  const [showDiscarded, setShowDiscarded] = useState(false);
   const pageSize = 10;
 
   const { data, isLoading, error } = useQuery<ExamHistoryResponse>({
@@ -132,6 +133,9 @@ export function ExamsPage() {
   };
 
   const exams = data?.items ?? [];
+  const visibleExams = showDiscarded
+    ? exams
+    : exams.filter((exam) => exam.state !== "discarded");
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -233,10 +237,58 @@ export function ExamsPage() {
         >
           No exams yet
         </div>
+      ) : visibleExams.length === 0 ? (
+        <div
+          style={{
+            padding: "2rem",
+            textAlign: "center",
+            backgroundColor: "#f9fafb",
+            border: "1px solid #e5e7eb",
+            borderRadius: "0.5rem",
+          }}
+        >
+          <p style={{ margin: "0 0 0.75rem" }}>No visible exams on this page</p>
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+              color: "#2563eb",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={showDiscarded}
+              onChange={() => setShowDiscarded((prev) => !prev)}
+            />
+            Show discarded exams
+          </label>
+        </div>
       ) : (
         <>
+          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.75rem" }}>
+            <label
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                cursor: "pointer",
+                fontSize: "0.875rem",
+                color: "#6b7280",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={showDiscarded}
+                onChange={() => setShowDiscarded((prev) => !prev)}
+              />
+              Show discarded
+            </label>
+          </div>
           <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-            {exams.map((exam) => (
+            {visibleExams.map((exam) => (
               <ExamHistoryCard
                 key={exam.id}
                 exam={exam}


### PR DESCRIPTION
## Summary

Frontend-only filter to hide discarded exams by default in the exam history page, with a toggle to show them.


## Changes

- Added `showDiscarded` local state (defaults to `false`) in `ExamsPage`
- Derive `visibleExams` by filtering out `state === "discarded"` when toggle is off
- Added a "Show discarded" checkbox toggle above the exam list
- Added a filtered-empty state: "No visible exams on this page" with inline toggle link when the current page only contains discarded exams
- No backend changes — pagination still uses backend `total`

## Acceptance criteria met

- [x] By default, discarded exams are not shown in the exam history list
- [x] A visible toggle lets the user show discarded exams
- [x] No backend files or API behavior are changed
- [x] Pagination remains unchanged and continues to use the backend `total`
- [x] The empty state is understandable when all exams on the current page are hidden by the filter

## Test results

No existing test infrastructure for ExamsPage was found. The worktree does not have `node_modules` installed, so `tsc` could not be run locally. The changes are structurally identical to existing patterns in the file (React state + conditional rendering).

## Known tradeoff

this is a frontend-only filter. Pages may show fewer than `pageSize` visible exams when discarded exams are hidden, because pagination is still controlled by the backend.