### PR TITLE
Fix Practice page available problem count

### DIFF
--- a/backend/app/domain/practice_selection.py
+++ b/backend/app/domain/practice_selection.py
@@ -21,15 +21,11 @@ class PracticeSelectionResult:
     status: str  # "ok", "no_eligible", "no_problems"
 
 
-def select_practice_problem(
+def get_eligible_practice_problems(
     problems: List[Problem],
     config: PracticeSelectionConfig,
     now: datetime,
-    rng: random.Random | None = None
-) -> PracticeSelectionResult:
-    if not problems:
-        return PracticeSelectionResult(None, "no_problems")
-
+) -> list[Problem]:
     eligible = []
     for p in problems:
         if p.isDeleted:
@@ -42,10 +38,26 @@ def select_practice_problem(
             if last_tested > cutoff:
                 continue
         eligible.append(p)
+    return eligible
+
+
+def _has_practiceable_answer(problems: List[Problem]) -> list[Problem]:
+    return [p for p in problems if not p.isDeleted and p.correctAnswer and p.correctAnswer.normalizedText]
+
+
+def select_practice_problem(
+    problems: List[Problem],
+    config: PracticeSelectionConfig,
+    now: datetime,
+    rng: random.Random | None = None
+) -> PracticeSelectionResult:
+    if not problems:
+        return PracticeSelectionResult(None, "no_problems")
+
+    eligible = get_eligible_practice_problems(problems, config, now)
 
     if not eligible:
-        all_eligible = [p for p in problems if not p.isDeleted and p.correctAnswer and p.correctAnswer.normalizedText]
-        if all_eligible:
+        if _has_practiceable_answer(problems):
             return PracticeSelectionResult(None, "no_eligible")
         return PracticeSelectionResult(None, "no_problems")
 

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -12,6 +12,7 @@ from app.domain.models import GradingStatus, GradingMethod, ProblemType
 from app.domain.normalization import compare_answers, normalize_answer
 from app.domain.practice_selection import (
     PracticeSelectionConfig,
+    get_eligible_practice_problems,
     select_practice_problem,
 )
 from app.infrastructure.config.settings import Settings, get_settings
@@ -91,14 +92,18 @@ class PracticeStatsResponse(BaseModel):
 async def get_practice_stats(
     database: DatabaseDependency,
     current_user: CurrentUserDependency,
+    settings: SettingsDependency,
 ) -> PracticeStatsResponse:
-    """Return count of problems eligible for practice (has correctAnswer, not deleted)."""
-    count = await database["problems"].count_documents({
-        "userId": current_user["_id"],
-        "isDeleted": False,
-        "correctAnswer.display": {"$exists": True, "$ne": ""},
-    })
-    return PracticeStatsResponse(practiceableCount=count)
+    problem_documents = await database["problems"].find(
+        {"userId": current_user["_id"], "isDeleted": False}
+    ).to_list(length=None)
+
+    problem_models = [problem_document_to_model(p) for p in problem_documents]
+    config = PracticeSelectionConfig(cooldown_days=settings.practice_cooldown_days)
+    now = datetime.now(UTC)
+    eligible = get_eligible_practice_problems(problem_models, config, now)
+
+    return PracticeStatsResponse(practiceableCount=len(eligible))
 
 
 @router.post("/next", response_model=PracticeNextResponse)

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from copy import deepcopy
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -186,3 +186,24 @@ async def test_stats_returns_practiceable_count(
     assert response.status_code == 200
     data = response.json()
     assert data["practiceableCount"] == 3
+
+
+@pytest.mark.asyncio
+async def test_stats_excludes_cooldown_problems(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    now = datetime.now(UTC)
+
+    recent = make_problem(user_id, text="Recent", correct_answer_display="1", last_tested_at=now)
+    old = make_problem(user_id, text="Old", correct_answer_display="2", last_tested_at=now - timedelta(days=10))
+    never = make_problem(user_id, text="Never", correct_answer_display="3")
+
+    database.seed("problems", [recent, old, never])
+
+    response = await client.get("/api/v1/practice/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["practiceableCount"] == 2

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -5,6 +5,7 @@ from app.domain.models import CorrectAnswer, Problem, Tracking
 from app.domain.practice_selection import (
     PracticeSelectionConfig,
     PracticeSelectionResult,
+    get_eligible_practice_problems,
     select_practice_problem,
 )
 
@@ -221,3 +222,55 @@ def test_empty_problem_list():
 
     assert result.status == "no_problems"
     assert result.selected_problem is None
+
+
+def test_get_eligible_excludes_cooldown():
+    now = datetime.now(UTC)
+    recent = now - timedelta(days=2)
+    old = now - timedelta(days=10)
+
+    problems = [
+        _make_problem("recent", last_tested_at=recent),
+        _make_problem("old", last_tested_at=old),
+        _make_problem("never", last_tested_at=None),
+    ]
+    config = PracticeSelectionConfig(cooldown_days=7)
+    eligible = get_eligible_practice_problems(problems, config, now)
+
+    ids = [p.id for p in eligible]
+    assert "old" in ids
+    assert "never" in ids
+    assert "recent" not in ids
+
+
+def test_get_eligible_excludes_deleted_and_no_answer():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("deleted", is_deleted=True),
+        _make_problem("no-answer", correct_answer=""),
+        _make_problem("valid"),
+    ]
+    config = PracticeSelectionConfig()
+    eligible = get_eligible_practice_problems(problems, config, now)
+
+    assert len(eligible) == 1
+    assert eligible[0].id == "valid"
+
+
+def test_get_eligible_empty():
+    now = datetime.now(UTC)
+    config = PracticeSelectionConfig()
+    eligible = get_eligible_practice_problems([], config, now)
+    assert eligible == []
+
+
+def test_get_eligible_all_in_cooldown():
+    now = datetime.now(UTC)
+    recent = now - timedelta(days=2)
+    problems = [
+        _make_problem("a", last_tested_at=recent),
+        _make_problem("b", last_tested_at=recent),
+    ]
+    config = PracticeSelectionConfig(cooldown_days=7)
+    eligible = get_eligible_practice_problems(problems, config, now)
+    assert eligible == []


### PR DESCRIPTION
## Summary

Fix `/practice/stats` to return the count of problems available for practice **now**, excluding problems inside the cooldown window. Previously it counted all problems with correct answers regardless of cooldown status, causing the displayed count to mismatch the actual selectable pool.

Closes #150

## Changes

- Extracted `get_eligible_practice_problems` helper from `select_practice_problem` in `practice_selection.py` — applies the same filters (not deleted, has correct answer, not in cooldown)
- Refactored `select_practice_problem` to call the shared helper instead of duplicating the filter logic
- Updated `get_practice_stats` to use the shared helper so the count and selection cannot drift
- `get_practice_stats` now requires `SettingsDependency` to read `practice_cooldown_days`

## Test results

```
27 passed in 0.39s
```

- All existing `test_practice_selection.py` domain tests pass (13 tests)
- All existing `test_practice.py` API tests pass (9 tests)
- New domain tests for `get_eligible_practice_problems` (4 tests)
- New API test `test_stats_excludes_cooldown_problems` verifying cooldown-aware count