### PR TITLE
feat: render collapsed reasoning_content above AI coach replies

### DIFF
--- a/frontend/src/pages/CoachingPage.test.tsx
+++ b/frontend/src/pages/CoachingPage.test.tsx
@@ -418,4 +418,158 @@ describe("CoachingPage", () => {
     expect(listItems.length).toBeGreaterThanOrEqual(1);
     expect(chatLog.textContent).toContain("Move constants to the right");
   });
+
+  it("renders collapsed reasoning section above coach reply when reasoning_content is present", async () => {
+    const conversationWithReasoning: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: [
+        {
+          role: "student",
+          content: "How do I solve this?",
+          created_at: "2026-05-25T12:31:00Z",
+        },
+        {
+          role: "coach",
+          content: "Take the square root of both sides.",
+          reasoning_content: "The equation is x^2 = 4. Taking sqrt of both sides gives x = ±2.",
+          created_at: "2026-05-25T12:32:00Z",
+        },
+      ],
+      created_at: "2026-05-25T12:30:00Z",
+      updated_at: "2026-05-25T12:32:00Z",
+    };
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationWithReasoning);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-log")).toBeInTheDocument();
+    });
+
+    // Reasoning section exists and is collapsed by default
+    const reasoning = screen.getByTestId("reasoning-1");
+    expect(reasoning).toBeInTheDocument();
+    expect(reasoning.tagName.toLowerCase()).toBe("details");
+    expect(reasoning.hasAttribute("open")).toBe(false);
+
+    // Reasoning summary text is visible
+    expect(within(reasoning).getByText("🧠 Reasoning")).toBeInTheDocument();
+
+    // Coach reply is still rendered
+    const chatLog = screen.getByTestId("chat-log");
+    expect(chatLog.textContent).toContain("Take the square root of both sides.");
+  });
+
+  it("expanding reasoning section reveals the reasoning text", async () => {
+    const conversationWithReasoning: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: [
+        {
+          role: "coach",
+          content: "The answer is 2.",
+          reasoning_content: "Step by step: x^2 = 4, so x = sqrt(4) = 2.",
+          created_at: "2026-05-25T12:32:00Z",
+        },
+      ],
+      created_at: "2026-05-25T12:30:00Z",
+      updated_at: "2026-05-25T12:32:00Z",
+    };
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationWithReasoning);
+
+    const user = userEvent.setup();
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reasoning-0")).toBeInTheDocument();
+    });
+
+    // Click to expand
+    await user.click(screen.getByText("🧠 Reasoning"));
+
+    // Reasoning text is now visible
+    expect(screen.getByTestId("reasoning-0")).toHaveAttribute("open");
+    expect(screen.getByTestId("reasoning-0").textContent).toContain("Step by step");
+  });
+
+  it("does not render reasoning section for coach messages without reasoning_content", async () => {
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationWithMessages);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-log")).toBeInTheDocument();
+    });
+
+    // No reasoning sections should exist
+    expect(screen.queryByTestId(/reasoning-/)).not.toBeInTheDocument();
+  });
+
+  it("does not render reasoning section for student messages", async () => {
+    const conversationWithReasoning: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: [
+        {
+          role: "student",
+          content: "Help me solve this.",
+          reasoning_content: "This should not render for student messages.",
+          created_at: "2026-05-25T12:31:00Z",
+        },
+        {
+          role: "coach",
+          content: "Sure!",
+          created_at: "2026-05-25T12:32:00Z",
+        },
+      ],
+      created_at: "2026-05-25T12:30:00Z",
+      updated_at: "2026-05-25T12:32:00Z",
+    };
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationWithReasoning);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-log")).toBeInTheDocument();
+    });
+
+    // No reasoning sections should exist (student reasoning_content is ignored)
+    expect(screen.queryByTestId(/reasoning-/)).not.toBeInTheDocument();
+  });
+
+  it("reasoning section appears above the coach reply in DOM order", async () => {
+    const conversationWithReasoning: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: [
+        {
+          role: "coach",
+          content: "The answer is x = 2.",
+          reasoning_content: "Analyzing the equation step by step.",
+          created_at: "2026-05-25T12:32:00Z",
+        },
+      ],
+      created_at: "2026-05-25T12:30:00Z",
+      updated_at: "2026-05-25T12:32:00Z",
+    };
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationWithReasoning);
+
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reasoning-0")).toBeInTheDocument();
+    });
+
+    // The reasoning details element should come before the coach reply text in DOM order
+    const chatLog = screen.getByTestId("chat-log");
+    const reasoning = screen.getByTestId("reasoning-0");
+    const allElements = chatLog.querySelectorAll("[data-testid]");
+    const reasoningIndex = Array.from(allElements).indexOf(reasoning);
+
+    // Find the coach reply bubble (the MarkdownText content)
+    const coachReply = chatLog.querySelector('[data-testid="reasoning-0"]')?.nextElementSibling;
+    expect(coachReply).toBeTruthy();
+    expect(coachReply!.textContent).toContain("The answer is x = 2.");
+  });
 });

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -380,6 +380,7 @@ export function CoachingPage() {
               ) : (
                 conversation?.messages?.map((msg, index) => {
                   const isStudent = msg.role === "student";
+                  const hasReasoning = !isStudent && msg.reasoning_content?.trim();
                   return (
                     <div
                       key={index}
@@ -389,21 +390,43 @@ export function CoachingPage() {
                         width: "100%",
                       }}
                     >
-                      <div
-                        style={{
-                          maxWidth: "85%",
-                          padding: "0.75rem 1rem",
-                          borderRadius: "0.75rem",
-                          borderBottomRightRadius: isStudent ? "0px" : "0.75rem",
-                          borderBottomLeftRadius: isStudent ? "0.75rem" : "0px",
-                          backgroundColor: isStudent ? "var(--color-student-bubble-bg)" : "var(--color-coach-bubble-bg)",
-                          color: isStudent ? "var(--color-student-bubble-text)" : "var(--color-coach-bubble-text)",
-                          border: isStudent ? "1px solid var(--color-student-bubble-border)" : "1px solid var(--color-coach-bubble-border)",
-                          fontSize: "0.925rem",
-                          lineHeight: 1.5,
-                        }}
-                      >
-                        <MarkdownText content={msg.content} />
+                      <div style={{ maxWidth: "85%", display: "flex", flexDirection: "column", gap: "0.375rem" }}>
+                        {hasReasoning && (
+                          <details
+                            data-testid={`reasoning-${index}`}
+                            style={{
+                              fontSize: "0.8125rem",
+                              color: "var(--color-text-muted)",
+                              backgroundColor: "var(--color-surface-muted)",
+                              border: "1px solid var(--color-border-muted)",
+                              borderRadius: "0.5rem",
+                              padding: "0.375rem 0.625rem",
+                              lineHeight: 1.4,
+                            }}
+                          >
+                            <summary style={{ cursor: "pointer", fontWeight: 600, userSelect: "none" }}>
+                              🧠 Reasoning
+                            </summary>
+                            <div style={{ marginTop: "0.375rem", whiteSpace: "pre-wrap" }}>
+                              <MarkdownText content={msg.reasoning_content!} />
+                            </div>
+                          </details>
+                        )}
+                        <div
+                          style={{
+                            padding: "0.75rem 1rem",
+                            borderRadius: "0.75rem",
+                            borderBottomRightRadius: isStudent ? "0px" : "0.75rem",
+                            borderBottomLeftRadius: isStudent ? "0.75rem" : "0px",
+                            backgroundColor: isStudent ? "var(--color-student-bubble-bg)" : "var(--color-coach-bubble-bg)",
+                            color: isStudent ? "var(--color-student-bubble-text)" : "var(--color-coach-bubble-text)",
+                            border: isStudent ? "1px solid var(--color-student-bubble-border)" : "1px solid var(--color-coach-bubble-border)",
+                            fontSize: "0.925rem",
+                            lineHeight: 1.5,
+                          }}
+                        >
+                          <MarkdownText content={msg.content} />
+                        </div>
                       </div>
                     </div>
                   );

--- a/frontend/src/types/coaching.ts
+++ b/frontend/src/types/coaching.ts
@@ -4,6 +4,7 @@ export interface CoachingMessage {
   role: CoachingRole;
   content: string;
   whiteboard_dsl?: string | null;
+  reasoning_content?: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary

- Add optional `reasoning_content` to frontend `CoachingMessage` type
- Render a collapsed `<details>` section above each coach reply that has non-empty `reasoning_content`
- Use native `<details>`/`<summary>` for keyboard-accessible, state-free collapsed UI

## Linked Issue

Closes #190

## Issue Alignment

This PR implements the issue by:

- Adding `reasoning_content?: string | null` to the frontend `CoachingMessage` interface
- Rendering a collapsed `<details>` element inside the coach-turn container, above the reply bubble
- Using existing CSS variables and inline style patterns from `CoachingPage.tsx`
- Rendering reasoning content with `MarkdownText` for markdown support

Scope covered:

- Frontend type support for `reasoning_content`
- Collapsed reasoning section above matching coach replies
- Visual association with the same coach turn
- Styling with existing theme variables
- Tests for rendering, collapsed state, expansion, and absence cases

Out of scope / intentionally not included:

- Backend parsing, persistence, or API exposure (handled by #189 / PR #191)
- Streaming reasoning content
- Changing LLM prompts
- Inferring or generating reasoning content on the frontend

## Implementation Notes

- Uses native `<details>`/`<summary>` — no additional state management needed, keyboard-accessible by default
- Reasoning section only renders for coach messages with non-empty trimmed `reasoning_content`
- Student messages with `reasoning_content` are intentionally ignored (only coach reasoning is meaningful)
- Reasoning content rendered with `MarkdownText` to support potential markdown formatting
- Styled with existing CSS variables (`--color-surface-muted`, `--color-border-muted`, `--color-text-muted`)

## Tests

Commands run:

- `npx vitest run src/pages/CoachingPage.test.tsx` — 16 passed
- `npx vitest run` — 228 passed (full suite)
- `npx tsc --noEmit` — no errors

Automated tests added or updated:

- `renders collapsed reasoning section above coach reply when reasoning_content is present` — verifies `<details>` element exists, is collapsed by default
- `expanding reasoning section reveals the reasoning text` — verifies click-to-expand behavior
- `does not render reasoning section for coach messages without reasoning_content` — verifies absence path
- `does not render reasoning section for student messages` — verifies student messages are ignored
- `reasoning section appears above the coach reply in DOM order` — verifies ordering requirement

Manual verification:

- All 228 frontend tests pass
- TypeScript type check passes with no errors

## Deviations From Issue Plan

None.

## Follow-Up Work

None.