### PR TITLE
Separate practice exposure from attempts for skip and cooldown

### DIFF
--- a/backend/app/domain/practice_selection.py
+++ b/backend/app/domain/practice_selection.py
@@ -76,8 +76,9 @@ def _compute_problem_weight(problem: Problem, config: PracticeSelectionConfig, n
         last_wrong_score = 2.0
 
     failure_score = 1.0
-    if problem.tracking.exposureCount > 0:
-        failure_rate = problem.tracking.failedCount / problem.tracking.exposureCount
+    attempt_count = problem.tracking.correctCount + problem.tracking.failedCount
+    if attempt_count > 0:
+        failure_rate = problem.tracking.failedCount / attempt_count
         failure_score = 1.0 + failure_rate
 
     recency_score = 1.0

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -145,7 +145,6 @@ async def get_next_practice_problem(
 
     tracking = selected_document.get("tracking", {})
     tracking["exposureCount"] = tracking.get("exposureCount", 0) + 1
-    tracking["lastTestedAt"] = now
 
     await database["problems"].update_one(
         {"_id": selected_document["_id"]},

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -72,7 +72,7 @@ async def test_exposure_count_incremented(
 
 
 @pytest.mark.asyncio
-async def test_last_tested_at_updated(
+async def test_last_tested_at_not_updated_by_next(
     practice_app: FastAPI,
     client: AsyncClient,
 ) -> None:
@@ -81,14 +81,27 @@ async def test_last_tested_at_updated(
     problem = make_problem(user_id)
     database.seed("problems", [problem])
 
-    before = datetime.now(UTC)
     await client.post("/api/v1/practice/next")
 
     updated_problem = await database["problems"].find_one({"_id": problem["_id"]})
-    last_tested = updated_problem["tracking"]["lastTestedAt"]
-    assert last_tested is not None
-    after = datetime.now(UTC)
-    assert before <= last_tested <= after
+    assert updated_problem["tracking"]["lastTestedAt"] is None
+
+
+@pytest.mark.asyncio
+async def test_skip_does_not_put_in_cooldown(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+
+    response1 = await client.post("/api/v1/practice/next")
+    assert response1.json()["status"] == "ok"
+
+    response2 = await client.post("/api/v1/practice/next")
+    assert response2.json()["status"] == "ok"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -17,8 +17,10 @@ def _make_problem(
     last_tested_at: datetime | None = None,
     last_attempt_correct: bool | None = None,
     exposure_count: int = 0,
+    correct_count: int | None = None,
     failed_count: int = 0,
 ) -> Problem:
+    cc = correct_count if correct_count is not None else max(0, exposure_count - failed_count)
     return Problem(
         id=pid,
         userId="user1",
@@ -32,7 +34,7 @@ def _make_problem(
         ),
         tracking=Tracking(
             exposureCount=exposure_count,
-            correctCount=exposure_count - failed_count if exposure_count >= failed_count else 0,
+            correctCount=cc,
             failedCount=failed_count,
             lastTestedAt=last_tested_at,
             lastAttemptCorrect=last_attempt_correct,
@@ -221,3 +223,21 @@ def test_empty_problem_list():
 
     assert result.status == "no_problems"
     assert result.selected_problem is None
+
+
+def test_failure_rate_uses_attempts_not_exposures():
+    now = datetime.now(UTC)
+    problems = [
+        _make_problem("many-exposures-no-attempts", exposure_count=100, correct_count=0, failed_count=0),
+        _make_problem("some-failed-attempts", exposure_count=5, correct_count=1, failed_count=4),
+    ]
+    config = PracticeSelectionConfig()
+    rng = random.Random(42)
+
+    failed_count = 0
+    for _ in range(100):
+        result = select_practice_problem(problems, config, now, rng=rng)
+        if result.selected_problem.id == "some-failed-attempts":
+            failed_count += 1
+
+    assert failed_count > 50


### PR DESCRIPTION
## Summary

Fix two bugs in the practice system related to skip/exposure semantics:

1. **Skip no longer causes cooldown**: `POST /practice/next` now increments `exposureCount` only, without updating `lastTestedAt`. Previously, merely viewing a problem put it into cooldown, so clicking Skip made the problem unavailable — even though the user never attempted it.

2. **Failure-rate weighting uses attempts**: The practice selection weight now computes failure rate as `failedCount / (correctCount + failedCount)` instead of `failedCount / exposureCount`. This prevents repeated skips from diluting the apparent failure rate.

Closes #151

## Changes

- `backend/app/presentation/practice.py`: Removed `tracking["lastTestedAt"] = now` from `get_next_practice_problem`. `exposureCount` increment is preserved.
- `backend/app/domain/practice_selection.py`: Changed `_compute_problem_weight` to use attempt-based denominator for failure rate.
- Updated `_make_problem` helper in domain tests to accept `correct_count` explicitly.
- Updated existing API test `test_last_tested_at_updated` → `test_last_tested_at_not_updated_by_next`.
- Added `test_skip_does_not_put_in_cooldown` API test.
- Added `test_failure_rate_uses_attempts_not_exposures` domain test.

## Test results

```
24 passed in 0.42s
```

- All 14 domain tests pass (including new `test_failure_rate_uses_attempts_not_exposures`)
- All 10 API tests pass (including new `test_last_tested_at_not_updated_by_next` and `test_skip_does_not_put_in_cooldown`)
- No frontend changes required