### PR TITLE
feat: allow changing problem type from problem edit page

### DIFF
--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -416,4 +416,83 @@ describe("ProblemDetailPage", () => {
 
     vi.unstubAllGlobals();
   });
+
+  it("edit form shows problem type select prefilled with current type", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: { ...baseProblem, problemType: "short-answer" } })
+      .mockResolvedValueOnce({ problemId: "abc123", tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 } });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("short-answer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    const select = screen.getByTestId("problem-type-input");
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue("short-answer");
+  });
+
+  it("changing problem type sends it in PATCH", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: { ...baseProblem, problemType: "short-answer" } })
+      .mockResolvedValueOnce({ problemId: "abc123", tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 } })
+      .mockResolvedValueOnce({ problem: { ...baseProblem, problemType: "fill-in-the-blank" } })
+      .mockResolvedValueOnce({ problem: { ...baseProblem, problemType: "fill-in-the-blank" } })
+      .mockResolvedValueOnce({ problemId: "abc123", tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 } });
+
+    vi.mocked(api.patch).mockResolvedValueOnce({ problem: { ...baseProblem, problemType: "fill-in-the-blank" } });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("short-answer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    const select = screen.getByTestId("problem-type-input");
+    await user.selectOptions(select, "fill-in-the-blank");
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(api.patch).toHaveBeenCalledWith(
+        "/problems/abc123",
+        expect.objectContaining({ problemType: "fill-in-the-blank" }),
+      );
+    });
+  });
+
+  it("changing problem type does not reveal answer input", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: { ...baseProblem, problemType: "short-answer" } })
+      .mockResolvedValueOnce({ problemId: "abc123", tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 } });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("short-answer")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+
+    // Answer input should not be visible
+    expect(screen.queryByTestId("edit-answer-input")).not.toBeInTheDocument();
+
+    // Change problem type
+    const select = screen.getByTestId("problem-type-input");
+    await user.selectOptions(select, "fill-in-the-blank");
+
+    // Answer input should still not be visible
+    expect(screen.queryByTestId("edit-answer-input")).not.toBeInTheDocument();
+
+    // Edit Answer button should still be visible (teacher-password gated)
+    expect(screen.getByTestId("edit-answer-button")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -48,6 +48,7 @@ interface TrackingData {
 
 interface UpdateProblemInput {
   text?: string;
+  problemType?: string;
   tags?: string[];
   graphDsl?: string;
   correctAnswer?: string;
@@ -116,6 +117,7 @@ export function ProblemDetailPage() {
     if (problem) {
         setEditForm({
           text: problem.text,
+          problemType: problem.problemType,
           tags: [...problem.tags],
           graphDsl: problem.graphDsl || "",
         });
@@ -198,16 +200,6 @@ export function ProblemDetailPage() {
             </div>
           </div>
           <div>
-            <span
-              style={{
-                padding: "0.25rem 0.5rem",
-                background: "#e0e0e0",
-                borderRadius: "4px",
-                marginRight: "0.5rem",
-              }}
-            >
-              {problem.problemType}
-            </span>
             {problem.isDeleted && (
               <span
                 style={{
@@ -242,6 +234,50 @@ export function ProblemDetailPage() {
             />
           ) : (
             <LatexText text={problem.text} style={{ whiteSpace: "pre-wrap" }} />
+          )}
+        </div>
+
+        <div style={{ marginBottom: "1rem" }}>
+          <label style={{ fontWeight: "bold" }}>Problem Type:</label>
+          {isEditing ? (
+            <div>
+              <select
+                value={editForm.problemType || ""}
+                onChange={(e) =>
+                  setEditForm((prev) => ({ ...prev, problemType: e.target.value }))
+                }
+                style={{
+                  width: "100%",
+                  padding: "0.375rem 0.75rem",
+                  border: "1px solid #d1d5db",
+                  borderRadius: "0.25rem",
+                  fontSize: "0.875rem",
+                  marginTop: "0.5rem",
+                  boxSizing: "border-box",
+                }}
+                data-testid="problem-type-input"
+              >
+                <option value="">Select a problem type…</option>
+                <option value="single-choice">Single Choice</option>
+                <option value="multi-choice">Multi Choice</option>
+                <option value="fill-in-the-blank">Fill in the Blank</option>
+                <option value="short-answer">Short Answer</option>
+              </select>
+              <div style={{ marginTop: "0.25rem", fontSize: "0.75rem", color: "#6b7280" }}>
+                The existing correct answer will be interpreted using the selected type.
+              </div>
+            </div>
+          ) : (
+            <span
+              style={{
+                padding: "0.25rem 0.5rem",
+                background: "#e0e0e0",
+                borderRadius: "4px",
+                marginLeft: "0.5rem",
+              }}
+            >
+              {problem.problemType}
+            </span>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- Add a problem type `<select>` to the problem detail edit form
- Prefills with the current problem type when entering edit mode
- Sends `problemType` in the PATCH request when saved
- Shows a note that the existing correct answer will be reinterpreted using the selected type
- Removes duplicate problem type badge from header (now shown in dedicated Problem Type section)
- No backend API change required — backend already supports `problemType` in update endpoint

## Test results
```
frontend: npm test -- ProblemDetailPage.test.tsx
  ✓ 16 tests passed (13 existing + 3 new)
    - edit form shows problem type select prefilled with current type
    - changing problem type sends it in PATCH
    - changing problem type does not reveal answer input
```

## Linked issue
Closes #152