### PR TITLE
feat: show VLM feedback in practice history

### DIFF
--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -52,6 +52,7 @@ class PracticeAttemptRequest(BaseModel):
 class PracticeAttemptResult(BaseModel):
     gradingStatus: str
     gradingMethod: str
+    feedback: str | None = None
 
 
 class PracticeAttemptDetail(BaseModel):
@@ -59,6 +60,7 @@ class PracticeAttemptDetail(BaseModel):
     gradingStatus: str
     gradingMethod: str
     createdAt: datetime
+    feedback: str | None = None
 
 
 class PracticeHistorySummary(BaseModel):
@@ -174,7 +176,7 @@ async def _grade_answer(
     vlm_client: VLMClient,
     storage: S3StorageAdapter,
     now: datetime,
-) -> tuple[GradingStatus, GradingMethod]:
+) -> tuple[GradingStatus, GradingMethod, str | None]:
     problem_type = ProblemType(problem["problemType"])
     correct_answer = problem.get("correctAnswer", {})
 
@@ -182,7 +184,7 @@ async def _grade_answer(
         normalized = normalize_answer(answer, problem_type)
         is_correct = compare_answers(normalized, correct_answer, problem_type)
         status = GradingStatus.CORRECT if is_correct else GradingStatus.INCORRECT
-        return status, GradingMethod.NORMALIZED_MATCH
+        return status, GradingMethod.NORMALIZED_MATCH, None
 
     image_base64 = load_source_image_base64(problem.get("sourceImage"), storage)
     for _ in range(2):
@@ -193,14 +195,14 @@ async def _grade_answer(
                 correct_answer=str(correct_answer.get("display", "")),
             )
             status = GradingStatus.CORRECT if result.is_correct else GradingStatus.INCORRECT
-            return status, GradingMethod.VLM
+            return status, GradingMethod.VLM, result.feedback
         except VLMError as exc:
             if not exc.retryable:
-                return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
+                return GradingStatus.PENDING_REVIEW, GradingMethod.VLM, None
             continue
         except Exception:
-            return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
-    return GradingStatus.PENDING_REVIEW, GradingMethod.VLM
+            return GradingStatus.PENDING_REVIEW, GradingMethod.VLM, None
+    return GradingStatus.PENDING_REVIEW, GradingMethod.VLM, None
 
 
 @router.post("/attempts", response_model=PracticeAttemptResult, status_code=201)
@@ -219,7 +221,7 @@ async def submit_practice_attempt(
         raise ApiError(404, "NOT_FOUND", "Problem not found")
 
     now = datetime.now(UTC)
-    grading_status, grading_method = await _grade_answer(
+    grading_status, grading_method, feedback = await _grade_answer(
         problem, payload.submittedAnswer, vlm_client, storage, now
     )
 
@@ -232,6 +234,8 @@ async def submit_practice_attempt(
         "gradingMethod": grading_method.value,
         "createdAt": now,
     }
+    if feedback is not None:
+        attempt["feedback"] = feedback
     await database["practice_attempts"].insert_one(attempt)
 
     tracking = problem.get("tracking", {})
@@ -249,6 +253,7 @@ async def submit_practice_attempt(
     return PracticeAttemptResult(
         gradingStatus=grading_status.value,
         gradingMethod=grading_method.value,
+        feedback=feedback,
     )
 
 
@@ -296,6 +301,7 @@ async def get_practice_history(
                 gradingStatus=a["gradingStatus"],
                 gradingMethod=a["gradingMethod"],
                 createdAt=a["createdAt"],
+                feedback=a.get("feedback"),
             )
             for a in problem_attempts
         ]

--- a/backend/tests/api/test_practice_submit.py
+++ b/backend/tests/api/test_practice_submit.py
@@ -11,7 +11,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from app.main import create_app
-from app.presentation.deps import get_current_user, get_database
+from app.presentation.deps import get_current_user, get_database, get_grading_vlm_client
 from tests.api.conftest import FakeDatabase, make_user, make_problem
 
 
@@ -237,3 +237,126 @@ async def test_no_correct_answer_in_result(client: AsyncClient, practice_app: Fa
     data = response.json()
     assert "correctAnswer" not in data
     assert "secret" not in str(data)
+
+
+@pytest.mark.asyncio
+async def test_submit_short_answer_vlm_feedback_persisted(client: AsyncClient, practice_app: FastAPI) -> None:
+    from unittest.mock import AsyncMock
+    from app.infrastructure.vlm.client import GradingResult
+
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id, problem_type="short-answer", correct_answer_display="4")
+    database.seed("problems", [problem])
+
+    fake_grading = GradingResult(
+        request_type="short-answer-grading",
+        model="test-model",
+        prompt_version="1",
+        schema_version="1",
+        is_correct=True,
+        feedback="The answer is correct because 2+2=4.",
+        provider_metadata={},
+        raw_provider_response={},
+    )
+
+    fake_vlm = AsyncMock()
+    fake_vlm.grade_short_answer = AsyncMock(return_value=fake_grading)
+    fake_vlm.aclose = AsyncMock()
+    practice_app.dependency_overrides[get_grading_vlm_client] = lambda: fake_vlm
+
+    response = await client.post(
+        "/api/v1/practice/attempts",
+        json={"problemId": str(problem["_id"]), "submittedAnswer": "4"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["gradingStatus"] == "correct"
+    assert data["gradingMethod"] == "vlm"
+    assert data["feedback"] == "The answer is correct because 2+2=4."
+
+    attempts = database["practice_attempts"]._documents
+    assert len(attempts) == 1
+    assert attempts[0]["feedback"] == "The answer is correct because 2+2=4."
+
+
+@pytest.mark.asyncio
+async def test_submit_short_answer_vlm_no_feedback_on_pending_review(client: AsyncClient, practice_app: FastAPI) -> None:
+    from unittest.mock import AsyncMock
+    from app.infrastructure.vlm.client import VLMError
+
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id, problem_type="short-answer", correct_answer_display="4")
+    database.seed("problems", [problem])
+
+    fake_vlm = AsyncMock()
+    fake_vlm.grade_short_answer = AsyncMock(side_effect=VLMError("fail", code="err", retryable=False))
+    fake_vlm.aclose = AsyncMock()
+    practice_app.dependency_overrides[get_grading_vlm_client] = lambda: fake_vlm
+
+    response = await client.post(
+        "/api/v1/practice/attempts",
+        json={"problemId": str(problem["_id"]), "submittedAnswer": "4"},
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["gradingStatus"] == "pending-review"
+    assert data["feedback"] is None
+
+    attempts = database["practice_attempts"]._documents
+    assert len(attempts) == 1
+    assert "feedback" not in attempts[0]
+
+
+@pytest.mark.asyncio
+async def test_history_includes_feedback_when_present(client: AsyncClient, practice_app: FastAPI) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id, text="Test problem", correct_answer_display="answer")
+    database.seed("problems", [problem])
+
+    now = datetime.now(UTC)
+    attempt = {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "problemId": problem["_id"],
+        "submittedAnswer": "answer",
+        "gradingStatus": "correct",
+        "gradingMethod": "vlm",
+        "feedback": "Great job!",
+        "createdAt": now,
+    }
+    database.seed("practice_attempts", [attempt])
+
+    response = await client.get("/api/v1/practice/history")
+    assert response.status_code == 200
+    data = response.json()
+    item = data["items"][0]
+    assert item["attempts"][0]["feedback"] == "Great job!"
+
+
+@pytest.mark.asyncio
+async def test_history_without_feedback_still_works(client: AsyncClient, practice_app: FastAPI) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id, text="Test problem", correct_answer_display="answer")
+    database.seed("problems", [problem])
+
+    now = datetime.now(UTC)
+    attempt = {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "problemId": problem["_id"],
+        "submittedAnswer": "answer",
+        "gradingStatus": "correct",
+        "gradingMethod": "normalized-match",
+        "createdAt": now,
+    }
+    database.seed("practice_attempts", [attempt])
+
+    response = await client.get("/api/v1/practice/history")
+    assert response.status_code == 200
+    data = response.json()
+    item = data["items"][0]
+    assert item["attempts"][0]["feedback"] is None

--- a/frontend/src/pages/PracticePage.test.tsx
+++ b/frontend/src/pages/PracticePage.test.tsx
@@ -502,4 +502,112 @@ describe("PracticePage", () => {
     });
     expect(screen.getByText(/Error loading history/)).toBeInTheDocument();
   });
+
+  it("renders feedback block when attempt has feedback", async () => {
+    const user = userEvent.setup();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              problemId: "problem-1",
+              problemText: "Test problem",
+              problemType: "short-answer",
+              summary: {
+                totalAttempts: 1,
+                correctCount: 1,
+                wrongCount: 0,
+                lastPracticedAt: "2024-01-01T12:00:00Z",
+                lastResult: "correct",
+              },
+              attempts: [
+                {
+                  submittedAnswer: "4",
+                  gradingStatus: "correct",
+                  gradingMethod: "vlm",
+                  feedback: "The answer is correct because 2+2=4.",
+                  createdAt: "2024-01-01T12:00:00Z",
+                },
+              ],
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 1 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "none" }),
+      });
+
+    renderPracticePage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("history-row-problem-1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("history-row-problem-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attempts-problem-1")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Feedback:")).toBeInTheDocument();
+    expect(screen.getByText("The answer is correct because 2+2=4.")).toBeInTheDocument();
+  });
+
+  it("does not render feedback block when attempt has no feedback", async () => {
+    const user = userEvent.setup();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [
+            {
+              problemId: "problem-1",
+              problemText: "Test problem",
+              problemType: "fill-in-the-blank",
+              summary: {
+                totalAttempts: 1,
+                correctCount: 1,
+                wrongCount: 0,
+                lastPracticedAt: "2024-01-01T12:00:00Z",
+                lastResult: "correct",
+              },
+              attempts: [
+                {
+                  submittedAnswer: "4",
+                  gradingStatus: "correct",
+                  gradingMethod: "normalized-match",
+                  createdAt: "2024-01-01T12:00:00Z",
+                },
+              ],
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ practiceableCount: 1 }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "none" }),
+      });
+
+    renderPracticePage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("history-row-problem-1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("history-row-problem-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attempts-problem-1")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Feedback:")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -247,6 +247,12 @@ function HistoryRow({
                   <div style={{ color: "var(--color-text)" }}>
                     Answer: {attempt.submittedAnswer}
                   </div>
+                  {attempt.feedback && (
+                    <div style={{ marginTop: "0.5rem", padding: "0.75rem", backgroundColor: "var(--color-primary-bg)", borderRadius: "0.25rem" }}>
+                      <div style={{ fontSize: "0.875rem", color: "var(--color-primary-text)", marginBottom: "0.25rem" }}>Feedback:</div>
+                      <div>{attempt.feedback}</div>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/frontend/src/types/practice.ts
+++ b/frontend/src/types/practice.ts
@@ -8,6 +8,7 @@ export interface PracticeProblem {
 export interface PracticeAttemptResult {
   gradingStatus: string;
   gradingMethod: string;
+  feedback?: string;
 }
 
 export interface PracticeAttemptDetail {
@@ -15,6 +16,7 @@ export interface PracticeAttemptDetail {
   gradingStatus: string;
   gradingMethod: string;
   createdAt: string;
+  feedback?: string;
 }
 
 export interface PracticeHistorySummary {


### PR DESCRIPTION
## Summary

- Preserve and display VLM grading feedback for short-answer practice attempts, matching the feedback behavior already available in exam history.

## Linked Issue

Closes #180

## Issue Alignment

This PR implements the issue by:

- Extending `_grade_answer` to return optional `feedback` from VLM grading results
- Persisting `feedback` on new practice attempt documents when present
- Adding optional `feedback` to `PracticeAttemptResult` and `PracticeAttemptDetail` response models
- Returning `feedback` in practice history attempt details when present
- Adding optional `feedback` to frontend practice types
- Rendering a feedback block in expanded practice history attempts (matching exam history style)

Scope covered:

- VLM feedback persistence on new practice attempts
- Practice history API feedback exposure
- Frontend feedback rendering in practice history

Out of scope / intentionally not included:

- Migrating old practice attempts without feedback
- Changing exam grading behavior
- Changing VLM prompt content or grading rules
- Showing correct answers in practice history
- Active practice immediate feedback (follow-up)

## Implementation Notes

- `_grade_answer` return type changed from `tuple[GradingStatus, GradingMethod]` to `tuple[GradingStatus, GradingMethod, str | None]`
- Feedback is only stored for successful VLM-graded short-answer attempts; pending-review and normalized-match attempts have no feedback
- Frontend renders the feedback block only when `attempt.feedback` is truthy, matching the exam history pattern
- Existing attempts without feedback serialize with `feedback: null` — no migration needed

## Tests

Commands run:

- `cd backend && uv run --frozen pytest tests/api/test_practice.py tests/api/test_practice_submit.py -v` — **26 passed**
- `cd frontend && npx vitest run PracticePage.test.tsx` — **15 passed**
- `cd frontend && npx vitest run ExamDetailPage.test.tsx` — **16 passed** (no regression)

Automated tests added or updated:

- `test_submit_short_answer_vlm_feedback_persisted` — verifies VLM feedback is persisted and returned in submit response
- `test_submit_short_answer_vlm_no_feedback_on_pending_review` — verifies pending-review attempts have no feedback
- `test_history_includes_feedback_when_present` — verifies practice history returns feedback when present
- `test_history_without_feedback_still_works` — verifies existing no-feedback attempts serialize with `null`
- Frontend: `renders feedback block when attempt has feedback` — verifies feedback block rendered
- Frontend: `does not render feedback block when attempt has no feedback` — verifies no empty feedback block

Manual verification:

- Feedback block styling matches exam history feedback block (same CSS variables and structure)

## Deviations From Issue Plan

None.

## Follow-Up Work

None.