### PR TITLE
feat: guide JSXGraph extraction DSL to preserve aspect ratio

### DIFF
--- a/backend/app/infrastructure/vlm/prompts.py
+++ b/backend/app/infrastructure/vlm/prompts.py
@@ -1,4 +1,4 @@
-EXTRACTION_PROMPT_VERSION = "2026-05-29.extraction.v3"
+EXTRACTION_PROMPT_VERSION = "2026-06-01.extraction.v4"
 GRADING_PROMPT_VERSION = "2026-05-14.grading.v1"
 
 EXTRACTION_SCHEMA_VERSION = "1.0"
@@ -40,6 +40,8 @@ Available element types and their parents:
 - functiongraph: board.create('functiongraph', [f, xMin, xMax])
 
 Guidelines:
+- The board is initialized with keepaspectratio: true, meaning x/y unit scales stay equal.
+  Choose bounding box ranges that preserve the source diagram's visual proportions.
 - Set board.setBoundingBox([xMin, yMax, xMax, yMin]) first if the default [-5,5,5,-5] is unsuitable.
 - Keep the construction simple: only reproduce what is visually present in the image.
 - Do NOT call JXG.JSXGraph.initBoard — the board already exists.

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -124,6 +124,42 @@ async def test_vlm_extraction_prompt_includes_latex_spacing_guidance() -> None:
 
 
 @pytest.mark.asyncio
+async def test_vlm_extraction_prompt_includes_keepaspectratio_guidance() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads((await request.aread()).decode())
+        prompt = payload["messages"][0]["content"][0]["text"]
+        assert "keepaspectratio: true" in prompt
+        assert "preserve the source diagram" in prompt
+        assert "JXG.JSXGraph.initBoard" in prompt
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "text": "Triangle problem",
+                                    "problemType": "short-answer",
+                                    "graphDsl": None,
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert result.prompt_version == EXTRACTION_PROMPT_VERSION
+
+
+@pytest.mark.asyncio
 async def test_vlm_grading_happy_path() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path == "/api/chat/completions"


### PR DESCRIPTION
## Summary

- Add `keepaspectratio: true` guidance to the VLM extraction prompt so generated `graphDsl` bounding boxes preserve source diagram proportions.

## Linked Issue

Closes #181

## Issue Alignment

This PR implements the issue by:

- Updating `EXTRACTION_PROMPT_TEMPLATE` to state the existing board is initialized with `keepaspectratio: true`
- Adding bounding box guidance to preserve source diagram proportions under `keepaspectratio: true`
- Bumping `EXTRACTION_PROMPT_VERSION` from `2026-05-29.extraction.v3` to `2026-06-01.extraction.v4`
- Adding a regression test asserting the new guidance appears in the outbound prompt

Scope covered:

- Extraction prompt update with aspect-ratio guidance
- Prompt version bump
- Regression test

Out of scope / intentionally not included:

- Changing `GraphSandbox` board initialization (already has `keepaspectratio: true`)
- Frontend rendering changes
- VLM provider request/response handling changes
- Retrofitting existing stored `graphDsl` values

## Implementation Notes

- Verified `GraphSandbox` already initializes with `keepaspectratio: true` before updating prompt
- Prompt still forbids `JXG.JSXGraph.initBoard(...)` — unchanged
- Two lines added to the Guidelines section of the prompt, preserving all existing content

## Tests

Commands run:

- `cd backend && uv run --frozen pytest tests/infrastructure/test_vlm.py -v` — **13 passed**

Automated tests added or updated:

- `test_vlm_extraction_prompt_includes_keepaspectratio_guidance` — asserts `keepaspectratio: true`, `preserve the source diagram`, and `JXG.JSXGraph.initBoard` all appear in the outbound extraction prompt

Manual verification:

- Confirmed `GraphSandbox.tsx` contains `keepaspectratio: true` (verified via `rg`)

## Deviations From Issue Plan

None.

## Follow-Up Work

None.