### PR TITLE
feat: add theme foundation with light/dark mode support

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { AppRoutes } from "./App";
 import { AuthProvider, useAuth } from "./contexts/AuthContext";
+import { ThemeProvider } from "./contexts/ThemeContext";
 import { ProtectedRoute } from "./components/ProtectedRoute";
 
 const mockFetch = vi.fn();
@@ -36,9 +37,11 @@ function renderWithRouterAndAuth(
   return render(
     <QueryClientProvider client={createQueryClient()}>
       <MemoryRouter initialEntries={initialEntries}>
-        <AuthProvider>
-          <AppRoutes />
-        </AuthProvider>
+        <ThemeProvider>
+          <AuthProvider>
+            <AppRoutes />
+          </AuthProvider>
+        </ThemeProvider>
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -90,19 +93,21 @@ describe("Route guards", () => {
     return render(
       <QueryClientProvider client={createQueryClient()}>
         <MemoryRouter initialEntries={initialEntries}>
-          <AuthProvider>
-            <Routes>
-              <Route path="/login" element={<div>Login Page</div>} />
-              <Route
-                path="/protected"
-                element={
-                  <ProtectedRoute>
-                    <div>Protected Content</div>
-                  </ProtectedRoute>
-                }
-              />
-            </Routes>
-          </AuthProvider>
+          <ThemeProvider>
+            <AuthProvider>
+              <Routes>
+                <Route path="/login" element={<div>Login Page</div>} />
+                <Route
+                  path="/protected"
+                  element={
+                    <ProtectedRoute>
+                      <div>Protected Content</div>
+                    </ProtectedRoute>
+                  }
+                />
+              </Routes>
+            </AuthProvider>
+          </ThemeProvider>
         </MemoryRouter>
       </QueryClientProvider>,
     );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import { AuthProvider, useAuth } from "@/contexts/AuthContext";
+import { useTheme } from "@/contexts/ThemeContext";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 
 import { LoginPage } from "@/pages/LoginPage";
@@ -20,6 +21,7 @@ import { CoachingPage } from "@/pages/CoachingPage";
 
 function AppShell({ children }: { children: ReactNode }) {
   const { user, logout } = useAuth();
+  const { theme, toggleTheme } = useTheme();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -46,8 +48,8 @@ function AppShell({ children }: { children: ReactNode }) {
           alignItems: "center",
           gap: "1rem",
           padding: "0.75rem 1rem",
-          borderBottom: "1px solid #e5e7eb",
-          backgroundColor: "#ffffff",
+          borderBottom: "1px solid var(--color-border)",
+          backgroundColor: "var(--color-surface)",
           position: "sticky",
           top: 0,
           zIndex: 10,
@@ -66,9 +68,9 @@ function AppShell({ children }: { children: ReactNode }) {
                   style={{
                     padding: "0.5rem 0.75rem",
                     borderRadius: "0.375rem",
-                    border: active ? "1px solid #2563eb" : "1px solid #d1d5db",
-                    backgroundColor: active ? "#dbeafe" : "#ffffff",
-                    color: active ? "#1d4ed8" : "#111827",
+                    border: active ? "1px solid var(--color-primary)" : "1px solid var(--color-border)",
+                    backgroundColor: active ? "var(--color-primary-bg)" : "var(--color-surface)",
+                    color: active ? "var(--color-primary-text)" : "var(--color-text)",
                     cursor: "pointer",
                     fontWeight: active ? 600 : 500,
                   }}
@@ -80,15 +82,31 @@ function AppShell({ children }: { children: ReactNode }) {
           </nav>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
-          <span style={{ color: "#4b5563", fontSize: "0.875rem" }}>{user?.username}</span>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+            style={{
+              padding: "0.5rem 0.75rem",
+              borderRadius: "0.375rem",
+              border: "1px solid var(--color-border)",
+              backgroundColor: "var(--color-surface)",
+              color: "var(--color-text)",
+              cursor: "pointer",
+            }}
+          >
+            {theme === "light" ? "Dark" : "Light"}
+          </button>
+          <span style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>{user?.username}</span>
           <button
             type="button"
             onClick={() => void handleLogout()}
             style={{
               padding: "0.5rem 0.75rem",
               borderRadius: "0.375rem",
-              border: "1px solid #d1d5db",
-              backgroundColor: "#ffffff",
+              border: "1px solid var(--color-border)",
+              backgroundColor: "var(--color-surface)",
+              color: "var(--color-text)",
               cursor: "pointer",
             }}
           >

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -48,7 +48,7 @@ export function Modal({
   };
 
   const defaultCardStyle: React.CSSProperties = {
-    backgroundColor: "white",
+    backgroundColor: "var(--color-surface)",
     padding: "1.5rem",
     borderRadius: "8px",
     maxWidth: "400px",

--- a/frontend/src/contexts/ThemeContext.tsx
+++ b/frontend/src/contexts/ThemeContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+const STORAGE_KEY = "learnloop-theme";
+
+function getInitialTheme(): Theme {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === "light" || saved === "dark") return saved;
+  } catch {}
+  return "light";
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+    try {
+      localStorage.setItem(STORAGE_KEY, theme);
+    } catch {}
+  }, [theme]);
+
+  const setTheme = (t: Theme) => setThemeState(t);
+  const toggleTheme = () => setThemeState((prev) => (prev === "light" ? "dark" : "light"));
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,8 +2,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import "katex/dist/katex.min.css";
+import "./theme.css";
 
 import App from "./App";
+import { ThemeProvider } from "./contexts/ThemeContext";
 
 
 const queryClient = new QueryClient();
@@ -12,7 +14,9 @@ const queryClient = new QueryClient();
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -1,0 +1,37 @@
+:root {
+  color-scheme: light;
+  --color-bg: #ffffff;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f9fafb;
+  --color-text: #111827;
+  --color-text-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-primary: #2563eb;
+  --color-primary-bg: #dbeafe;
+  --color-primary-text: #1d4ed8;
+  --color-danger: #dc2626;
+  --color-success: #10b981;
+  --color-warning: #f59e0b;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --color-bg: #0f172a;
+  --color-surface: #111827;
+  --color-surface-muted: #1e293b;
+  --color-text: #f8fafc;
+  --color-text-muted: #94a3b8;
+  --color-border: #334155;
+  --color-primary: #60a5fa;
+  --color-primary-bg: #1e3a8a;
+  --color-primary-text: #bfdbfe;
+  --color-danger: #f87171;
+  --color-success: #34d399;
+  --color-warning: #fbbf24;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+}


### PR DESCRIPTION
## Summary
- Added theme context with localStorage persistence for light/dark mode
- Created global CSS variables for semantic color tokens
- Migrated AppShell header to use theme variables
- Added theme toggle button in header
- Migrated Modal component to use CSS variables
- Updated tests to wrap with ThemeProvider

## Implementation Notes
- Theme state stored in `localStorage` under key `learnloop-theme`
- Applied via `data-theme` attribute on `document.documentElement`
- CSS variables defined in `frontend/src/theme.css`
- ThemeProvider wraps app in `main.tsx`

## Test Results
All 204 tests passing after changes.

## Linked Issue
Closes #155