### PR TITLE
feat: support coaching reasoning_content from OpenAI-compatible responses

### DIFF
--- a/backend/app/domain/coaching/service.py
+++ b/backend/app/domain/coaching/service.py
@@ -127,7 +127,8 @@ class CoachingService:
             conversation.add_message(CoachingMessage(
                 role=CoachingRole.COACH,
                 content=llm_result.text,
-                whiteboard_dsl=llm_result.whiteboard_dsl
+                whiteboard_dsl=llm_result.whiteboard_dsl,
+                reasoning_content=llm_result.reasoning_content
             ))
         except ValueError as exc:
             raise CoachingError(str(exc), code="MESSAGE_CAP_EXCEEDED", status_code=400)

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -276,6 +276,7 @@ class CoachingMessage(BaseModel):
     role: CoachingRole
     content: str
     whiteboard_dsl: Optional[str] = None
+    reasoning_content: Optional[str] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 

--- a/backend/app/infrastructure/llm/client.py
+++ b/backend/app/infrastructure/llm/client.py
@@ -62,6 +62,7 @@ class _ChatCompletionRequest(BaseModel):
 class _ChatCompletionMessage(BaseModel):
     role: str
     content: str | None = None
+    reasoning_content: str | None = None
 
 
 class _ChatCompletionChoice(BaseModel):
@@ -111,6 +112,7 @@ class CoachingVLMResult(BaseModel):
     model: str
     text: str
     whiteboard_dsl: str | None = None
+    reasoning_content: str | None = None
     raw_provider_response: dict[str, Any]
 
 
@@ -127,6 +129,7 @@ class _CoachingProviderPayload(BaseModel):
 
     text: str
     whiteboard_dsl: str | None = None
+    reasoning_content: str | None = None
 
 
 class _BaseLLMClient:
@@ -277,7 +280,8 @@ class _BaseLLMClient:
                 raw_provider_response=raw_body,
             )
 
-        content = completion.choices[0].message.content
+        message = completion.choices[0].message
+        content = message.content
         if not content:
             raise LLMClientError(
                 "LLM provider response content was empty",
@@ -286,7 +290,10 @@ class _BaseLLMClient:
                 raw_provider_response=raw_body,
             )
 
-        return cls._load_json_content(content)
+        parsed = cls._load_json_content(content)
+        if message.reasoning_content is not None:
+            parsed["reasoning_content"] = message.reasoning_content
+        return parsed
 
 
 class SolutionVLMClient(_BaseLLMClient):
@@ -423,6 +430,7 @@ class CoachingVLMClient(_BaseLLMClient):
             model=self._model,
             text=parsed.text,
             whiteboard_dsl=_sanitize_whiteboard_dsl(parsed.whiteboard_dsl),
+            reasoning_content=parsed.reasoning_content,
             raw_provider_response=raw_provider_response,
         )
 

--- a/backend/tests/api/test_coaching.py
+++ b/backend/tests/api/test_coaching.py
@@ -218,3 +218,46 @@ async def test_access_other_user_conversation(client: AsyncClient, coaching_app:
     response = await client.get(f"/api/v1/coaching/{str(other_prob_id)}/conversation")
     assert response.status_code == 404
 
+
+@pytest.mark.asyncio
+async def test_send_message_returns_reasoning_content(client: AsyncClient, setup_problem: str):
+    with patch("app.infrastructure.llm.client.CoachingVLMClient.send_message", new_callable=AsyncMock) as mock_send:
+        mock_send.return_value = CoachingVLMResult(
+            prompt_version="1",
+            model="test",
+            text="coach response",
+            whiteboard_dsl=None,
+            reasoning_content="step by step thinking",
+            raw_provider_response={}
+        )
+
+        response = await client.post(
+            f"/api/v1/coaching/{setup_problem}/messages",
+            json={"message": "help me understand"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages"][1]["reasoning_content"] == "step by step thinking"
+
+
+@pytest.mark.asyncio
+async def test_send_message_reasoning_content_null_when_absent(client: AsyncClient, setup_problem: str):
+    with patch("app.infrastructure.llm.client.CoachingVLMClient.send_message", new_callable=AsyncMock) as mock_send:
+        mock_send.return_value = CoachingVLMResult(
+            prompt_version="1",
+            model="test",
+            text="coach response",
+            whiteboard_dsl=None,
+            raw_provider_response={}
+        )
+
+        response = await client.post(
+            f"/api/v1/coaching/{setup_problem}/messages",
+            json={"message": "help me understand"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["messages"][1].get("reasoning_content") is None
+

--- a/backend/tests/domain/test_coaching_service.py
+++ b/backend/tests/domain/test_coaching_service.py
@@ -210,3 +210,53 @@ async def test_send_message_llm_failure():
         await service.send_message(str(prob_id), str(user_id), "hello")
     assert exc.value.code == "LLM_FAILURE"
     assert exc.value.status_code == 503
+
+@pytest.mark.asyncio
+async def test_send_message_persists_reasoning_content():
+    db = FakeDatabase()
+    client = FakeCoachingVLMClient()
+    client.result = CoachingVLMResult(
+        prompt_version="1",
+        model="test",
+        text="coach reply",
+        whiteboard_dsl=None,
+        reasoning_content="step by step thinking",
+        raw_provider_response={}
+    )
+    service = CoachingService(db, client)
+
+    prob_id = ObjectId()
+    user_id = ObjectId()
+
+    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db.cols["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
+
+    conv = await service.send_message(str(prob_id), str(user_id), "help me")
+
+    assert len(conv.messages) == 2
+    assert conv.messages[1].role == CoachingRole.COACH
+    assert conv.messages[1].content == "coach reply"
+    assert conv.messages[1].reasoning_content == "step by step thinking"
+
+@pytest.mark.asyncio
+async def test_send_message_reasoning_content_none_when_absent():
+    db = FakeDatabase()
+    client = FakeCoachingVLMClient()
+    client.result = CoachingVLMResult(
+        prompt_version="1",
+        model="test",
+        text="coach reply",
+        whiteboard_dsl=None,
+        raw_provider_response={}
+    )
+    service = CoachingService(db, client)
+
+    prob_id = ObjectId()
+    user_id = ObjectId()
+
+    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db.cols["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
+
+    conv = await service.send_message(str(prob_id), str(user_id), "help me")
+
+    assert conv.messages[1].reasoning_content is None

--- a/backend/tests/infrastructure/test_llm_client.py
+++ b/backend/tests/infrastructure/test_llm_client.py
@@ -332,3 +332,74 @@ async def test_coaching_vlm_client_network_failure_is_catchable() -> None:
 
     assert exc_info.value.code == FAILURE_CODE_NETWORK
     assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_coaching_vlm_client_parses_reasoning_content() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps({"text": "答案是 x=2。"}),
+                            "reasoning_content": "先分析等式，两边减3得到x=2。",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingVLMRequest(
+            problem_text="x + 3 = 5",
+            correct_answer="2",
+            canonical_steps_markdown="步骤",
+            canonical_final_answer="2",
+            math_level_classification="primary",
+            new_message="怎么做？",
+        )
+    )
+    await client.aclose()
+
+    assert result.text == "答案是 x=2。"
+    assert result.reasoning_content == "先分析等式，两边减3得到x=2。"
+
+
+@pytest.mark.asyncio
+async def test_coaching_vlm_client_reasoning_content_none_when_absent() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps({"text": "简单回答。"}),
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingVLMRequest(
+            problem_text="题目",
+            correct_answer="答案",
+            canonical_steps_markdown="步骤",
+            canonical_final_answer="答案",
+            math_level_classification="primary",
+            new_message="你好",
+        )
+    )
+    await client.aclose()
+
+    assert result.text == "简单回答。"
+    assert result.reasoning_content is None


### PR DESCRIPTION
## Summary

- Add optional `reasoning_content` field support to the coaching backend, sourced from OpenAI-compatible `choices[].message.reasoning_content`
- Parse, persist, and expose reasoning content through the coaching conversation API

## Linked Issue

Closes #189

## Issue Alignment

This PR implements the issue by:

- Extending `_ChatCompletionMessage` to accept optional `reasoning_content`
- Propagating `reasoning_content` through `_parse_chat_completion_response` to the parsed provider payload
- Adding `reasoning_content` to `_CoachingProviderPayload` and `CoachingVLMResult`
- Adding `reasoning_content` to domain `CoachingMessage` model
- Persisting `llm_result.reasoning_content` on coach messages in `CoachingService.send_message()`

Scope covered:

- LLM client parsing of `choices[0].message.reasoning_content`
- Domain model support for optional `reasoning_content`
- Service-layer persistence of reasoning content on coach messages
- API responses include `reasoning_content` when available
- Tests for parsing, persistence, and API response behavior

Out of scope / intentionally not included:

- Frontend rendering of reasoning content (deferred to #190)
- Streaming reasoning content
- Changing prompts to request reasoning text

## Implementation Notes

- `reasoning_content` is treated as a provider-supplied optional string from the chat-completion message object, separate from the JSON payload inside `message.content`
- The field propagates through: LLM client parsing → `CoachingVLMResult` → `CoachingService` → domain `CoachingMessage` → API response
- Backward compatible: existing responses without `reasoning_content` produce `null` for the field

## Tests

Commands run:

- `uv run pytest tests/infrastructure/test_llm_client.py tests/domain/test_coaching_service.py tests/api/test_coaching.py -v` — 27 passed
- `uv run pyright` — 72 pre-existing errors, no new errors introduced

Automated tests added or updated:

- `test_coaching_vlm_client_parses_reasoning_content` — verifies parsing when provider returns reasoning_content
- `test_coaching_vlm_client_reasoning_content_none_when_absent` — verifies null when field is missing
- `test_send_message_persists_reasoning_content` — verifies service persists reasoning on coach messages
- `test_send_message_reasoning_content_none_when_absent` — verifies backward compatibility
- `test_send_message_returns_reasoning_content` — verifies API includes reasoning_content in response
- `test_send_message_reasoning_content_null_when_absent` — verifies API returns null when absent

Manual verification:

- All 27 focused tests pass
- Existing tests continue to pass (no regressions)

## Deviations From Issue Plan

None.

## Follow-Up Work

- #190 — Render collapsed reasoning_content above AI coach replies (frontend)