### PR TITLE
feat: show JSXGraph panel during active practice

### DIFF
--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -167,6 +167,9 @@ async def get_next_practice_problem(
     if selected_document.get("sourceImage"):
         problem_response["imageUrl"] = build_problem_image_url(selected_document["_id"])
 
+    if selected_document.get("graphDsl"):
+        problem_response["graphDsl"] = selected_document["graphDsl"]
+
     return PracticeNextResponse(status="ok", problem=problem_response)
 
 

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -223,3 +223,39 @@ async def test_stats_excludes_cooldown_problems(
     assert response.status_code == 200
     data = response.json()
     assert data["practiceableCount"] == 2
+
+
+@pytest.mark.asyncio
+async def test_next_problem_includes_graph_dsl(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id, text="Triangle problem", correct_answer_display="4")
+    problem["graphDsl"] = "board.create('point', [0, 0], {name:'A'});"
+    database.seed("problems", [problem])
+
+    response = await client.post("/api/v1/practice/next")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["problem"]["graphDsl"] == "board.create('point', [0, 0], {name:'A'});"
+    assert "correctAnswer" not in data["problem"]
+
+
+@pytest.mark.asyncio
+async def test_next_problem_without_graph_dsl(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    problem = make_problem(user_id, text="Text only", correct_answer_display="4")
+    database.seed("problems", [problem])
+
+    response = await client.post("/api/v1/practice/next")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "graphDsl" not in data["problem"]

--- a/frontend/src/pages/ActivePracticePage.test.tsx
+++ b/frontend/src/pages/ActivePracticePage.test.tsx
@@ -18,7 +18,7 @@ function createQueryClient() {
   });
 }
 
-function renderActivePracticePage(problem?: { id: string; text: string; type: string; imageUrl?: string }) {
+function renderActivePracticePage(problem?: { id: string; text: string; type: string; imageUrl?: string; graphDsl?: string }) {
   return render(
     <QueryClientProvider client={createQueryClient()}>
       <MemoryRouter initialEntries={[{ pathname: "/practice/active", state: { problem } }]}>
@@ -337,5 +337,34 @@ describe("ActivePracticePage", () => {
       expect(screen.getByTestId("next-button")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("explain-button")).not.toBeInTheDocument();
+  });
+
+  it("renders GraphSandbox when problem has graphDsl", async () => {
+    const graphProblem = {
+      id: "problem-1",
+      text: "Triangle problem",
+      type: "short-answer",
+      graphDsl: "board.create('point', [0, 0], {name:'A'});",
+    };
+    vi.spyOn(api, "getSolutionStatus").mockResolvedValue({ status: "none" });
+
+    renderActivePracticePage(graphProblem);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-button")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Triangle problem")).toBeInTheDocument();
+    expect(screen.getByTestId("jsxgraph-iframe")).toBeInTheDocument();
+  });
+
+  it("does not render GraphSandbox when problem has no graphDsl", async () => {
+    vi.spyOn(api, "getSolutionStatus").mockResolvedValue({ status: "none" });
+
+    renderActivePracticePage(mockProblem);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-button")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("jsxgraph-iframe")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ActivePracticePage.tsx
+++ b/frontend/src/pages/ActivePracticePage.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "@/api/client";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
+import { GraphSandbox } from "@/components/GraphSandbox";
 import { LatexText } from "@/components/LatexText";
 import { AnswerInput, parseOptions } from "@/components/AnswerInput";
 import type { PracticeProblem, PracticeNextResponse, PracticeAttemptResult } from "@/types/practice";
@@ -173,6 +174,12 @@ export function ActivePracticePage() {
           }}
           data-testid="problem-text"
         />
+
+        {currentProblem.graphDsl && (
+          <div style={{ marginBottom: "1.5rem" }}>
+            <GraphSandbox dsl={currentProblem.graphDsl} height={250} />
+          </div>
+        )}
 
         {currentProblem.imageUrl && (
           <CollapsibleImage

--- a/frontend/src/types/practice.ts
+++ b/frontend/src/types/practice.ts
@@ -3,6 +3,7 @@ export interface PracticeProblem {
   text: string;
   type: string;
   imageUrl?: string;
+  graphDsl?: string;
 }
 
 export interface PracticeAttemptResult {


### PR DESCRIPTION
## Summary

- Include `graphDsl` in the practice next-problem API response and render `GraphSandbox` in `ActivePracticePage` for problems with JSXGraph DSL, matching the rendering pattern used in active exams.

## Linked Issue

Closes #182

## Issue Alignment

This PR implements the issue by:

- Adding `graphDsl` to the `/practice/next` response when the selected problem has graph DSL
- Adding optional `graphDsl` to the `PracticeProblem` frontend type
- Rendering `GraphSandbox` in `ActivePracticePage` between problem text and image, matching active exam placement
- Adding backend and frontend regression tests

Scope covered:

- Practice next-problem payload includes `graphDsl`
- Frontend type updated
- `GraphSandbox` rendered in active practice when `graphDsl` exists
- Backend and frontend tests added

Out of scope / intentionally not included:

- Changing exam rendering behavior
- Changing `GraphSandbox` internals
- Showing correct answers during active practice
- Refactoring practice payload into shared schema

## Implementation Notes

- Used the exact same `GraphSandbox` rendering pattern from `ActiveExamPage`: `<GraphSandbox dsl={...} height={250} />` wrapped in a `marginBottom: "1.5rem"` div
- `graphDsl` only included in response when the field is present and truthy (preserves backward compatibility)
- `correctAnswer` still excluded from practice next response

## Tests

Commands run:

- `cd backend && uv run --frozen pytest tests/api/test_practice.py -v` — **13 passed**
- `cd frontend && npx vitest run ActivePracticePage.test.tsx` — **17 passed**

Automated tests added or updated:

- `test_next_problem_includes_graph_dsl` — verifies `/practice/next` returns `graphDsl` for graph problems
- `test_next_problem_without_graph_dsl` — verifies `graphDsl` absent for text-only problems
- Frontend: `renders GraphSandbox when problem has graphDsl` — verifies `jsxgraph-iframe` rendered
- Frontend: `does not render GraphSandbox when problem has no graphDsl` — verifies no iframe rendered

Manual verification:

- `GraphSandbox` rendering placement matches `ActiveExamPage` (between text and image, height 250)

## Deviations From Issue Plan

None.

## Follow-Up Work

None.