### PR TITLE
feat: add Problems folder sidebar and bulk move UI

### DIFF
--- a/frontend/src/pages/ProblemsPage.test.tsx
+++ b/frontend/src/pages/ProblemsPage.test.tsx
@@ -26,367 +26,361 @@ function createQueryClient() {
   });
 }
 
-function renderProblemsPage() {
+function renderProblemsPage(initialEntries = ["/problems"]) {
   return render(
     <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={initialEntries}>
         <ProblemsPage />
       </MemoryRouter>
     </QueryClientProvider>,
   );
 }
 
+function okJson(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    json: async () => data,
+  };
+}
+
+function problem(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "p1",
+    problemType: "single-choice",
+    text: "What is 2+2?",
+    tags: ["algebra"],
+    isDeleted: false,
+    tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 },
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  };
+}
+
+const folderTree = {
+  allProblemsCount: 4,
+  unfiledCount: 1,
+  items: [
+    {
+      id: "chapter-1",
+      name: "Chapter 1",
+      parentId: null,
+      problemCount: 3,
+      createdAt: "",
+      updatedAt: "",
+      children: [
+        {
+          id: "section-1",
+          name: "Section 1",
+          parentId: "chapter-1",
+          problemCount: 2,
+          createdAt: "",
+          updatedAt: "",
+          children: [],
+        },
+      ],
+    },
+  ],
+};
+
+function installApiMock(options: {
+  problems?: unknown[];
+  total?: number;
+  folderResponse?: unknown;
+  tags?: string[];
+  failMutations?: boolean;
+} = {}) {
+  const tags = options.tags ?? ["algebra", "geometry"];
+  mockFetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+
+    if (method === "GET" && url.startsWith("/api/v1/problems?")) {
+      const items = options.problems ?? [problem()];
+      return okJson({
+        items,
+        total: options.total ?? items.length,
+        page: 1,
+        pageSize: 20,
+      });
+    }
+
+    if (method === "GET" && url === "/api/v1/folders") {
+      return okJson(options.folderResponse ?? folderTree);
+    }
+
+    if (method === "GET" && url === "/api/v1/tags") {
+      return okJson({
+        items: tags.map((name, index) => ({
+          id: `tag-${index}`,
+          name,
+          createdAt: "",
+          problemCount: 1,
+        })),
+      });
+    }
+
+    if (options.failMutations && method !== "GET") {
+      return okJson({ error: { message: "Folder request failed" } }, 400);
+    }
+
+    if (method === "POST" && url === "/api/v1/folders") {
+      return okJson({ folder: { id: "new-folder", name: "New Folder", parentId: null, createdAt: "", updatedAt: "" } }, 201);
+    }
+
+    if (method === "PATCH" && url.startsWith("/api/v1/folders/")) {
+      return okJson({ folder: { id: "chapter-1", name: "Chapter 1", parentId: null, createdAt: "", updatedAt: "" } });
+    }
+
+    if (method === "DELETE" && url.startsWith("/api/v1/folders/")) {
+      return okJson({ ok: true });
+    }
+
+    if (method === "PATCH" && url === "/api/v1/problems/bulk-folder") {
+      return okJson({ ok: true });
+    }
+
+    throw new Error(`Unhandled request: ${method} ${url}`);
+  });
+}
+
+function problemRequestUrls() {
+  return mockFetch.mock.calls
+    .map((call) => String(call[0]))
+    .filter((url) => url.startsWith("/api/v1/problems?"));
+}
+
 describe("ProblemsPage", () => {
   beforeEach(() => {
     mockFetch.mockReset();
     mockNavigate.mockReset();
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
   });
 
-  it("renders problems list", async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "1", problemType: "single-choice", text: "What is 2+2?", tags: ["algebra"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-            { id: "2", problemType: "multi-choice", text: "If A then B", tags: ["deduction"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 2,
-          page: 1,
-          pageSize: 20,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [
-          { id: "t1", name: "algebra", createdAt: "", problemCount: 1 },
-          { id: "t2", name: "deduction", createdAt: "", problemCount: 1 },
-          { id: "t3", name: "geometry", createdAt: "", problemCount: 0 },
-        ] }),
-      });
+  it("defaults to All Problems without a folderId query param", async () => {
+    installApiMock();
 
     renderProblemsPage();
 
-    await waitFor(() => {
-      expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
-    });
+    await screen.findByText("What is 2+2?");
 
-    expect(screen.getByText("If A then B")).toBeInTheDocument();
-    expect(screen.getAllByText("single-choice").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText("multi-choice").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText("Showing 2 of 2 problems")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show All Problems" })).toBeInTheDocument();
+    expect(problemRequestUrls()[0]).not.toContain("folderId=");
   });
 
-  it("navigates to problem detail on click", async () => {
+  it("renders All Problems, Unfiled, and nested folders with count badges", async () => {
+    installApiMock();
+
+    renderProblemsPage();
+
+    await screen.findByText("Chapter 1");
+
+    expect(screen.getByRole("button", { name: "Show All Problems" })).toBeInTheDocument();
+    expect(screen.getByLabelText("All Problems count")).toHaveTextContent("4");
+    expect(screen.getByRole("button", { name: "Show Unfiled" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Unfiled count")).toHaveTextContent("1");
+    expect(screen.getByRole("button", { name: "Select folder Chapter 1" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Chapter 1 count")).toHaveTextContent("3");
+    expect(screen.getByRole("button", { name: "Select folder Section 1" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Section 1 count")).toHaveTextContent("2");
+  });
+
+  it("filters by Unfiled and resets requests to page 1", async () => {
     const user = userEvent.setup();
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [{ id: "abc123", problemType: "single-choice", text: "Test problem", tags: [], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" }],
-          total: 1,
-          page: 1,
-          pageSize: 20,
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Show Unfiled" }));
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=unfiled");
+      expect(lastUrl).toContain("page=1");
+    });
+  });
+
+  it("filters by real folder and composes with tag, type, and search params", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
+    await user.selectOptions(screen.getByLabelText("Filter by Type:"), "short-answer");
+    await user.type(screen.getByLabelText("Search problems:"), "proof");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=section-1");
+      expect(lastUrl).toContain("tag=algebra");
+      expect(lastUrl).toContain("type=short-answer");
+      expect(lastUrl).toContain("q=proof");
+      expect(lastUrl).toContain("page=1");
+    });
+  });
+
+  it("persists sidebar collapse state in session storage and shows the active label", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Select folder Chapter 1" }));
+    await user.click(screen.getByRole("button", { name: "Hide" }));
+
+    expect(window.sessionStorage.getItem("problems.folderSidebarCollapsed")).toBe("true");
+    expect(screen.getByText("Folder: Chapter 1")).toBeInTheDocument();
+  });
+
+  it("expands ancestors of the selected folder on load", async () => {
+    installApiMock();
+
+    renderProblemsPage(["/problems?folderId=section-1"]);
+
+    await screen.findByRole("button", { name: "Select folder Section 1" });
+    expect(screen.getByRole("button", { name: "Collapse Chapter 1" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(problemRequestUrls()[0]).toContain("folderId=section-1");
+    });
+  });
+
+  it("creates root and child folders through the folder API", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+    vi.spyOn(window, "prompt").mockReturnValue("New Folder");
+
+    renderProblemsPage();
+    await screen.findByText("Chapter 1");
+
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+    await user.click(screen.getByRole("button", { name: "New child folder in Chapter 1" }));
+
+    await waitFor(() => {
+      const mutationCalls = mockFetch.mock.calls.filter((call) => call[1]?.method === "POST");
+      expect(mutationCalls).toHaveLength(2);
+      expect(JSON.parse(String(mutationCalls[0][1]?.body))).toEqual({ name: "New Folder", parentId: null });
+      expect(JSON.parse(String(mutationCalls[1][1]?.body))).toEqual({ name: "New Folder", parentId: "chapter-1" });
+    });
+  });
+
+  it("renames, moves, and deletes folders through the folder API", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+    vi.spyOn(window, "prompt").mockReturnValue("Renamed");
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    renderProblemsPage();
+    await screen.findByText("Chapter 1");
+
+    await user.click(screen.getByRole("button", { name: "Rename Chapter 1" }));
+    await user.click(screen.getByRole("button", { name: "Move Chapter 1" }));
+    await user.selectOptions(screen.getByLabelText("Move Chapter 1 to:"), "root");
+    await user.click(screen.getByRole("button", { name: "Save move" }));
+    await user.click(screen.getByRole("button", { name: "Delete Chapter 1" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/folders/chapter-1",
+        expect.objectContaining({ method: "PATCH", body: JSON.stringify({ name: "Renamed" }) }),
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/folders/chapter-1",
+        expect.objectContaining({ method: "PATCH", body: JSON.stringify({ parentId: null }) }),
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/folders/chapter-1",
+        expect.objectContaining({ method: "DELETE" }),
+      );
+    });
+  });
+
+  it("bulk moves selected problems to a folder, clears selection, and refetches data", async () => {
+    const user = userEvent.setup();
+    installApiMock({ problems: [problem({ id: "p1" }), problem({ id: "p2", text: "Second problem" })], total: 2 });
+
+    renderProblemsPage();
+    await screen.findByText("Second problem");
+
+    await user.click(screen.getByRole("checkbox", { name: "Select problem p1" }));
+    await user.selectOptions(screen.getByLabelText("Move to:"), "section-1");
+    await user.click(screen.getByRole("button", { name: "Move selected" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/problems/bulk-folder",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ problemIds: ["p1"], folderId: "section-1" }),
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [] }),
-      });
+      );
+    });
+    expect(screen.queryByLabelText("Bulk actions")).not.toBeInTheDocument();
+    expect(problemRequestUrls().length).toBeGreaterThan(1);
+  });
+
+  it("bulk move to Unfiled sends folderId null", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("checkbox", { name: "Select problem p1" }));
+    await user.click(screen.getByRole("button", { name: "Move selected" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/problems/bulk-folder",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ problemIds: ["p1"], folderId: null }),
+        }),
+      );
+    });
+  });
+
+  it("uses folder-aware empty state copy", async () => {
+    installApiMock({ problems: [], total: 0 });
+
+    renderProblemsPage(["/problems?folderId=unfiled"]);
+
+    await screen.findAllByText("No problems found in Unfiled");
+  });
+
+  it("shows concise error feedback for folder and bulk move failures", async () => {
+    const user = userEvent.setup();
+    installApiMock({ failMutations: true });
+    vi.spyOn(window, "prompt").mockReturnValue("New Folder");
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await screen.findByText("Folder request failed");
+
+    await user.click(screen.getByRole("checkbox", { name: "Select problem p1" }));
+    await user.click(screen.getByRole("button", { name: "Move selected" }));
+
+    await screen.findByText("Folder request failed");
+  });
+
+  it("navigates to problem detail on card click", async () => {
+    const user = userEvent.setup();
+    installApiMock({ problems: [problem({ id: "abc123", text: "Test problem" })] });
 
     renderProblemsPage();
 
-    await waitFor(() => {
-      expect(screen.getByText("Test problem")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("Test problem"));
+    await user.click(await screen.findByText("Test problem"));
 
     expect(mockNavigate).toHaveBeenCalledWith("/problems/abc123");
-  });
-
-  it("filters by tag", async () => {
-    const user = userEvent.setup();
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "1", problemType: "single-choice", text: "Test", tags: ["algebra"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 1,
-          page: 1,
-          pageSize: 20,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [
-          { id: "t1", name: "algebra", createdAt: "", problemCount: 1 },
-          { id: "t2", name: "geometry", createdAt: "", problemCount: 0 },
-        ] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "1", problemType: "single-choice", text: "Algebra problem", tags: ["algebra"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 1,
-          page: 1,
-          pageSize: 20,
-        }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Filter by Tag:")).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      const select = screen.getByLabelText("Filter by Tag:") as HTMLSelectElement;
-      expect(select.options.length).toBeGreaterThan(1);
-    });
-
-    await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("tag=algebra"),
-        expect.any(Object),
-      );
-    });
-  });
-
-  it("filters by problem type", async () => {
-    const user = userEvent.setup();
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "1", problemType: "single-choice", text: "Test", tags: ["algebra"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 1,
-          page: 1,
-          pageSize: 20,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [
-          { id: "t1", name: "algebra", createdAt: "", problemCount: 1 },
-          { id: "t2", name: "geometry", createdAt: "", problemCount: 0 },
-        ] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "2", problemType: "short-answer", text: "Explain", tags: ["geometry"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 1,
-          page: 1,
-          pageSize: 20,
-        }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Filter by Type:")).toBeInTheDocument();
-    });
-
-    await user.selectOptions(screen.getByLabelText("Filter by Type:"), "short-answer");
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("type=short-answer"),
-        expect.any(Object),
-      );
-    });
-  });
-
-  it("shows pagination controls when there are multiple pages", async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: Array.from({ length: 20 }, (_, index) => ({
-            id: `problem-${index + 1}`,
-            problemType: "single-choice",
-            text: `Problem ${index + 1}`,
-            tags: [],
-            isDeleted: false,
-            tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 },
-            createdAt: "",
-            updatedAt: "",
-          })),
-          total: 50,
-          page: 1,
-          pageSize: 20,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [] }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
-    });
-
-    expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled();
-  });
-
-  it("shows no problems message when list is empty", async () => {
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [],
-          total: 0,
-          page: 1,
-          pageSize: 20,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [] }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByText("No problems found")).toBeInTheDocument();
-    });
-  });
-
-  it("sends search query to API", async () => {
-    const user = userEvent.setup();
-    mockFetch
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "1", problemType: "single-choice", text: "Algebra problem", tags: ["algebra"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 1,
-          page: 1,
-          pageSize: 20,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ items: [] }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({
-          items: [
-            { id: "1", problemType: "single-choice", text: "Algebra problem", tags: ["algebra"], isDeleted: false, tracking: { exposureCount: 0, correctCount: 0, failedCount: 0 }, createdAt: "", updatedAt: "" },
-          ],
-          total: 1,
-          page: 1,
-          pageSize: 20,
-        }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Search problems:")).toBeInTheDocument();
-    });
-
-    await user.type(screen.getByLabelText("Search problems:"), "algebra");
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        expect.stringContaining("q=algebra"),
-        expect.any(Object),
-      );
-    });
-  });
-
-  it("resets page to 1 when search changes", async () => {
-    const user = userEvent.setup();
-    mockFetch
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          items: [],
-          total: 0,
-          page: 1,
-          pageSize: 20,
-        }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Search problems:")).toBeInTheDocument();
-    });
-
-    await user.type(screen.getByLabelText("Search problems:"), "test");
-
-    await waitFor(() => {
-      const calls = mockFetch.mock.calls;
-      const lastCall = calls[calls.length - 1][0];
-      expect(lastCall).toContain("page=1");
-      expect(lastCall).toContain("q=test");
-    });
-  });
-
-  it("does not include q parameter when search is empty", async () => {
-    mockFetch
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          items: [],
-          total: 0,
-          page: 1,
-          pageSize: 20,
-        }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled();
-    });
-
-    const firstCall = mockFetch.mock.calls[0][0];
-    expect(firstCall).not.toContain("q=");
-  });
-
-  it("trims whitespace from search query", async () => {
-    const user = userEvent.setup();
-    mockFetch
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          items: [],
-          total: 0,
-          page: 1,
-          pageSize: 20,
-        }),
-      });
-
-    renderProblemsPage();
-
-    await waitFor(() => {
-      expect(screen.getByLabelText("Search problems:")).toBeInTheDocument();
-    });
-
-    await user.type(screen.getByLabelText("Search problems:"), "   ");
-
-    await waitFor(() => {
-      const calls = mockFetch.mock.calls.map((call) => call[0]);
-      expect(calls.some((url) => !url.includes("q="))).toBeTruthy();
-    });
   });
 });

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { formatProblemReference } from "@/utils/format";
 import { useTagSuggestions } from "@/hooks/useTagSuggestions";
@@ -25,6 +25,22 @@ interface Problem {
   updatedAt: string;
 }
 
+interface FolderNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  problemCount: number;
+  children: FolderNode[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface FolderTreeResponse {
+  allProblemsCount: number;
+  unfiledCount: number;
+  items: FolderNode[];
+}
+
 interface ProblemsResponse {
   items: Problem[];
   total: number;
@@ -40,16 +56,73 @@ const PROBLEM_TYPE_OPTIONS = [
   { value: "short-answer", label: "Short Answer" },
 ];
 
+const SIDEBAR_COLLAPSED_KEY = "problems.folderSidebarCollapsed";
+const UNFILED_FOLDER_ID = "unfiled";
+const EMPTY_FOLDERS: FolderNode[] = [];
+
+type Feedback = { type: "success" | "error"; message: string } | null;
+
+function flattenFolders(folders: FolderNode[], depth = 0): Array<FolderNode & { depth: number }> {
+  return folders.flatMap((folder) => [
+    { ...folder, depth },
+    ...flattenFolders(folder.children, depth + 1),
+  ]);
+}
+
+function getDescendantIds(folder: FolderNode): Set<string> {
+  const ids = new Set<string>();
+  for (const child of folder.children) {
+    ids.add(child.id);
+    for (const id of getDescendantIds(child)) ids.add(id);
+  }
+  return ids;
+}
+
+function findFolder(folders: FolderNode[], folderId: string): FolderNode | undefined {
+  for (const folder of folders) {
+    if (folder.id === folderId) return folder;
+    const found = findFolder(folder.children, folderId);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+function buildAncestorMap(folders: FolderNode[]) {
+  const map = new Map<string, string[]>();
+  const visit = (folder: FolderNode, ancestors: string[]) => {
+    map.set(folder.id, ancestors);
+    folder.children.forEach((child) => visit(child, [...ancestors, folder.id]));
+  };
+  folders.forEach((folder) => visit(folder, []));
+  return map;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : "Request failed";
+}
+
 export function ProblemsPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [selectedTag, setSelectedTag] = useState<string>("");
   const [selectedProblemType, setSelectedProblemType] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const [selectedProblemIds, setSelectedProblemIds] = useState<Set<string>>(new Set());
+  const [bulkTarget, setBulkTarget] = useState<string>(UNFILED_FOLDER_ID);
+  const [movingFolderId, setMovingFolderId] = useState<string | null>(null);
+  const [movingParentId, setMovingParentId] = useState<string>("root");
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [expandedFolderIds, setExpandedFolderIds] = useState<Set<string>>(new Set());
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(() => {
+    return window.sessionStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
+  });
   const pageSize = 20;
+  const selectedFolderId = searchParams.get("folderId") ?? "";
 
   const { data: problemsData, isLoading: isLoadingProblems } = useQuery({
-    queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery],
+    queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery, selectedFolderId],
     queryFn: async () => {
       const params = new URLSearchParams({
         page: String(page),
@@ -58,8 +131,14 @@ export function ProblemsPage() {
       if (selectedTag) params.append("tag", selectedTag);
       if (selectedProblemType) params.append("type", selectedProblemType);
       if (searchQuery.trim()) params.append("q", searchQuery.trim());
+      if (selectedFolderId) params.append("folderId", selectedFolderId);
       return api.get<ProblemsResponse>(`/problems?${params.toString()}`);
     },
+  });
+
+  const { data: folderTree } = useQuery({
+    queryKey: ["folders"],
+    queryFn: async () => api.get<FolderTreeResponse>("/folders"),
   });
 
   const tags = useTagSuggestions();
@@ -67,10 +146,266 @@ export function ProblemsPage() {
   const problems = problemsData?.items || [];
   const total = problemsData?.total || 0;
   const totalPages = Math.ceil(total / pageSize);
+  const folders = folderTree?.items ?? EMPTY_FOLDERS;
+  const flatFolders = useMemo(() => flattenFolders(folders), [folders]);
+  const ancestorMap = useMemo(() => buildAncestorMap(folders), [folders]);
+  const selectedFolder = selectedFolderId && selectedFolderId !== UNFILED_FOLDER_ID
+    ? findFolder(folders, selectedFolderId)
+    : undefined;
+  const activeFolderLabel = selectedFolderId === UNFILED_FOLDER_ID
+    ? "Unfiled"
+    : selectedFolder?.name ?? "All Problems";
+  const movingFolder = movingFolderId ? findFolder(folders, movingFolderId) : undefined;
+  const invalidMoveTargets = movingFolder ? getDescendantIds(movingFolder) : new Set<string>();
+  if (movingFolderId) invalidMoveTargets.add(movingFolderId);
+
+  useEffect(() => {
+    window.sessionStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(isSidebarCollapsed));
+  }, [isSidebarCollapsed]);
+
+  useEffect(() => {
+    setExpandedFolderIds((current) => {
+      const next = new Set(current);
+      folders.forEach((folder) => next.add(folder.id));
+      if (selectedFolderId && selectedFolderId !== UNFILED_FOLDER_ID) {
+        ancestorMap.get(selectedFolderId)?.forEach((folderId) => next.add(folderId));
+      }
+      if (next.size === current.size && Array.from(next).every((folderId) => current.has(folderId))) {
+        return current;
+      }
+      return next;
+    });
+  }, [ancestorMap, folders, selectedFolderId]);
+
+  const refreshProblemsAndFolders = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ["problems"] }),
+      queryClient.invalidateQueries({ queryKey: ["folders"] }),
+    ]);
+  };
+
+  const folderMutation = useMutation({
+    mutationFn: async (operation: () => Promise<unknown>) => operation(),
+    onSuccess: async () => {
+      await refreshProblemsAndFolders();
+    },
+  });
+
+  const bulkMoveMutation = useMutation({
+    mutationFn: async ({ problemIds, folderId }: { problemIds: string[]; folderId: string | null }) => {
+      return api.patch<{ ok: boolean }>("/problems/bulk-folder", { problemIds, folderId });
+    },
+    onSuccess: async () => {
+      setSelectedProblemIds(new Set());
+      setPage(1);
+      setFeedback({ type: "success", message: "Problems moved" });
+      await refreshProblemsAndFolders();
+    },
+    onError: (error) => {
+      setFeedback({ type: "error", message: getErrorMessage(error) });
+    },
+  });
+
+  const updateFolderFilter = (folderId: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (folderId) next.set("folderId", folderId);
+    else next.delete("folderId");
+    setSearchParams(next);
+    setPage(1);
+    setSelectedProblemIds(new Set());
+  };
+
+  const runFolderOperation = async (
+    operation: () => Promise<unknown>,
+    successMessage: string,
+  ) => {
+    setFeedback(null);
+    try {
+      await folderMutation.mutateAsync(operation);
+      setFeedback({ type: "success", message: successMessage });
+    } catch (error) {
+      setFeedback({ type: "error", message: getErrorMessage(error) });
+    }
+  };
+
+  const createFolder = (parentId: string | null = null) => {
+    const name = window.prompt(parentId ? "New child folder name" : "New folder name");
+    if (!name?.trim()) return;
+    void runFolderOperation(
+      () => api.post("/folders", { name: name.trim(), parentId }),
+      "Folder created",
+    );
+  };
+
+  const renameFolder = (folder: FolderNode) => {
+    const name = window.prompt("Rename folder", folder.name);
+    if (!name?.trim() || name.trim() === folder.name) return;
+    void runFolderOperation(
+      () => api.patch(`/folders/${folder.id}`, { name: name.trim() }),
+      "Folder renamed",
+    );
+  };
+
+  const deleteFolder = (folder: FolderNode) => {
+    if (!window.confirm(`Delete "${folder.name}"?`)) return;
+    void runFolderOperation(
+      () => api.delete(`/folders/${folder.id}`),
+      "Folder deleted",
+    );
+  };
+
+  const openMoveFolder = (folder: FolderNode) => {
+    setMovingFolderId(folder.id);
+    setMovingParentId(folder.parentId ?? "root");
+  };
+
+  const moveFolder = () => {
+    if (!movingFolderId) return;
+    const parentId = movingParentId === "root" ? null : movingParentId;
+    void runFolderOperation(
+      () => api.patch(`/folders/${movingFolderId}`, { parentId }),
+      "Folder moved",
+    );
+    setMovingFolderId(null);
+  };
+
+  const toggleProblemSelection = (problemId: string) => {
+    setSelectedProblemIds((current) => {
+      const next = new Set(current);
+      if (next.has(problemId)) next.delete(problemId);
+      else next.add(problemId);
+      return next;
+    });
+  };
+
+  const moveSelectedProblems = () => {
+    if (selectedProblemIds.size === 0) return;
+    bulkMoveMutation.mutate({
+      problemIds: Array.from(selectedProblemIds),
+      folderId: bulkTarget === UNFILED_FOLDER_ID ? null : bulkTarget,
+    });
+  };
+
+  const folderButtonStyle = (active: boolean): React.CSSProperties => ({
+    width: "100%",
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: "0.5rem",
+    padding: "0.45rem 0.5rem",
+    borderRadius: "4px",
+    border: active ? "1px solid var(--color-primary)" : "1px solid transparent",
+    background: active ? "var(--color-primary-bg)" : "transparent",
+    color: active ? "var(--color-primary-text)" : "var(--color-text)",
+    cursor: "pointer",
+    textAlign: "left",
+  });
+
+  const renderFolderNode = (folder: FolderNode, depth = 0): JSX.Element => {
+    const isExpanded = expandedFolderIds.has(folder.id);
+    const hasChildren = folder.children.length > 0;
+    return (
+      <li key={folder.id}>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.25rem", paddingLeft: `${depth * 0.75}rem` }}>
+          <button
+            type="button"
+            aria-label={isExpanded ? `Collapse ${folder.name}` : `Expand ${folder.name}`}
+            disabled={!hasChildren}
+            onClick={() => {
+              setExpandedFolderIds((current) => {
+                const next = new Set(current);
+                if (next.has(folder.id)) next.delete(folder.id);
+                else next.add(folder.id);
+                return next;
+              });
+            }}
+            style={{
+              width: "1.5rem",
+              height: "1.5rem",
+              border: "1px solid transparent",
+              background: "transparent",
+              color: "var(--color-text-muted)",
+              cursor: hasChildren ? "pointer" : "default",
+            }}
+          >
+            {hasChildren ? (isExpanded ? "v" : ">") : ""}
+          </button>
+          <button
+            type="button"
+            aria-label={`Select folder ${folder.name}`}
+            onClick={() => updateFolderFilter(folder.id)}
+            style={folderButtonStyle(selectedFolderId === folder.id)}
+          >
+            <span>{folder.name}</span>
+            <span aria-label={`${folder.name} count`}>{folder.problemCount}</span>
+          </button>
+        </div>
+        <div style={{ display: "flex", gap: "0.25rem", margin: "0.25rem 0 0.5rem", paddingLeft: `${depth * 0.75 + 1.75}rem` }}>
+          <button type="button" aria-label={`New child folder in ${folder.name}`} onClick={() => createFolder(folder.id)}>New child</button>
+          <button type="button" aria-label={`Rename ${folder.name}`} onClick={() => renameFolder(folder)}>Rename</button>
+          <button type="button" aria-label={`Move ${folder.name}`} onClick={() => openMoveFolder(folder)}>Move</button>
+          <button type="button" aria-label={`Delete ${folder.name}`} onClick={() => deleteFolder(folder)}>Delete</button>
+        </div>
+        {hasChildren && isExpanded && (
+          <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+            {folder.children.map((child) => renderFolderNode(child, depth + 1))}
+          </ul>
+        )}
+      </li>
+    );
+  };
 
   return (
     <main style={{ padding: "1rem" }}>
       <h1>Problems</h1>
+
+      {feedback && (
+        <div
+          role="status"
+          style={{
+            marginBottom: "1rem",
+            padding: "0.75rem",
+            borderRadius: "4px",
+            border: `1px solid ${feedback.type === "success" ? "var(--color-success-border)" : "var(--color-danger-border)"}`,
+            background: feedback.type === "success" ? "var(--color-success-bg)" : "var(--color-danger-bg)",
+            color: feedback.type === "success" ? "var(--color-success-text)" : "var(--color-text-danger-secondary)",
+          }}
+        >
+          {feedback.message}
+        </div>
+      )}
+
+      {movingFolderId && (
+        <div
+          role="dialog"
+          aria-label="Move folder"
+          style={{
+            marginBottom: "1rem",
+            padding: "1rem",
+            border: "1px solid var(--color-border)",
+            borderRadius: "4px",
+            background: "var(--color-surface-muted)",
+          }}
+        >
+          <label htmlFor="folder-parent-picker">Move {movingFolder?.name ?? "folder"} to: </label>
+          <select
+            id="folder-parent-picker"
+            value={movingParentId}
+            onChange={(event) => setMovingParentId(event.target.value)}
+          >
+            <option value="root">Root</option>
+            {flatFolders
+              .filter((folder) => !invalidMoveTargets.has(folder.id))
+              .map((folder) => (
+                <option key={folder.id} value={folder.id}>
+                  {"- ".repeat(folder.depth)}{folder.name}
+                </option>
+              ))}
+          </select>
+          <button type="button" onClick={moveFolder}>Save move</button>
+          <button type="button" onClick={() => setMovingFolderId(null)}>Cancel</button>
+        </div>
+      )}
 
       <div
         style={{
@@ -134,10 +469,107 @@ export function ProblemsPage() {
         </div>
         <div style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>
           {total === 0
-            ? "No problems found"
+            ? selectedFolderId
+              ? `No problems found in ${activeFolderLabel}`
+              : "No problems found"
             : `Showing ${problems.length} of ${total} problem${total === 1 ? "" : "s"}`}
         </div>
       </div>
+
+      <div style={{ display: "grid", gridTemplateColumns: isSidebarCollapsed ? "minmax(0, 1fr)" : "260px minmax(0, 1fr)", gap: "1rem" }}>
+        {isSidebarCollapsed ? (
+          <div
+            style={{
+              marginBottom: "1rem",
+              display: "flex",
+              alignItems: "center",
+              gap: "0.75rem",
+              padding: "0.75rem",
+              border: "1px solid var(--color-border)",
+              borderRadius: "4px",
+            }}
+          >
+            <button type="button" onClick={() => setIsSidebarCollapsed(false)}>Show folders</button>
+            <span>Folder: {activeFolderLabel}</span>
+          </div>
+        ) : (
+          <aside
+            aria-label="Problem folders"
+            style={{
+              border: "1px solid var(--color-border)",
+              borderRadius: "4px",
+              padding: "0.75rem",
+              alignSelf: "start",
+            }}
+          >
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.5rem", marginBottom: "0.75rem" }}>
+              <strong>Folders</strong>
+              <button type="button" onClick={() => setIsSidebarCollapsed(true)}>Hide</button>
+            </div>
+            <button type="button" onClick={() => createFolder(null)} style={{ width: "100%", marginBottom: "0.75rem" }}>
+              Create folder
+            </button>
+            <nav aria-label="Folder filters">
+              <button
+                type="button"
+                aria-label="Show All Problems"
+                onClick={() => updateFolderFilter("")}
+                style={folderButtonStyle(!selectedFolderId)}
+              >
+                <span>All Problems</span>
+                <span aria-label="All Problems count">{folderTree?.allProblemsCount ?? 0}</span>
+              </button>
+              <button
+                type="button"
+                aria-label="Show Unfiled"
+                onClick={() => updateFolderFilter(UNFILED_FOLDER_ID)}
+                style={folderButtonStyle(selectedFolderId === UNFILED_FOLDER_ID)}
+              >
+                <span>Unfiled</span>
+                <span aria-label="Unfiled count">{folderTree?.unfiledCount ?? 0}</span>
+              </button>
+              <ul style={{ listStyle: "none", margin: "0.75rem 0 0", padding: 0 }}>
+                {folders.map((folder) => renderFolderNode(folder))}
+              </ul>
+            </nav>
+          </aside>
+        )}
+
+        <section>
+          {selectedProblemIds.size > 0 && (
+            <div
+              aria-label="Bulk actions"
+              style={{
+                marginBottom: "1rem",
+                padding: "0.75rem",
+                border: "1px solid var(--color-border)",
+                borderRadius: "4px",
+                display: "flex",
+                gap: "0.75rem",
+                alignItems: "center",
+                flexWrap: "wrap",
+              }}
+            >
+              <span>{selectedProblemIds.size} selected</span>
+              <label htmlFor="bulk-folder-picker">Move to: </label>
+              <select
+                id="bulk-folder-picker"
+                value={bulkTarget}
+                onChange={(event) => setBulkTarget(event.target.value)}
+              >
+                <option value={UNFILED_FOLDER_ID}>Unfiled</option>
+                {flatFolders.map((folder) => (
+                  <option key={folder.id} value={folder.id}>
+                    {"- ".repeat(folder.depth)}{folder.name}
+                  </option>
+                ))}
+              </select>
+              <button type="button" onClick={moveSelectedProblems} disabled={bulkMoveMutation.isPending}>
+                Move selected
+              </button>
+              <button type="button" onClick={() => setSelectedProblemIds(new Set())}>Clear selection</button>
+            </div>
+          )}
 
       {isLoadingProblems ? (
         <div>Loading...</div>
@@ -162,6 +594,18 @@ export function ProblemsPage() {
                   opacity: problem.isDeleted ? 0.5 : 1,
                 }}
               >
+                <label
+                  onClick={(event) => event.stopPropagation()}
+                  style={{ display: "flex", alignItems: "center", gap: "0.5rem", marginBottom: "0.5rem" }}
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={`Select problem ${formatProblemReference(problem.id)}`}
+                    checked={selectedProblemIds.has(problem.id)}
+                    onChange={() => toggleProblemSelection(problem.id)}
+                  />
+                  Select problem
+                </label>
                 <div style={{ marginBottom: "0.5rem" }}>
                   <strong title={problem.id}>Problem {formatProblemReference(problem.id)}</strong>
                   <span
@@ -211,11 +655,13 @@ export function ProblemsPage() {
 
           {problems.length === 0 && (
             <div style={{ textAlign: "center", marginTop: "2rem" }}>
-              No problems found
+              {selectedFolderId ? `No problems found in ${activeFolderLabel}` : "No problems found"}
             </div>
           )}
         </>
       )}
+        </section>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- Add a Problems page folder sidebar with All Problems, Unfiled, nested folders, recursive count badges, URL-backed folder filters, and session-only sidebar collapse state.
- Add sidebar folder create, child-create, rename, move, and delete controls backed by the folder APIs.
- Add problem selection plus a bulk move toolbar that moves selected problems to a folder or Unfiled and refreshes the active list/tree.

## Linked Issue

Closes #195

## Issue Alignment

This PR implements the issue by:

- Fetching `/api/v1/folders` and rendering All Problems, Unfiled, and nested real folders with API-provided count badges.
- Reading/writing `folderId` through React Router search params with the requested semantics: omitted for All Problems, `unfiled` for Unfiled, and a folder ID for real folders.
- Including the active folder in the problem list query key and request params while preserving existing search, tag, type, and pagination behavior.
- Persisting the sidebar collapsed state in `sessionStorage`, expanding root folders by default, and expanding selected-folder ancestors on load.
- Adding folder create, new child, rename, move, and delete flows with concise success/error feedback.
- Adding bulk selection and a bulk move toolbar with Unfiled and folder targets.
- Clearing selection, resetting to page 1, and refetching list/tree data after a successful bulk move.
- Adding folder-aware empty state copy.

Scope covered:

- Frontend Problems page UI and API consumption.
- Folder sidebar browsing and URL behavior.
- Folder management controls in the sidebar.
- Bulk list-view folder moves.
- Component tests for the required v1 behaviors.

Out of scope / intentionally not included:

- Backend folder or problem assignment API changes.
- Problem detail/edit folder assignment UI.
- Ingestion folder assignment.
- Drag-and-drop, folder colors/icons/sharing/import/export/manual ordering, or folder picker search.

## Implementation Notes

- Kept the implementation in `ProblemsPage` to match the issue approach and the existing local page style.
- Uses existing generic `api.get/post/patch/delete` helpers rather than adding a new API abstraction layer for one page.
- Folder creation/rename use simple `window.prompt` dialogs; delete uses `window.confirm`; folder move and bulk move use local select pickers.
- Per-folder action controls are rendered directly in the sidebar for this v1 instead of introducing a new dropdown/menu component.

## Tests

Commands run:

- `cd frontend && npm test -- ProblemsPage.test.tsx --run --maxWorkers=1 --minWorkers=1` — passed (13 tests)
- `cd frontend && npm run build` — passed; Vite emitted the existing chunk-size warning
- `git diff --check` — passed

Automated tests added or updated:

- Default All Problems behavior without `folderId`.
- Folder tree rendering with All Problems, Unfiled, nested folders, and count badges.
- Unfiled and real-folder URL filter behavior with page reset.
- Folder filter composition with existing tag/type/search params.
- Sidebar collapse persistence and active-folder label.
- Ancestor expansion on selected-folder load.
- Create root folder and new child folder API calls.
- Rename, move, and delete folder API calls with delete confirmation.
- Bulk move to a folder and to Unfiled (`folderId: null`).
- Folder-aware empty state copy.
- Concise error feedback for folder and bulk move failures.
- Existing problem-detail navigation from a problem card.

Manual verification:

- Started this branch backend on `127.0.0.1:8001` with existing MongoDB/RustFS services.
- Started this branch frontend with `PLAYWRIGHT_API_ORIGIN=http://127.0.0.1:8001 npm run dev -- --host 127.0.0.1 --port 5174`.
- Created a temporary user, folders, and seeded two problems for isolated browser verification.
- Verified login and Problems page load.
- Verified folder tree render, recursive count badges, child folder selection, `folderId=<id>` URL behavior, and filtered list result.
- Verified Unfiled selection, `folderId=unfiled` URL behavior, and filtered list result.
- Verified sidebar collapse stores `problems.folderSidebarCollapsed=true` in session storage and shows `Folder: Unfiled` while collapsed.
- Verified create, rename, move, and delete folder controls with success feedback.
- Verified bulk move from Unfiled to a real folder clears the toolbar, refreshes data, and shows folder-aware empty state in the active Unfiled view.
- Verified search plus type filtering still narrows the list after folder work.

## Deviations From Issue Plan

- Folder actions are exposed as per-folder sidebar action buttons rather than a hidden dropdown menu. The requested actions, confirmations, picker behavior, and API wiring are implemented.

## Follow-Up Work

None.
