### PR TITLE
fix: hide discarded exams by default in exam history

### DIFF
--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -432,10 +432,14 @@ async def list_exam_history(
     current_user: CurrentUserDependency,
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
+    include_discarded: bool = Query(default=False, alias="includeDiscarded"),
 ) -> ExamHistoryResponse:
+    states = [ExamState.SUBMITTED.value]
+    if include_discarded:
+        states.append(ExamState.DISCARDED.value)
     query = {
         "userId": current_user["_id"],
-        "state": {"$in": [ExamState.SUBMITTED.value, ExamState.DISCARDED.value]},
+        "state": {"$in": states},
     }
     total = await database["exams"].count_documents(query)
     cursor = database["exams"].find(query).sort("updatedAt", -1)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -380,6 +380,48 @@ def make_ready_preview(
 
 
 @pytest_asyncio.fixture
+async def exams_app() -> AsyncIterator[FastAPI]:
+    """Minimal app fixture for exam history tests that don't need auth, ingestion, or VLM."""
+    from app.presentation.deps import get_current_user
+
+    application = create_app()
+    database = FakeDatabase()
+    adapter = FakeMongoAdapter()
+    storage = FakeStorage()
+    vlm = FakeVLMClient()
+    settings = Settings(ingestion_vlm_model="gpt-4.1-mini", ingestion_vlm_timeout_seconds=1.0)
+
+    primary_user = {
+        "_id": ObjectId(),
+        "username": "primary-user",
+        "status": "active",
+    }
+
+    application.state.fake_database = database
+    application.state.fake_storage = storage
+    application.state.fake_adapter = adapter
+    application.state.fake_vlm = vlm
+    application.state.primary_user = primary_user
+    application.state.sync_wait_seconds = 1.0
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_app_settings] = lambda: settings
+    application.dependency_overrides[get_current_user] = lambda: primary_user
+    application.dependency_overrides[get_exam_storage] = lambda: storage
+    application.dependency_overrides[get_exam_mongo_adapter] = lambda: adapter
+    application.dependency_overrides[get_exam_vlm_client] = lambda: vlm
+
+    yield application
+
+
+@pytest_asyncio.fixture
+async def exams_client(exams_app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=exams_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+@pytest_asyncio.fixture
 async def app() -> AsyncIterator[FastAPI]:
     application = create_app()
     database = FakeDatabase()

--- a/backend/tests/integration/test_exam_workflow.py
+++ b/backend/tests/integration/test_exam_workflow.py
@@ -277,7 +277,7 @@ async def test_wf_exam_4_pending_review_then_self_report_updates_score(
 @pytest.mark.asyncio
 async def test_list_exam_history_excludes_discarded_by_default(
     exams_app: FastAPI,
-    client: AsyncClient,
+    exams_client: AsyncClient,
 ) -> None:
     database = exams_app.state.fake_database
     user_id = exams_app.state.primary_user["_id"]
@@ -305,7 +305,7 @@ async def test_list_exam_history_excludes_discarded_by_default(
         },
     )
 
-    response = await client.get("/api/v1/exams")
+    response = await exams_client.get("/api/v1/exams")
     assert response.status_code == 200
     body = response.json()
     assert body["total"] == 1
@@ -315,7 +315,7 @@ async def test_list_exam_history_excludes_discarded_by_default(
 @pytest.mark.asyncio
 async def test_list_exam_history_includes_discarded_when_requested(
     exams_app: FastAPI,
-    client: AsyncClient,
+    exams_client: AsyncClient,
 ) -> None:
     database = exams_app.state.fake_database
     user_id = exams_app.state.primary_user["_id"]
@@ -343,7 +343,7 @@ async def test_list_exam_history_includes_discarded_when_requested(
         },
     )
 
-    response = await client.get("/api/v1/exams", params={"includeDiscarded": "true"})
+    response = await exams_client.get("/api/v1/exams", params={"includeDiscarded": "true"})
     assert response.status_code == 200
     body = response.json()
     assert body["total"] == 2
@@ -355,7 +355,7 @@ async def test_list_exam_history_includes_discarded_when_requested(
 @pytest.mark.asyncio
 async def test_list_exam_history_pagination_matches_filter(
     exams_app: FastAPI,
-    client: AsyncClient,
+    exams_client: AsyncClient,
 ) -> None:
     database = exams_app.state.fake_database
     user_id = exams_app.state.primary_user["_id"]
@@ -387,7 +387,7 @@ async def test_list_exam_history_pagination_matches_filter(
             },
         )
 
-    response = await client.get("/api/v1/exams", params={"page": 1, "pageSize": 3})
+    response = await exams_client.get("/api/v1/exams", params={"page": 1, "pageSize": 3})
     assert response.status_code == 200
     body = response.json()
     assert body["total"] == 5

--- a/backend/tests/integration/test_exam_workflow.py
+++ b/backend/tests/integration/test_exam_workflow.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
+from bson import ObjectId
 from httpx import ASGITransport, AsyncClient
 import pytest
 from fastapi import FastAPI
@@ -269,3 +272,124 @@ async def test_wf_exam_4_pending_review_then_self_report_updates_score(
     assert after_resolve_document["tracking"]["exposureCount"] == 1
     assert after_resolve_document["tracking"]["correctCount"] == 1
     assert after_resolve_document["tracking"]["failedCount"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_exam_history_excludes_discarded_by_default(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    database["exams"].seed(
+        {
+            "_id": ObjectId(),
+            "userId": user_id,
+            "state": "submitted",
+            "items": [],
+            "summary": {"totalProblems": 1, "answeredProblems": 1, "gradedProblems": 1, "pendingProblems": 0, "correctProblems": 1, "failedProblems": 0, "score": 1.0},
+            "createdAt": datetime.now(UTC) - timedelta(days=2),
+            "submittedAt": datetime.now(UTC) - timedelta(days=2),
+            "updatedAt": datetime.now(UTC) - timedelta(days=2),
+        },
+        {
+            "_id": ObjectId(),
+            "userId": user_id,
+            "state": "discarded",
+            "items": [],
+            "summary": {"totalProblems": 1, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC) - timedelta(days=1),
+            "discardedAt": datetime.now(UTC) - timedelta(days=1),
+            "updatedAt": datetime.now(UTC) - timedelta(days=1),
+        },
+    )
+
+    response = await client.get("/api/v1/exams")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert all(item["state"] != "discarded" for item in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_list_exam_history_includes_discarded_when_requested(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    database["exams"].seed(
+        {
+            "_id": ObjectId(),
+            "userId": user_id,
+            "state": "submitted",
+            "items": [],
+            "summary": {"totalProblems": 1, "answeredProblems": 1, "gradedProblems": 1, "pendingProblems": 0, "correctProblems": 1, "failedProblems": 0, "score": 1.0},
+            "createdAt": datetime.now(UTC) - timedelta(days=2),
+            "submittedAt": datetime.now(UTC) - timedelta(days=2),
+            "updatedAt": datetime.now(UTC) - timedelta(days=2),
+        },
+        {
+            "_id": ObjectId(),
+            "userId": user_id,
+            "state": "discarded",
+            "items": [],
+            "summary": {"totalProblems": 1, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC) - timedelta(days=1),
+            "discardedAt": datetime.now(UTC) - timedelta(days=1),
+            "updatedAt": datetime.now(UTC) - timedelta(days=1),
+        },
+    )
+
+    response = await client.get("/api/v1/exams", params={"includeDiscarded": "true"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2
+    states = {item["state"] for item in body["items"]}
+    assert "submitted" in states
+    assert "discarded" in states
+
+
+@pytest.mark.asyncio
+async def test_list_exam_history_pagination_matches_filter(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    for i in range(5):
+        database["exams"].seed(
+            {
+                "_id": ObjectId(),
+                "userId": user_id,
+                "state": "submitted",
+                "items": [],
+                "summary": {"totalProblems": 1, "answeredProblems": 1, "gradedProblems": 1, "pendingProblems": 0, "correctProblems": 1, "failedProblems": 0, "score": 1.0},
+                "createdAt": datetime.now(UTC) - timedelta(days=i),
+                "submittedAt": datetime.now(UTC) - timedelta(days=i),
+                "updatedAt": datetime.now(UTC) - timedelta(days=i),
+            },
+        )
+    for i in range(3):
+        database["exams"].seed(
+            {
+                "_id": ObjectId(),
+                "userId": user_id,
+                "state": "discarded",
+                "items": [],
+                "summary": {"totalProblems": 1, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+                "createdAt": datetime.now(UTC) - timedelta(days=i),
+                "discardedAt": datetime.now(UTC) - timedelta(days=i),
+                "updatedAt": datetime.now(UTC) - timedelta(days=i),
+            },
+        )
+
+    response = await client.get("/api/v1/exams", params={"page": 1, "pageSize": 3})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 5
+    assert len(body["items"]) == 3
+    assert all(item["state"] != "discarded" for item in body["items"])

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -109,8 +109,11 @@ export function ExamsPage() {
   const pageSize = 10;
 
   const { data, isLoading, error } = useQuery<ExamHistoryResponse>({
-    queryKey: ["exams", page, pageSize],
-    queryFn: () => api.get<ExamHistoryResponse>(`/exams?page=${page}&pageSize=${pageSize}`),
+    queryKey: ["exams", page, pageSize, showDiscarded],
+    queryFn: () =>
+      api.get<ExamHistoryResponse>(
+        `/exams?page=${page}&pageSize=${pageSize}&includeDiscarded=${showDiscarded}`,
+      ),
   });
 
   const createExamMutation = useMutation({
@@ -133,9 +136,6 @@ export function ExamsPage() {
   };
 
   const exams = data?.items ?? [];
-  const visibleExams = showDiscarded
-    ? exams
-    : exams.filter((exam) => exam.state !== "discarded");
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -235,36 +235,7 @@ export function ExamsPage() {
             borderRadius: "0.5rem",
           }}
         >
-          No exams yet
-        </div>
-      ) : visibleExams.length === 0 ? (
-        <div
-          style={{
-            padding: "2rem",
-            textAlign: "center",
-            backgroundColor: "#f9fafb",
-            border: "1px solid #e5e7eb",
-            borderRadius: "0.5rem",
-          }}
-        >
-          <p style={{ margin: "0 0 0.75rem" }}>No visible exams on this page</p>
-          <label
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: "0.5rem",
-              cursor: "pointer",
-              fontSize: "0.875rem",
-              color: "#2563eb",
-            }}
-          >
-            <input
-              type="checkbox"
-              checked={showDiscarded}
-              onChange={() => setShowDiscarded((prev) => !prev)}
-            />
-            Show discarded exams
-          </label>
+          {showDiscarded ? "No exams yet" : "No submitted exams yet"}
         </div>
       ) : (
         <>
@@ -282,13 +253,16 @@ export function ExamsPage() {
               <input
                 type="checkbox"
                 checked={showDiscarded}
-                onChange={() => setShowDiscarded((prev) => !prev)}
+                onChange={() => {
+                  setShowDiscarded((prev) => !prev);
+                  setPage(1);
+                }}
               />
               Show discarded
             </label>
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-            {visibleExams.map((exam) => (
+            {exams.map((exam) => (
               <ExamHistoryCard
                 key={exam.id}
                 exam={exam}

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -105,6 +105,7 @@ export function ExamsPage() {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [showActiveExamPrompt, setShowActiveExamPrompt] = useState(false);
+  const [showDiscarded, setShowDiscarded] = useState(false);
   const pageSize = 10;
 
   const { data, isLoading, error } = useQuery<ExamHistoryResponse>({
@@ -132,6 +133,9 @@ export function ExamsPage() {
   };
 
   const exams = data?.items ?? [];
+  const visibleExams = showDiscarded
+    ? exams
+    : exams.filter((exam) => exam.state !== "discarded");
   const total = data?.total ?? 0;
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
@@ -233,10 +237,58 @@ export function ExamsPage() {
         >
           No exams yet
         </div>
+      ) : visibleExams.length === 0 ? (
+        <div
+          style={{
+            padding: "2rem",
+            textAlign: "center",
+            backgroundColor: "#f9fafb",
+            border: "1px solid #e5e7eb",
+            borderRadius: "0.5rem",
+          }}
+        >
+          <p style={{ margin: "0 0 0.75rem" }}>No visible exams on this page</p>
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "0.5rem",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+              color: "#2563eb",
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={showDiscarded}
+              onChange={() => setShowDiscarded((prev) => !prev)}
+            />
+            Show discarded exams
+          </label>
+        </div>
       ) : (
         <>
+          <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.75rem" }}>
+            <label
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "0.5rem",
+                cursor: "pointer",
+                fontSize: "0.875rem",
+                color: "#6b7280",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={showDiscarded}
+                onChange={() => setShowDiscarded((prev) => !prev)}
+              />
+              Show discarded
+            </label>
+          </div>
           <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-            {exams.map((exam) => (
+            {visibleExams.map((exam) => (
               <ExamHistoryCard
                 key={exam.id}
                 exam={exam}


### PR DESCRIPTION
## Summary

- **Backend**: Added `includeDiscarded` query parameter to `GET /exams` endpoint. Defaults to `false`, returning only submitted exams. When `true`, includes both submitted and discarded exams. Filtering happens before pagination so `total` always matches the active filter.
- **Frontend**: Removed client-side filtering that caused incorrect pagination. The toggle now sends the backend parameter and resets page to 1 when changed. Empty state text adapts to the active filter.

## Why not frontend-only filtering?

Frontend-only filtering causes pagination drift: if a page of 10 items contains 7 discarded exams, the user sees only 3 while submitted exams remain hidden on later pages. Backend filtering ensures `total` and page counts are always accurate.

## Implementation notes

- Backend default is `includeDiscarded=false`, matching the product requirement
- Frontend `showDiscarded` state is included in the React Query key for proper cache invalidation
- Toggle handler resets `page` to 1 since the filtered total may change

## Test results

Backend tests added:
- `test_list_exam_history_excludes_discarded_by_default` — verifies discarded exams excluded without parameter
- `test_list_exam_history_includes_discarded_when_requested` — verifies `includeDiscarded=true` returns both states
- `test_list_exam_history_pagination_matches_filter` — verifies `total` and items match the filtered result with pagination

## Linked issue

Closes #149