### PR TITLE
feat: add backend folder tree and CRUD API

### DIFF
--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -16,6 +16,7 @@ TAGS_COLLECTION = "tags"
 SOLUTION_GENERATION_TASKS_COLLECTION = "solution_generation_tasks"
 CANONICAL_SOLUTIONS_COLLECTION = "canonical_solutions"
 COACHING_CONVERSATIONS_COLLECTION = "coaching_conversations"
+FOLDERS_COLLECTION = "folders"
 
 
 class SupportsAsyncClose(Protocol):
@@ -91,6 +92,7 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
         SOLUTION_GENERATION_TASKS_COLLECTION,
         CANONICAL_SOLUTIONS_COLLECTION,
         COACHING_CONVERSATIONS_COLLECTION,
+        FOLDERS_COLLECTION,
     ):
         if collection_name not in existing_collections and hasattr(database, "create_collection"):
             await database.create_collection(collection_name)
@@ -109,6 +111,16 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
             [("problem_id", ASCENDING), ("user_id", ASCENDING)],
             unique=True,
             name="problem_user_conversation_unique",
+        )
+
+    # Folder indexes: user lookup and sibling uniqueness (case-insensitive via collation)
+    create_folder_user_parent_index = getattr(database[FOLDERS_COLLECTION], "create_index", None)
+    if callable(create_folder_user_parent_index):
+        await create_folder_user_parent_index(
+            [("userId", ASCENDING), ("parentId", ASCENDING), ("name", ASCENDING)],
+            unique=True,
+            name="user_parent_folder_unique",
+            collation={"locale": "en", "strength": 2},  # case-insensitive
         )
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.presentation.solution_generation import backfill_solution_generation_ta
 from app.presentation.auth import router as auth_router
 from app.presentation.exams import router as exams_router
 from app.presentation.errors import ApiError, api_error_handler, validation_error_handler
+from app.presentation.folders import router as folders_router
 from app.presentation.ingestion import router as ingestion_router
 from app.presentation.media import router as media_router
 from app.presentation.problems import router as problems_router
@@ -78,6 +79,7 @@ def create_app() -> FastAPI:
     api_v1_router.include_router(exams_router)
     api_v1_router.include_router(media_router)
     api_v1_router.include_router(tags_router)
+    api_v1_router.include_router(folders_router)
     api_v1_router.include_router(practice_router)
     api_v1_router.include_router(settings_router)
     api_v1_router.include_router(teacher_password_router)

--- a/backend/app/presentation/folders.py
+++ b/backend/app/presentation/folders.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated, Any
+
+from bson import ObjectId
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from app.presentation.deps import DatabaseDependency, get_current_user
+from app.presentation.errors import ApiError
+from app.presentation.helpers import parse_object_id
+
+router = APIRouter(prefix="/folders", tags=["folders"])
+
+CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
+
+MAX_FOLDER_NAME_LENGTH = 200
+
+
+class FolderNodePayload(BaseModel):
+    id: str
+    name: str
+    parentId: str | None
+    problemCount: int
+    children: list["FolderNodePayload"]
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class FolderTreeResponse(BaseModel):
+    allProblemsCount: int
+    unfiledCount: int
+    items: list[FolderNodePayload]
+
+
+class CreateFolderRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=MAX_FOLDER_NAME_LENGTH)
+    parentId: str | None = None
+
+
+class UpdateFolderRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=MAX_FOLDER_NAME_LENGTH)
+    parentId: str | None = None
+
+
+class FolderPayload(BaseModel):
+    id: str
+    name: str
+    parentId: str | None
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class FolderResponse(BaseModel):
+    folder: FolderPayload
+
+
+class DeleteFolderResponse(BaseModel):
+    ok: bool
+
+
+def _normalize_folder_name(name: str) -> str:
+    """Trim and validate folder name."""
+    trimmed = name.strip()
+    if not trimmed:
+        raise ApiError(400, "VALIDATION_ERROR", "Folder name cannot be empty")
+    if len(trimmed) > MAX_FOLDER_NAME_LENGTH:
+        raise ApiError(400, "VALIDATION_ERROR", f"Folder name cannot exceed {MAX_FOLDER_NAME_LENGTH} characters")
+    return trimmed
+
+
+async def _get_owned_folder(
+    database: DatabaseDependency,
+    folder_id: str,
+    user_id: ObjectId,
+) -> dict[str, Any]:
+    """Get a folder by ID, verifying ownership."""
+    object_id = parse_object_id(folder_id, resource_name="Folder")
+    folder = await database["folders"].find_one({"_id": object_id})
+    if folder is None:
+        raise ApiError(404, "NOT_FOUND", "Folder not found")
+    if folder.get("userId") != user_id:
+        raise ApiError(403, "FORBIDDEN", "Forbidden")
+    return folder
+
+
+async def _check_sibling_name_conflict(
+    database: DatabaseDependency,
+    user_id: ObjectId,
+    name: str,
+    parent_id: ObjectId | None,
+    exclude_folder_id: ObjectId | None = None,
+) -> None:
+    """Check for case-insensitive name conflict among siblings."""
+    query: dict[str, Any] = {
+        "userId": user_id,
+        "parentId": parent_id,
+    }
+    if exclude_folder_id is not None:
+        query["_id"] = {"$ne": exclude_folder_id}
+
+    # Use regex for case-insensitive match since we can't rely on collation in query
+    existing = await database["folders"].find_one({
+        **query,
+        "name": {"$regex": f"^{re.escape(name)}$", "$options": "i"},
+    })
+    if existing is not None:
+        raise ApiError(409, "DUPLICATE_FOLDER_NAME", "A folder with this name already exists in this location")
+
+
+import re
+
+
+async def _get_all_descendant_ids(
+    database: DatabaseDependency,
+    folder_id: ObjectId,
+) -> set[ObjectId]:
+    """Get all descendant folder IDs recursively."""
+    descendants: set[ObjectId] = set()
+    to_check = [folder_id]
+
+    while to_check:
+        current_batch = to_check
+        to_check = []
+
+        cursor = database["folders"].find(
+            {"parentId": {"$in": current_batch}},
+            {"_id": 1},
+        )
+        children = await cursor.to_list(length=None)
+
+        for child in children:
+            child_id = child["_id"]
+            if child_id not in descendants:
+                descendants.add(child_id)
+                to_check.append(child_id)
+
+    return descendants
+
+
+async def _count_problems_in_folder(
+    database: DatabaseDependency,
+    user_id: ObjectId,
+    folder_id: ObjectId | None,
+) -> int:
+    """Count non-deleted problems in a folder (None = unfiled)."""
+    query: dict[str, Any] = {"userId": user_id, "isDeleted": False}
+    if folder_id is None:
+        query["folderId"] = None
+    else:
+        query["folderId"] = str(folder_id)
+    return await database["problems"].count_documents(query)
+
+
+async def _count_problems_in_folder_tree(
+    database: DatabaseDependency,
+    user_id: ObjectId,
+    folder_id: ObjectId,
+) -> int:
+    """Count non-deleted problems in a folder and all its descendants."""
+    # Get all descendants
+    descendant_ids = await _get_all_descendant_ids(database, folder_id)
+    all_folder_ids = {folder_id} | descendant_ids
+
+    # Count problems in all these folders
+    query: dict[str, Any] = {
+        "userId": user_id,
+        "isDeleted": False,
+        "folderId": {"$in": [str(fid) for fid in all_folder_ids]},
+    }
+    return await database["problems"].count_documents(query)
+
+
+def _build_folder_tree(
+    folders: list[dict[str, Any]],
+    counts_by_folder: dict[str, int],
+    parent_id: ObjectId | None = None,
+) -> list[FolderNodePayload]:
+    """Build nested folder tree from flat list, sorted alphabetically by name."""
+    children = [f for f in folders if f.get("parentId") == parent_id]
+    # Sort alphabetically by name
+    children = sorted(children, key=lambda f: f["name"].lower())
+
+    result = []
+    for folder in children:
+        folder_id = str(folder["_id"])
+        node = FolderNodePayload(
+            id=folder_id,
+            name=folder["name"],
+            parentId=str(folder["parentId"]) if folder.get("parentId") else None,
+            problemCount=counts_by_folder.get(folder_id, 0),
+            children=_build_folder_tree(folders, counts_by_folder, folder["_id"]),
+            createdAt=folder["createdAt"],
+            updatedAt=folder["updatedAt"],
+        )
+        result.append(node)
+
+    return result
+
+
+def _serialize_folder(folder: dict[str, Any]) -> FolderPayload:
+    return FolderPayload(
+        id=str(folder["_id"]),
+        name=folder["name"],
+        parentId=str(folder["parentId"]) if folder.get("parentId") else None,
+        createdAt=folder["createdAt"],
+        updatedAt=folder["updatedAt"],
+    )
+
+
+@router.get("", response_model=FolderTreeResponse)
+async def list_folders_tree(
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> FolderTreeResponse:
+    """List all folders as a tree with recursive problem counts."""
+    user_id = current_user["_id"]
+
+    # Get all user's folders
+    cursor = database["folders"].find({"userId": user_id})
+    folders = await cursor.to_list(length=None)
+
+    # Get problem counts for each folder (recursive)
+    counts_by_folder: dict[str, int] = {}
+    for folder in folders:
+        folder_id = folder["_id"]
+        count = await _count_problems_in_folder_tree(database, user_id, folder_id)
+        counts_by_folder[str(folder_id)] = count
+
+    # Build tree
+    items = _build_folder_tree(folders, counts_by_folder, parent_id=None)
+
+    # Calculate all problems count and unfiled count
+    all_problems_count = await database["problems"].count_documents({
+        "userId": user_id,
+        "isDeleted": False,
+    })
+    unfiled_count = await _count_problems_in_folder(database, user_id, None)
+
+    return FolderTreeResponse(
+        allProblemsCount=all_problems_count,
+        unfiledCount=unfiled_count,
+        items=items,
+    )
+
+
+@router.post("", response_model=FolderResponse, status_code=201)
+async def create_folder(
+    payload: CreateFolderRequest,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> FolderResponse:
+    """Create a new folder."""
+    user_id = current_user["_id"]
+    name = _normalize_folder_name(payload.name)
+
+    # Validate parent if provided
+    parent_id: ObjectId | None = None
+    if payload.parentId is not None:
+        parent = await database["folders"].find_one({"_id": parse_object_id(payload.parentId, resource_name="Folder")})
+        if parent is None:
+            raise ApiError(404, "NOT_FOUND", "Parent folder not found")
+        if parent.get("userId") != user_id:
+            raise ApiError(403, "FORBIDDEN", "Forbidden")
+        parent_id = parent["_id"]
+
+    # Check for sibling name conflict
+    await _check_sibling_name_conflict(database, user_id, name, parent_id)
+
+    now = datetime.now(UTC)
+    folder = {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "name": name,
+        "parentId": parent_id,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+    await database["folders"].insert_one(folder)
+    return FolderResponse(folder=_serialize_folder(folder))
+
+
+@router.get("/{folder_id}", response_model=FolderResponse)
+async def get_folder(
+    folder_id: str,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> FolderResponse:
+    """Get a single folder by ID."""
+    user_id = current_user["_id"]
+    folder = await _get_owned_folder(database, folder_id, user_id)
+    return FolderResponse(folder=_serialize_folder(folder))
+
+
+@router.patch("/{folder_id}", response_model=FolderResponse)
+async def update_folder(
+    folder_id: str,
+    payload: UpdateFolderRequest,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> FolderResponse:
+    """Rename or move a folder."""
+    user_id = current_user["_id"]
+    folder = await _get_owned_folder(database, folder_id, user_id)
+    folder_oid = folder["_id"]
+
+    updates: dict[str, Any] = {"updatedAt": datetime.now(UTC)}
+
+    # Handle rename
+    if payload.name is not None:
+        new_name = _normalize_folder_name(payload.name)
+        if new_name.lower() != folder["name"].lower():
+            await _check_sibling_name_conflict(
+                database, user_id, new_name, folder.get("parentId"), exclude_folder_id=folder_oid
+            )
+        updates["name"] = new_name
+
+    # Handle move
+    if "parentId" in payload.model_fields_set:
+        new_parent_id: ObjectId | None = None
+
+        if payload.parentId is not None:
+            new_parent = await database["folders"].find_one({
+                "_id": parse_object_id(payload.parentId, resource_name="Folder")
+            })
+            if new_parent is None:
+                raise ApiError(404, "NOT_FOUND", "Parent folder not found")
+            if new_parent.get("userId") != user_id:
+                raise ApiError(403, "FORBIDDEN", "Forbidden")
+            new_parent_id = new_parent["_id"]
+
+        # Check for cycle (can't move folder under itself or its descendants)
+        if new_parent_id is not None:
+            if new_parent_id == folder_oid:
+                raise ApiError(400, "INVALID_MOVE", "Cannot move folder under itself")
+
+            descendants = await _get_all_descendant_ids(database, folder_oid)
+            if new_parent_id in descendants:
+                raise ApiError(400, "INVALID_MOVE", "Cannot move folder under its descendant")
+
+        # Check for sibling name conflict in new location
+        if payload.name is None:
+            # Name not changing, check conflict with current name
+            await _check_sibling_name_conflict(
+                database, user_id, updates.get("name", folder["name"]), new_parent_id, exclude_folder_id=folder_oid
+            )
+
+        updates["parentId"] = new_parent_id
+
+    await database["folders"].update_one({"_id": folder_oid}, {"$set": updates})
+    folder.update(updates)
+    return FolderResponse(folder=_serialize_folder(folder))
+
+
+@router.delete("/{folder_id}", response_model=DeleteFolderResponse)
+async def delete_folder(
+    folder_id: str,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> DeleteFolderResponse:
+    """Delete an empty folder."""
+    user_id = current_user["_id"]
+    folder = await _get_owned_folder(database, folder_id, user_id)
+    folder_oid = folder["_id"]
+
+    # Check for child folders
+    child_count = await database["folders"].count_documents({"parentId": folder_oid})
+    if child_count > 0:
+        raise ApiError(400, "FOLDER_NOT_EMPTY", "Cannot delete folder with subfolders")
+
+    # Check for problems in this folder
+    problem_count = await _count_problems_in_folder(database, user_id, folder_oid)
+    if problem_count > 0:
+        raise ApiError(400, "FOLDER_NOT_EMPTY", "Cannot delete folder with problems")
+
+    await database["folders"].delete_one({"_id": folder_oid})
+    return DeleteFolderResponse(ok=True)

--- a/backend/app/presentation/folders.py
+++ b/backend/app/presentation/folders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
@@ -107,9 +108,6 @@ async def _check_sibling_name_conflict(
     })
     if existing is not None:
         raise ApiError(409, "DUPLICATE_FOLDER_NAME", "A folder with this name already exists in this location")
-
-
-import re
 
 
 async def _get_all_descendant_ids(

--- a/backend/tests/api/test_folders.py
+++ b/backend/tests/api/test_folders.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.main import create_app
+from app.presentation.deps import get_current_user, get_database
+from app.presentation.errors import ApiError
+
+
+class FakeInsertOneResult:
+    def __init__(self, inserted_id: Any) -> None:
+        self.inserted_id = inserted_id
+
+
+class FakeUpdateResult:
+    def __init__(self, modified_count: int) -> None:
+        self.modified_count = modified_count
+
+
+class FakeDeleteResult:
+    def __init__(self, deleted_count: int) -> None:
+        self.deleted_count = deleted_count
+
+
+class FakeCursor:
+    def __init__(self, documents: list[dict[str, Any]]) -> None:
+        self._documents = [deepcopy(document) for document in documents]
+
+    def sort(self, field: str, direction: int) -> FakeCursor:
+        reverse = direction < 0
+        self._documents.sort(
+            key=lambda document: cast(Any, document.get(field, "")),
+            reverse=reverse,
+        )
+        return self
+
+    def limit(self, amount: int) -> FakeCursor:
+        return self
+
+    async def to_list(self, length: int | None = None) -> list[dict[str, Any]]:
+        return [deepcopy(document) for document in self._documents]
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self._documents: list[dict[str, Any]] = []
+
+    def seed(self, *documents: dict[str, Any]) -> None:
+        self._documents.extend(deepcopy(list(documents)))
+
+    async def find_one(self, query: dict[str, Any]) -> dict[str, Any] | None:
+        for document in self._documents:
+            if _matches(document, query):
+                return deepcopy(document)
+        return None
+
+    async def insert_one(self, document: dict[str, Any]) -> FakeInsertOneResult:
+        stored = deepcopy(document)
+        if "_id" not in stored:
+            stored["_id"] = ObjectId()
+        self._documents.append(stored)
+        return FakeInsertOneResult(stored["_id"])
+
+    async def update_one(self, query: dict[str, Any], update: dict[str, Any]) -> FakeUpdateResult:
+        for document in self._documents:
+            if _matches(document, query):
+                for key, value in update.get("$set", {}).items():
+                    document[key] = deepcopy(value)
+                return FakeUpdateResult(1)
+        return FakeUpdateResult(0)
+
+    async def delete_one(self, query: dict[str, Any]) -> FakeDeleteResult:
+        for i, document in enumerate(self._documents):
+            if _matches(document, query):
+                del self._documents[i]
+                return FakeDeleteResult(1)
+        return FakeDeleteResult(0)
+
+    async def count_documents(self, query: dict[str, Any]) -> int:
+        return sum(1 for document in self._documents if _matches(document, query))
+
+    def find(self, query: dict[str, Any], projection: dict[str, Any] | None = None) -> FakeCursor:
+        matches = [document for document in self._documents if _matches(document, query)]
+        return FakeCursor(matches)
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self._collections = {
+            "problems": FakeCollection(),
+            "tags": FakeCollection(),
+            "folders": FakeCollection(),
+            "users": FakeCollection(),
+            "sessions": FakeCollection(),
+        }
+
+    def __getitem__(self, name: str) -> FakeCollection:
+        return self._collections[name]
+
+
+def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
+    for key, value in query.items():
+        actual = document.get(key)
+        if isinstance(value, dict):
+            if "$in" in value:
+                if actual not in value["$in"]:
+                    return False
+                continue
+            if "$ne" in value:
+                if actual == value["$ne"]:
+                    return False
+                continue
+            if "$regex" in value:
+                import re
+                pattern = value["$regex"]
+                options = value.get("$options", "")
+                flags = re.IGNORECASE if "i" in options else 0
+                if not re.search(pattern, str(actual or ""), flags):
+                    return False
+                continue
+        if isinstance(actual, list):
+            if value not in actual:
+                return False
+            continue
+        if actual != value:
+            return False
+    return True
+
+
+def make_user(user_id: ObjectId, username: str) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": user_id,
+        "username": username,
+        "status": "active",
+        "createdAt": now,
+        "updatedAt": now,
+        "lastLoginAt": None,
+    }
+
+
+def make_folder(
+    user_id: ObjectId,
+    name: str,
+    *,
+    parent_id: ObjectId | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "name": name,
+        "parentId": parent_id,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def make_problem(
+    user_id: ObjectId,
+    *,
+    text: str = "What is 2+2?",
+    folder_id: str | None = None,
+    is_deleted: bool = False,
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "text": text,
+        "problemType": "short-answer",
+        "graphDsl": None,
+        "correctAnswer": {
+            "display": "4",
+            "normalizedText": "4",
+            "normalizedSet": [],
+            "format": "single",
+        },
+        "tags": ["math"],
+        "folderId": folder_id,
+        "isDeleted": is_deleted,
+        "deletedAt": now if is_deleted else None,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+@pytest_asyncio.fixture
+async def folders_app() -> FastAPI:
+    application = create_app()
+    database = FakeDatabase()
+    primary_user = make_user(ObjectId(), "student1")
+    secondary_user = make_user(ObjectId(), "student2")
+
+    application.state.fake_database = database
+    application.state.primary_user = primary_user
+    application.state.secondary_user = secondary_user
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_current_user] = lambda: deepcopy(primary_user)
+    return application
+
+
+@pytest_asyncio.fixture
+async def client(folders_app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=folders_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+# Tests
+
+
+@pytest.mark.asyncio
+async def test_create_root_folder(folders_app: FastAPI, client: AsyncClient) -> None:
+    response = await client.post("/api/v1/folders", json={"name": "Chapter 1"})
+    assert response.status_code == 201
+    body = response.json()["folder"]
+    assert body["name"] == "Chapter 1"
+    assert body["parentId"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_child_folder(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent = make_folder(user_id, "Chapter 1")
+    database["folders"].seed(parent)
+
+    response = await client.post(
+        "/api/v1/folders",
+        json={"name": "Section 1.1", "parentId": str(parent["_id"])},
+    )
+    assert response.status_code == 201
+    body = response.json()["folder"]
+    assert body["name"] == "Section 1.1"
+    assert body["parentId"] == str(parent["_id"])
+
+
+@pytest.mark.asyncio
+async def test_reject_empty_folder_name(folders_app: FastAPI, client: AsyncClient) -> None:
+    response = await client.post("/api/v1/folders", json={"name": ""})
+    assert response.status_code == 422  # validation error
+
+
+@pytest.mark.asyncio
+async def test_reject_whitespace_only_name(folders_app: FastAPI, client: AsyncClient) -> None:
+    response = await client.post("/api/v1/folders", json={"name": "   "})
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+@pytest.mark.asyncio
+async def test_reject_over_200_char_name(folders_app: FastAPI, client: AsyncClient) -> None:
+    long_name = "x" * 201
+    response = await client.post("/api/v1/folders", json={"name": long_name})
+    assert response.status_code == 422  # validation error
+
+
+@pytest.mark.asyncio
+async def test_reject_duplicate_sibling_name_case_insensitive(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent = make_folder(user_id, "Chapter 1")
+    child = make_folder(user_id, "Section 1", parent_id=parent["_id"])
+    database["folders"].seed(parent, child)
+
+    response = await client.post(
+        "/api/v1/folders",
+        json={"name": "SECTION 1", "parentId": str(parent["_id"])},
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "DUPLICATE_FOLDER_NAME"
+
+
+@pytest.mark.asyncio
+async def test_allow_same_name_under_different_parents(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent1 = make_folder(user_id, "Chapter 1")
+    parent2 = make_folder(user_id, "Chapter 2")
+    child1 = make_folder(user_id, "Section 1", parent_id=parent1["_id"])
+    database["folders"].seed(parent1, parent2, child1)
+
+    response = await client.post(
+        "/api/v1/folders",
+        json={"name": "Section 1", "parentId": str(parent2["_id"])},
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_rename_folder(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    database["folders"].seed(folder)
+
+    response = await client.patch(
+        f"/api/v1/folders/{folder['_id']}",
+        json={"name": "Chapter 1 Revised"},
+    )
+    assert response.status_code == 200
+    body = response.json()["folder"]
+    assert body["name"] == "Chapter 1 Revised"
+    assert body["parentId"] is None
+
+
+@pytest.mark.asyncio
+async def test_move_folder_to_another_parent(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent1 = make_folder(user_id, "Chapter 1")
+    parent2 = make_folder(user_id, "Chapter 2")
+    child = make_folder(user_id, "Section 1", parent_id=parent1["_id"])
+    database["folders"].seed(parent1, parent2, child)
+
+    response = await client.patch(
+        f"/api/v1/folders/{child['_id']}",
+        json={"parentId": str(parent2["_id"])},
+    )
+    assert response.status_code == 200
+    body = response.json()["folder"]
+    assert body["parentId"] == str(parent2["_id"])
+
+
+@pytest.mark.asyncio
+async def test_move_folder_to_root(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent = make_folder(user_id, "Chapter 1")
+    child = make_folder(user_id, "Section 1", parent_id=parent["_id"])
+    database["folders"].seed(parent, child)
+
+    response = await client.patch(
+        f"/api/v1/folders/{child['_id']}",
+        json={"parentId": None},
+    )
+    assert response.status_code == 200
+    body = response.json()["folder"]
+    assert body["parentId"] is None
+
+
+@pytest.mark.asyncio
+async def test_reject_move_under_self(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    database["folders"].seed(folder)
+
+    response = await client.patch(
+        f"/api/v1/folders/{folder['_id']}",
+        json={"parentId": str(folder["_id"])},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_MOVE"
+
+
+@pytest.mark.asyncio
+async def test_reject_move_under_descendant(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent = make_folder(user_id, "Chapter 1")
+    child = make_folder(user_id, "Section 1", parent_id=parent["_id"])
+    grandchild = make_folder(user_id, "Subsection 1.1", parent_id=child["_id"])
+    database["folders"].seed(parent, child, grandchild)
+
+    response = await client.patch(
+        f"/api/v1/folders/{parent['_id']}",
+        json={"parentId": str(grandchild["_id"])},
+    )
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_MOVE"
+
+
+@pytest.mark.asyncio
+async def test_block_delete_folder_with_subfolders(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    parent = make_folder(user_id, "Chapter 1")
+    child = make_folder(user_id, "Section 1", parent_id=parent["_id"])
+    database["folders"].seed(parent, child)
+
+    response = await client.delete(f"/api/v1/folders/{parent['_id']}")
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "FOLDER_NOT_EMPTY"
+
+
+@pytest.mark.asyncio
+async def test_block_delete_folder_with_problems(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    problem = make_problem(user_id, folder_id=str(folder["_id"]))
+    database["folders"].seed(folder)
+    database["problems"].seed(problem)
+
+    response = await client.delete(f"/api/v1/folders/{folder['_id']}")
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "FOLDER_NOT_EMPTY"
+
+
+@pytest.mark.asyncio
+async def test_delete_empty_folder(folders_app: FastAPI, client: AsyncClient) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    database["folders"].seed(folder)
+
+    response = await client.delete(f"/api/v1/folders/{folder['_id']}")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_folder_tree_with_recursive_counts(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    # Create folder structure:
+    # Chapter 1 (2 problems)
+    #   Section 1.1 (1 problem)
+    # Chapter 2 (1 problem)
+    # Unfiled: 2 problems
+
+    chapter1 = make_folder(user_id, "Chapter 1")
+    section1_1 = make_folder(user_id, "Section 1.1", parent_id=chapter1["_id"])
+    chapter2 = make_folder(user_id, "Chapter 2")
+
+    database["folders"].seed(chapter1, section1_1, chapter2)
+
+    # Problems
+    p1 = make_problem(user_id, text="P1", folder_id=str(chapter1["_id"]))
+    p2 = make_problem(user_id, text="P2", folder_id=str(chapter1["_id"]))
+    p3 = make_problem(user_id, text="P3", folder_id=str(section1_1["_id"]))
+    p4 = make_problem(user_id, text="P4", folder_id=str(chapter2["_id"]))
+    p5 = make_problem(user_id, text="P5", folder_id=None)
+    p6 = make_problem(user_id, text="P6")  # no folderId field
+
+    database["problems"].seed(p1, p2, p3, p4, p5, p6)
+
+    response = await client.get("/api/v1/folders")
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["allProblemsCount"] == 6
+    assert body["unfiledCount"] == 2
+
+    # Find Chapter 1 in items
+    chapter1_item = next(
+        (item for item in body["items"] if item["name"] == "Chapter 1"), None
+    )
+    assert chapter1_item is not None
+    assert chapter1_item["problemCount"] == 3  # 2 in chapter + 1 in section
+
+    # Check Section 1.1 is child
+    assert len(chapter1_item["children"]) == 1
+    section1_1_item = chapter1_item["children"][0]
+    assert section1_1_item["name"] == "Section 1.1"
+    assert section1_1_item["problemCount"] == 1
+
+    # Find Chapter 2
+    chapter2_item = next(
+        (item for item in body["items"] if item["name"] == "Chapter 2"), None
+    )
+    assert chapter2_item is not None
+    assert chapter2_item["problemCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cross_user_folder_access_denied(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    other_user_id = folders_app.state.secondary_user["_id"]
+
+    other_folder = make_folder(other_user_id, "Other's Folder")
+    database["folders"].seed(other_folder)
+
+    # Try to access other user's folder
+    response = await client.get(f"/api/v1/folders/{other_folder['_id']}")
+    assert response.status_code == 403
+
+    # Try to rename
+    response = await client.patch(
+        f"/api/v1/folders/{other_folder['_id']}",
+        json={"name": "Hacked"},
+    )
+    assert response.status_code == 403
+
+    # Try to delete
+    response = await client.delete(f"/api/v1/folders/{other_folder['_id']}")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_folder_tree_alphabetical_order(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    # Create folders in non-alphabetical order
+    folder_c = make_folder(user_id, "Chapter C")
+    folder_a = make_folder(user_id, "Chapter A")
+    folder_b = make_folder(user_id, "Chapter B")
+
+    child_c = make_folder(user_id, "Section C", parent_id=folder_c["_id"])
+    child_a = make_folder(user_id, "Section A", parent_id=folder_c["_id"])
+    child_b = make_folder(user_id, "Section B", parent_id=folder_c["_id"])
+
+    database["folders"].seed(folder_c, folder_a, folder_b, child_c, child_a, child_b)
+
+    response = await client.get("/api/v1/folders")
+    assert response.status_code == 200
+    body = response.json()
+
+    # Root level should be alphabetically sorted
+    root_names = [item["name"] for item in body["items"]]
+    assert root_names == ["Chapter A", "Chapter B", "Chapter C"]
+
+    # Children of Chapter C should be alphabetically sorted
+    chapter_c = next(item for item in body["items"] if item["name"] == "Chapter C")
+    child_names = [child["name"] for child in chapter_c["children"]]
+    assert child_names == ["Section A", "Section B", "Section C"]
+
+
+@pytest.mark.asyncio
+async def test_deleted_problems_not_counted(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = folders_app.state.fake_database
+    user_id = folders_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    database["folders"].seed(folder)
+
+    # Active problem
+    p1 = make_problem(user_id, text="Active", folder_id=str(folder["_id"]))
+    # Deleted problem
+    p2 = make_problem(user_id, text="Deleted", folder_id=str(folder["_id"]), is_deleted=True)
+
+    database["problems"].seed(p1, p2)
+
+    response = await client.get("/api/v1/folders")
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["allProblemsCount"] == 1  # only active
+
+    folder_item = body["items"][0]
+    assert folder_item["problemCount"] == 1  # only active problem
+
+
+@pytest.mark.asyncio
+async def test_non_existent_parent_returns_404(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    fake_id = str(ObjectId())
+
+    response = await client.post(
+        "/api/v1/folders",
+        json={"name": "Test", "parentId": fake_id},
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_non_existent_folder_returns_404(
+    folders_app: FastAPI, client: AsyncClient
+) -> None:
+    fake_id = str(ObjectId())
+
+    response = await client.get(f"/api/v1/folders/{fake_id}")
+    assert response.status_code == 404
+
+    response = await client.patch(f"/api/v1/folders/{fake_id}", json={"name": "Test"})
+    assert response.status_code == 404
+
+    response = await client.delete(f"/api/v1/folders/{fake_id}")
+    assert response.status_code == 404

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -11,6 +11,7 @@ from app.infrastructure.storage.mongo import (
     AsyncMongoClientFactory,
     CANONICAL_SOLUTIONS_COLLECTION,
     COACHING_CONVERSATIONS_COLLECTION,
+    FOLDERS_COLLECTION,
     MongoClientAdapter,
     SOLUTION_GENERATION_TASKS_COLLECTION,
     TAGS_COLLECTION,
@@ -136,6 +137,7 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
         SOLUTION_GENERATION_TASKS_COLLECTION,
         CANONICAL_SOLUTIONS_COLLECTION,
         COACHING_CONVERSATIONS_COLLECTION,
+        FOLDERS_COLLECTION,
     ]
     assert database[TAGS_COLLECTION].index_calls == [
         {
@@ -147,5 +149,15 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
         {
             "keys": [("problem_id", 1), ("user_id", 1)],
             "kwargs": {"unique": True, "name": "problem_user_conversation_unique"},
+        }
+    ]
+    assert database[FOLDERS_COLLECTION].index_calls == [
+        {
+            "keys": [("userId", 1), ("parentId", 1), ("name", 1)],
+            "kwargs": {
+                "unique": True,
+                "name": "user_parent_folder_unique",
+                "collation": {"locale": "en", "strength": 2},
+            },
         }
     ]


### PR DESCRIPTION
## Summary

- Add the backend folder entity and dedicated folder API for creating, listing, renaming, moving, and deleting user-scoped problem folders
- Implement folder tree endpoint with recursive problem counts
- Include virtual counts for All Problems and Unfiled

## Linked Issue

Closes #193

## Issue Alignment

This PR implements the issue by:

- Adding a `folders` Mongo collection with user/parent/name unique index (case-insensitive via collation)
- Implementing folder CRUD endpoints: GET (tree), GET (single), POST, PATCH, DELETE
- Enforcing folder ownership, sibling uniqueness, cycle prevention, and non-empty delete blocking
- Returning recursive problem counts in folder tree payload
- Including All Problems and Unfiled counts in the response

Scope covered:

- Folder collection and indexes in `mongo.py`
- Folder router module with all CRUD operations
- Folder tree with alphabetical ordering and recursive counts
- Comprehensive test coverage for all operations

Out of scope / intentionally not included:

- Filtering `GET /problems` by `folderId`
- Assigning or bulk-moving problems into folders
- Frontend sidebar, folder menus, or bulk move UI
- Folder sharing, colors, icons, drag and drop, or manual ordering

## Implementation Notes

- Used case-insensitive collation for the user/parent/name unique index
- Cycle prevention checks self-parenting and descendant parenting
- Name validation: trimmed, non-empty, max 200 characters
- Alphabetical sorting uses `name.lower()` for consistent ordering

## Tests

Commands run:

- `uv run pytest tests/api/test_folders.py` — passed (21 tests)
- `uv run pytest tests/api/test_problems.py tests/api/test_ingestion.py tests/api/test_auth.py` — passed (47 tests)
- `uv run pytest tests/infrastructure/test_mongo.py` — passed (5 tests)
- `uv run pytest` — passed (272 tests, 1 skipped)

Automated tests added or updated:

- `test_folders.py` with 21 tests covering:
  - Creating root and child folders
  - Rejecting empty, whitespace-only, over-200-char names
  - Case-insensitive duplicate sibling checks
  - Renaming and moving folders
  - Cycle prevention (self and descendant)
  - Non-empty deletion blocking
  - Folder tree with recursive counts
  - Alphabetical ordering
  - Deleted problems not counted
  - Cross-user access denied (403)
  - Non-existent resources (404)
- `test_mongo.py` updated to expect `folders` collection and index

Manual verification:

- Not applicable - all behavior covered by automated tests

## Deviations From Issue Plan

None. Implementation follows the chosen approach exactly.

## Follow-Up Work

Follow-up issues should add problem folder assignment/filtering and the frontend Problems sidebar/bulk-move UI.