### PR TITLE
feat: add problem folder assignment and server-side folder filtering

### DIFF
--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -6,12 +6,14 @@ import re
 
 from typing import Any, Annotated
 
+from bson import ObjectId
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
 from app.domain.models import ProblemType
 from app.domain.normalization import normalize_answer
 from app.presentation.deps import DatabaseDependency, get_current_user
+from app.presentation.errors import ApiError
 from app.presentation.helpers import build_problem_image_url, get_owned_problem, normalize_tags, parse_object_id
 from app.presentation.schemas import CorrectAnswerPayload
 from app.presentation.tags import _register_tags
@@ -55,6 +57,7 @@ class ProblemSummaryPayload(BaseModel):
     createdAt: datetime
     updatedAt: datetime
     imageUrl: str | None = None
+    folderId: str | None = None
 
 
 class ProblemDetailPayload(ProblemSummaryPayload):
@@ -88,6 +91,19 @@ class ProblemTagsResponse(BaseModel):
 
 class SolutionStatusResponse(BaseModel):
     status: str
+
+
+class SetProblemFolderRequest(BaseModel):
+    folderId: str | None = None
+
+
+class BulkSetFolderRequest(BaseModel):
+    problemIds: list[str] = Field(min_length=1)
+    folderId: str | None = None
+
+
+class BulkSetFolderResponse(BaseModel):
+    ok: bool
 
 
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
@@ -127,6 +143,7 @@ def _serialize_correct_answer(problem: dict[str, Any]) -> CorrectAnswerPayload:
 
 
 def _serialize_problem_summary(problem: dict[str, Any]) -> ProblemSummaryPayload:
+    folder_id = problem.get("folderId")
     return ProblemSummaryPayload(
         id=str(problem["_id"]),
         text=str(problem["text"]),
@@ -141,6 +158,7 @@ def _serialize_problem_summary(problem: dict[str, Any]) -> ProblemSummaryPayload
         imageUrl=build_problem_image_url(str(problem["_id"]))
         if problem.get("sourceImage")
         else None,
+        folderId=folder_id if folder_id else None,
     )
 
 
@@ -151,6 +169,48 @@ def _serialize_problem_detail(problem: dict[str, Any]) -> ProblemDetailPayload:
         correctAnswer=_serialize_correct_answer(problem),
         origin=_serialize_origin(problem),
     )
+
+
+async def _get_owned_folder(
+    database: DatabaseDependency,
+    folder_id: str,
+    user_id: ObjectId,
+) -> dict[str, Any]:
+    """Get a folder by ID, verifying ownership."""
+    object_id = parse_object_id(folder_id, resource_name="Folder")
+    folder = await database["folders"].find_one({"_id": object_id})
+    if folder is None:
+        raise ApiError(404, "NOT_FOUND", "Folder not found")
+    if folder.get("userId") != user_id:
+        raise ApiError(403, "FORBIDDEN", "Forbidden")
+    return folder
+
+
+async def _get_all_descendant_folder_ids(
+    database: DatabaseDependency,
+    folder_id: ObjectId,
+) -> set[ObjectId]:
+    """Get all descendant folder IDs recursively."""
+    descendants: set[ObjectId] = set()
+    to_check = [folder_id]
+
+    while to_check:
+        current_batch = to_check
+        to_check = []
+
+        cursor = database["folders"].find(
+            {"parentId": {"$in": current_batch}},
+            {"_id": 1},
+        )
+        children = await cursor.to_list(length=None)
+
+        for child in children:
+            child_id = child["_id"]
+            if child_id not in descendants:
+                descendants.add(child_id)
+                to_check.append(child_id)
+
+    return descendants
 
 
 
@@ -173,10 +233,12 @@ async def list_problems(
     tag: str | None = Query(default=None),
     problem_type: ProblemType | None = Query(default=None, alias="type"),
     q: str | None = Query(default=None),
+    folder_id: str | None = Query(default=None, alias="folderId"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
 ) -> ProblemListResponse:
-    query: dict[str, Any] = {"userId": current_user["_id"], "isDeleted": False}
+    user_id = current_user["_id"]
+    query: dict[str, Any] = {"userId": user_id, "isDeleted": False}
     if tag is not None:
         query["tags"] = tag
     if problem_type is not None:
@@ -190,6 +252,19 @@ async def list_problems(
                 {"tags": {"$regex": escaped, "$options": "i"}},
             ]
 
+    # Handle folder filtering
+    if folder_id is not None:
+        if folder_id == "unfiled":
+            # Unfiled: problems where folderId is null or absent
+            query["folderId"] = None
+        else:
+            # Real folder: validate ownership and include descendants
+            folder = await _get_owned_folder(database, folder_id, user_id)
+            folder_oid = folder["_id"]
+            descendant_ids = await _get_all_descendant_folder_ids(database, folder_oid)
+            all_folder_ids = {folder_oid} | descendant_ids
+            query["folderId"] = {"$in": [str(fid) for fid in all_folder_ids]}
+
     total = await database["problems"].count_documents(query)
     cursor = database["problems"].find(query).sort("updatedAt", -1)
     cursor = cursor.skip((page - 1) * page_size).limit(page_size)
@@ -200,6 +275,42 @@ async def list_problems(
         pageSize=page_size,
         total=total,
     )
+
+
+@router.patch("/bulk-folder", response_model=BulkSetFolderResponse)
+async def bulk_set_problem_folder(
+    payload: BulkSetFolderRequest,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> BulkSetFolderResponse:
+    """Bulk assign problems to a folder or Unfiled."""
+    user_id = current_user["_id"]
+
+    # Validate target folder if provided
+    target_folder_id: str | None = None
+    if payload.folderId is not None:
+        folder = await _get_owned_folder(database, payload.folderId, user_id)
+        target_folder_id = str(folder["_id"])
+
+    # Validate all problem IDs and ownership
+    problem_object_ids: list[ObjectId] = []
+    for problem_id_str in payload.problemIds:
+        problem_id = parse_object_id(problem_id_str, resource_name="Problem")
+        problem = await database["problems"].find_one({"_id": problem_id})
+        if problem is None or problem.get("isDeleted", False):
+            raise ApiError(404, "NOT_FOUND", f"Problem {problem_id_str} not found")
+        if problem.get("userId") != user_id:
+            raise ApiError(403, "FORBIDDEN", f"Problem {problem_id_str} not owned")
+        problem_object_ids.append(problem_id)
+
+    # Update all problems
+    now = datetime.now(UTC)
+    await database["problems"].update_many(
+        {"_id": {"$in": problem_object_ids}},
+        {"$set": {"folderId": target_folder_id, "updatedAt": now}},
+    )
+
+    return BulkSetFolderResponse(ok=True)
 
 
 @router.get("/{problem_id}", response_model=ProblemResponse)
@@ -257,6 +368,36 @@ async def update_problem(
     await database["problems"].update_one({"_id": problem["_id"]}, {"$set": updates})
     updated_problem = deepcopy(problem)
     updated_problem.update(updates)
+    return ProblemResponse(problem=_serialize_problem_detail(updated_problem))
+
+
+@router.patch("/{problem_id}/folder", response_model=ProblemResponse)
+async def set_problem_folder(
+    problem_id: str,
+    payload: SetProblemFolderRequest,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> ProblemResponse:
+    """Assign a problem to a folder or Unfiled."""
+    user_id = current_user["_id"]
+    problem = await get_owned_problem(database, problem_id, user_id, allow_deleted=False)
+
+    # Validate target folder if provided
+    target_folder_id: str | None = None
+    if payload.folderId is not None:
+        folder = await _get_owned_folder(database, payload.folderId, user_id)
+        target_folder_id = str(folder["_id"])
+
+    # Update the problem
+    now = datetime.now(UTC)
+    await database["problems"].update_one(
+        {"_id": problem["_id"]},
+        {"$set": {"folderId": target_folder_id, "updatedAt": now}},
+    )
+
+    updated_problem = deepcopy(problem)
+    updated_problem["folderId"] = target_folder_id
+    updated_problem["updatedAt"] = now
     return ProblemResponse(problem=_serialize_problem_detail(updated_problem))
 
 

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -93,10 +93,19 @@ class FakeCollection:
                 return FakeUpdateResult(1)
         return FakeUpdateResult(0)
 
+    async def update_many(self, query: dict[str, Any], update: dict[str, Any]) -> FakeUpdateResult:
+        count = 0
+        for document in self._documents:
+            if _matches(document, query):
+                for key, value in update.get("$set", {}).items():
+                    document[key] = deepcopy(value)
+                count += 1
+        return FakeUpdateResult(count)
+
     async def count_documents(self, query: dict[str, Any]) -> int:
         return sum(1 for document in self._documents if _matches(document, query))
 
-    def find(self, query: dict[str, Any]) -> FakeCursor:
+    def find(self, query: dict[str, Any], projection: dict[str, Any] | None = None) -> FakeCursor:
         matches = [document for document in self._documents if _matches(document, query)]
         return FakeCursor(matches)
 
@@ -121,6 +130,7 @@ class FakeDatabase:
         self._collections = {
             "problems": FakeCollection(),
             "tags": FakeCollection(),
+            "folders": FakeCollection(),
             "ingestion_previews": FakeCollection(),
             "users": FakeCollection(),
             "sessions": FakeCollection(),
@@ -234,6 +244,7 @@ def make_problem(
     updated_at: datetime | None = None,
     tags: list[str] | None = None,
     is_deleted: bool = False,
+    folder_id: str | None = None,
 ) -> dict[str, Any]:
     now = updated_at or datetime.now(UTC)
     return {
@@ -272,6 +283,7 @@ def make_problem(
         },
         "isDeleted": is_deleted,
         "deletedAt": now if is_deleted else None,
+        "folderId": folder_id,
         "createdAt": now,
         "updatedAt": now,
     }
@@ -752,3 +764,318 @@ async def test_search_pagination_total_reflects_filtered(
     data = response.json()
     assert data["total"] == 5
     assert len(data["items"]) == 2
+
+
+# Folder assignment and filtering tests
+
+
+def make_folder(
+    user_id: ObjectId,
+    name: str,
+    *,
+    parent_id: ObjectId | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "name": name,
+        "parentId": parent_id,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+async def test_assign_single_problem_to_folder(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    problem = make_problem(user_id, text="Problem to move")
+    database["folders"].seed(folder)
+    database["problems"].seed(problem)
+
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/folder",
+        json={"folderId": str(folder["_id"])},
+    )
+    assert response.status_code == 200
+    body = response.json()["problem"]
+    assert body["folderId"] == str(folder["_id"])
+
+    # Verify stored
+    stored = database["problems"]._documents[0]
+    assert stored["folderId"] == str(folder["_id"])
+
+
+async def test_assign_problem_to_unfiled(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    problem = make_problem(user_id, text="Problem in folder", folder_id=str(folder["_id"]))
+    database["folders"].seed(folder)
+    database["problems"].seed(problem)
+
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/folder",
+        json={"folderId": None},
+    )
+    assert response.status_code == 200
+    body = response.json()["problem"]
+    assert body["folderId"] is None
+
+
+async def test_bulk_assign_problems_to_folder(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    p1 = make_problem(user_id, text="P1")
+    p2 = make_problem(user_id, text="P2")
+    p3 = make_problem(user_id, text="P3")
+    database["folders"].seed(folder)
+    database["problems"].seed(p1, p2, p3)
+
+    response = await client.patch(
+        "/api/v1/problems/bulk-folder",
+        json={
+            "problemIds": [str(p1["_id"]), str(p2["_id"])],
+            "folderId": str(folder["_id"]),
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    # Verify only p1 and p2 were updated
+    stored_p1 = next(p for p in database["problems"]._documents if p["_id"] == p1["_id"])
+    stored_p2 = next(p for p in database["problems"]._documents if p["_id"] == p2["_id"])
+    stored_p3 = next(p for p in database["problems"]._documents if p["_id"] == p3["_id"])
+    assert stored_p1["folderId"] == str(folder["_id"])
+    assert stored_p2["folderId"] == str(folder["_id"])
+    assert stored_p3.get("folderId") is None
+
+
+async def test_bulk_assign_to_unfiled(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    p1 = make_problem(user_id, text="P1", folder_id=str(folder["_id"]))
+    p2 = make_problem(user_id, text="P2", folder_id=str(folder["_id"]))
+    database["folders"].seed(folder)
+    database["problems"].seed(p1, p2)
+
+    response = await client.patch(
+        "/api/v1/problems/bulk-folder",
+        json={
+            "problemIds": [str(p1["_id"]), str(p2["_id"])],
+            "folderId": None,
+        },
+    )
+    assert response.status_code == 200
+
+    stored_p1 = next(p for p in database["problems"]._documents if p["_id"] == p1["_id"])
+    stored_p2 = next(p for p in database["problems"]._documents if p["_id"] == p2["_id"])
+    assert stored_p1["folderId"] is None
+    assert stored_p2["folderId"] is None
+
+
+async def test_reject_assign_to_nonexistent_folder(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    problem = make_problem(user_id, text="P1")
+    database["problems"].seed(problem)
+
+    fake_folder_id = str(ObjectId())
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/folder",
+        json={"folderId": fake_folder_id},
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+
+async def test_reject_assign_to_other_user_folder(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    other_user_id = problems_app.state.secondary_user["_id"]
+
+    other_folder = make_folder(other_user_id, "Other's folder")
+    problem = make_problem(user_id, text="P1")
+    database["folders"].seed(other_folder)
+    database["problems"].seed(problem)
+
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/folder",
+        json={"folderId": str(other_folder["_id"])},
+    )
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "FORBIDDEN"
+
+
+async def test_reject_bulk_move_other_user_problems(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    other_user_id = problems_app.state.secondary_user["_id"]
+
+    folder = make_folder(user_id, "My folder")
+    other_problem = make_problem(other_user_id, text="Other's problem")
+    database["folders"].seed(folder)
+    database["problems"].seed(other_problem)
+
+    response = await client.patch(
+        "/api/v1/problems/bulk-folder",
+        json={
+            "problemIds": [str(other_problem["_id"])],
+            "folderId": str(folder["_id"]),
+        },
+    )
+    assert response.status_code == 403
+    assert "FORBIDDEN" in response.json()["error"]["code"]
+
+
+async def test_filter_by_folder_includes_descendants(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    # Create folder hierarchy: Chapter 1 -> Section 1.1
+    chapter = make_folder(user_id, "Chapter 1")
+    section = make_folder(user_id, "Section 1.1", parent_id=chapter["_id"])
+    database["folders"].seed(chapter, section)
+
+    # Problems in different folders
+    p_chapter = make_problem(user_id, text="In Chapter", folder_id=str(chapter["_id"]))
+    p_section = make_problem(user_id, text="In Section", folder_id=str(section["_id"]))
+    p_unfiled = make_problem(user_id, text="Unfiled")
+    database["problems"].seed(p_chapter, p_section, p_unfiled)
+
+    # Filter by Chapter 1 should include both chapter and section problems
+    response = await client.get(f"/api/v1/problems?folderId={chapter['_id']}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    texts = {item["text"] for item in data["items"]}
+    assert texts == {"In Chapter", "In Section"}
+
+
+async def test_filter_by_unfiled(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    p_in_folder = make_problem(user_id, text="In folder", folder_id=str(folder["_id"]))
+    p_unfiled_null = make_problem(user_id, text="Unfiled null", folder_id=None)
+    p_unfiled_missing = make_problem(user_id, text="Unfiled missing")
+    del p_unfiled_missing["folderId"]  # Remove the field entirely
+
+    database["folders"].seed(folder)
+    database["problems"].seed(p_in_folder, p_unfiled_null, p_unfiled_missing)
+
+    response = await client.get("/api/v1/problems?folderId=unfiled")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    texts = {item["text"] for item in data["items"]}
+    assert texts == {"Unfiled null", "Unfiled missing"}
+
+
+async def test_omit_folder_id_returns_all_problems(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    p_in_folder = make_problem(user_id, text="In folder", folder_id=str(folder["_id"]))
+    p_unfiled = make_problem(user_id, text="Unfiled")
+
+    database["folders"].seed(folder)
+    database["problems"].seed(p_in_folder, p_unfiled)
+
+    response = await client.get("/api/v1/problems")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+
+
+async def test_folder_filter_composes_with_tag_and_search(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    p1 = make_problem(user_id, text="Algebra problem", tags=["algebra"], folder_id=str(folder["_id"]))
+    p2 = make_problem(user_id, text="Geometry problem", tags=["geometry"], folder_id=str(folder["_id"]))
+    p3 = make_problem(user_id, text="Another algebra", tags=["algebra"], folder_id=str(folder["_id"]))
+
+    database["folders"].seed(folder)
+    database["problems"].seed(p1, p2, p3)
+
+    # Filter by folder + tag
+    response = await client.get(f"/api/v1/problems?folderId={folder['_id']}&tag=algebra")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+
+    # Filter by folder + search
+    response = await client.get(f"/api/v1/problems?folderId={folder['_id']}&q=Algebra")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+
+
+async def test_problem_payload_includes_folder_id(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+
+    folder = make_folder(user_id, "Chapter 1")
+    problem = make_problem(user_id, text="Problem", folder_id=str(folder["_id"]))
+    database["folders"].seed(folder)
+    database["problems"].seed(problem)
+
+    # List endpoint
+    list_response = await client.get("/api/v1/problems")
+    assert list_response.status_code == 200
+    item = list_response.json()["items"][0]
+    assert item["folderId"] == str(folder["_id"])
+
+    # Detail endpoint
+    detail_response = await client.get(f"/api/v1/problems/{problem['_id']}")
+    assert detail_response.status_code == 200
+    body = detail_response.json()["problem"]
+    assert body["folderId"] == str(folder["_id"])


### PR DESCRIPTION
## Summary

- Add `folderId` field to problem list and detail payloads
- Add `PATCH /api/v1/problems/{problemId}/folder` for single problem folder assignment
- Add `PATCH /api/v1/problems/bulk-folder` for bulk problem folder assignment  
- Add `folderId` query param to `GET /api/v1/problems` with subtree filtering
- Validate folder ownership and problem ownership on all operations

## Linked Issue

Closes #194

## Issue Alignment

This PR implements the issue by:

- Adding `folderId` to `ProblemSummaryPayload` and `ProblemDetailPayload`
- Adding single folder assignment endpoint at `PATCH /problems/{problemId}/folder`
- Adding bulk folder assignment endpoint at `PATCH /problems/bulk-folder` (defined before dynamic routes)
- Extending `list_problems` with `folderId` query param:
  - `folderId` omitted: All Problems (no filter)
  - `folderId=unfiled`: only problems where `folderId` is null or absent
  - `folderId=<folderId>`: problems in the selected folder and all descendant folders
- Validating that target folders exist and belong to the current user
- Enforcing ownership for all addressed problems in single and bulk operations

Scope covered:

- `folderId` field in problem payloads
- Single problem folder assignment endpoint
- Bulk folder assignment endpoint
- `folderId` query param with descendant folder resolution
- Unfiled filtering (null/absent folderId)
- Folder ownership validation
- Problem ownership enforcement
- Comprehensive test coverage

Out of scope / intentionally not included:

- Frontend sidebar, selection UI, or folder picker
- Problem detail/edit folder assignment UI
- Folder sharing, colors, icons, or drag-and-drop
- Data migration for existing problems
- Counts in folder tree (handled by #193)

## Implementation Notes

- Static route `/bulk-folder` is defined before dynamic `/{problem_id}` routes to avoid shadowing
- Used `_get_all_descendant_folder_ids` helper for recursive folder subtree resolution
- Reused `_get_owned_folder` helper pattern from folders router
- `folderId` in payload is `null` when absent (consistent with API contract)

## Tests

Commands run:

- `uv run pytest tests/api/test_problems.py` — passed (28 tests)
- `uv run pytest tests/api/` — passed (151 tests)
- `uv run pytest` — passed (284 tests, 1 skipped)

Automated tests added or updated:

- `test_assign_single_problem_to_folder` — assign owned problem to owned folder
- `test_assign_problem_to_unfiled` — clear folderId to null
- `test_bulk_assign_problems_to_folder` — bulk move to folder
- `test_bulk_assign_to_unfiled` — bulk move to Unfiled
- `test_reject_assign_to_nonexistent_folder` — 404 for invalid folder ID
- `test_reject_assign_to_other_user_folder` — 403 for non-owned folder
- `test_reject_bulk_move_other_user_problems` — 403 for non-owned problems
- `test_filter_by_folder_includes_descendants` — subtree filtering works
- `test_filter_by_unfiled` — unfiled filtering for null/absent folderId
- `test_omit_folder_id_returns_all_problems` — All Problems behavior preserved
- `test_folder_filter_composes_with_tag_and_search` — filter composition
- `test_problem_payload_includes_folder_id` — payload includes folderId

Manual verification:

- Not applicable — all behavior covered by automated tests

## Deviations From Issue Plan

None. Implementation follows the chosen approach exactly.

## Follow-Up Work

Frontend Problems page sidebar and bulk move UI will be implemented in #195.