### PR TITLE
Fix objective option parsing and preview detected choices during ingestion

### DIFF
--- a/frontend/src/components/AnswerInput.test.tsx
+++ b/frontend/src/components/AnswerInput.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseOptions, extractOptionKey } from "./AnswerInput";
+
+describe("parseOptions", () => {
+  it("returns lettered choices when present", () => {
+    const text = "1. — Could I use your bike?\n— Yes, you ________. But you ________ keep it clean.\nA. could; can\nB. can; must\nC. must; can\nD. could; must";
+    const result = parseOptions(text);
+    expect(result).toHaveLength(4);
+    expect(result[0]).toMatch(/^A/);
+    expect(result[1]).toMatch(/^B/);
+    expect(result[2]).toMatch(/^C/);
+    expect(result[3]).toMatch(/^D/);
+  });
+
+  it("ignores numeric question stems when lettered choices exist", () => {
+    const text = "1. What is 2+2?\n2. What is 3+3?\nA. 4\nB. 5\nC. 6\nD. 7";
+    const result = parseOptions(text);
+    expect(result).toHaveLength(4);
+    expect(result.every((r) => /^[A-Z]/.test(r))).toBe(true);
+  });
+
+  it("returns numeric choices when no lettered choices exist", () => {
+    const text = "Choose the correct answer:\n1. First option\n2. Second option\n3. Third option";
+    const result = parseOptions(text);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toMatch(/^1/);
+  });
+
+  it("returns empty array when no options are found", () => {
+    const text = "This is just plain text\nwith no option markers\nat all.";
+    const result = parseOptions(text);
+    expect(result).toEqual([]);
+  });
+
+  it("handles single choice with just A and B", () => {
+    const text = "True or false?\nA. True\nB. False";
+    const result = parseOptions(text);
+    expect(result).toHaveLength(2);
+  });
+
+  it("handles lettered options with parenthesis format", () => {
+    const text = "Pick one:\nA) Alpha\nB) Beta\nC) Gamma";
+    const result = parseOptions(text);
+    expect(result).toHaveLength(3);
+  });
+
+  it("handles lettered options with colon format", () => {
+    const text = "Pick one:\nA: Alpha\nB: Beta";
+    const result = parseOptions(text);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("extractOptionKey", () => {
+  it("extracts letter key from lettered option", () => {
+    expect(extractOptionKey("A. could; can")).toBe("A");
+  });
+
+  it("extracts numeric key from numeric option", () => {
+    expect(extractOptionKey("1. First option")).toBe("1");
+  });
+
+  it("returns trimmed option when no marker is found", () => {
+    expect(extractOptionKey("no marker")).toBe("no marker");
+  });
+});

--- a/frontend/src/components/AnswerInput.tsx
+++ b/frontend/src/components/AnswerInput.tsx
@@ -5,14 +5,19 @@ export function extractOptionKey(option: string): string {
 
 export function parseOptions(text: string): string[] {
   const lines = text.split("\n");
-  const options: string[] = [];
+  const lettered: string[] = [];
+  const numeric: string[] = [];
   for (const line of lines) {
     const trimmed = line.trim();
-    if (/^[A-Z][.):\s]/.test(trimmed) || /^\d+[.):\s]/.test(trimmed)) {
-      options.push(trimmed);
+    if (/^[A-Z][.):\s]/.test(trimmed)) {
+      lettered.push(trimmed);
+    } else if (/^\d+[.):\s]/.test(trimmed)) {
+      numeric.push(trimmed);
     }
   }
-  return options.length > 0 ? options : [];
+  if (lettered.length > 0) return lettered;
+  if (numeric.length > 0) return numeric;
+  return [];
 }
 
 interface SingleChoiceInputProps {

--- a/frontend/src/components/IngestionWizard.test.tsx
+++ b/frontend/src/components/IngestionWizard.test.tsx
@@ -266,4 +266,21 @@ describe("IngestionWizard", () => {
       expect(screen.queryByText("View error details")).not.toBeInTheDocument();
     });
   });
+
+  describe("choice preview", () => {
+    it("renders ingestion wizard with single-choice draft data", () => {
+      const draft = {
+        text: "1. What is 2+2?\nA. 3\nB. 4\nC. 5\nD. 6",
+        problemType: "single-choice",
+        graphDsl: "",
+        correctAnswer: "B",
+        tags: [],
+      };
+      localStorage.setItem("ingestion-draft", JSON.stringify(draft));
+
+      render(<IngestionWizard />);
+      // Verify the wizard renders (starts at paste step)
+      expect(screen.getByTestId("ingestion-wizard")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent, ClipboardEvent } from "react";
 import { GraphSandbox } from "./GraphSandbox";
 import { TagInput } from "./TagInput";
 import { LatexText } from "./LatexText";
+import { parseOptions } from "./AnswerInput";
 import { api } from "@/api/client";
 import { useTagSuggestions } from "@/hooks/useTagSuggestions";
 
@@ -704,6 +705,43 @@ function EditingStep({
         />
       </div>
 
+      {(formData.problemType === "single-choice" || formData.problemType === "multi-choice") && (
+        <div style={{ marginBottom: "24px" }}>
+          <label
+            style={{
+              display: "block",
+              marginBottom: "6px",
+              fontSize: "14px",
+              fontWeight: 500,
+              color: "var(--color-text)",
+            }}
+          >
+            Detected Choices
+          </label>
+          {(() => {
+            const choices = parseOptions(formData.text);
+            return choices.length > 0 ? (
+              <div data-testid="detected-choices" style={{ padding: "10px 12px", backgroundColor: "var(--color-surface-muted)", borderRadius: "6px", border: "1px solid var(--color-border)" }}>
+                <div data-testid="detected-choices-count" style={{ fontSize: "12px", color: "var(--color-text-muted)", marginBottom: "8px" }}>
+                  {choices.length} choice{choices.length !== 1 ? "s" : ""} detected
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                  {choices.map((choice, index) => (
+                    <div key={index} style={{ fontSize: "14px", color: "var(--color-text)", padding: "2px 0" }}>
+                      {choice}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <div data-testid="detected-choices" style={{ padding: "10px 12px", backgroundColor: "var(--color-surface-muted)", borderRadius: "6px", border: "1px solid var(--color-border)", fontSize: "14px", color: "var(--color-text-muted)" }}>
+                No choices detected in problem text
+              </div>
+            );
+          })()}
+        </div>
+      )}
+
       <div style={{ marginBottom: "24px" }}>
         <TagInput
           tags={formData.tags}
@@ -881,6 +919,40 @@ function ConfirmingStep({
             {formData.correctAnswer || "(empty)"}
           </div>
         </div>
+
+        {(formData.problemType === "single-choice" || formData.problemType === "multi-choice") && (
+          <div style={{ marginBottom: "16px" }}>
+            <div
+              style={{
+                fontSize: "12px",
+                fontWeight: 600,
+                color: "var(--color-text-muted)",
+                textTransform: "uppercase",
+                letterSpacing: "0.05em",
+                marginBottom: "4px",
+              }}
+            >
+              Detected Choices
+            </div>
+            {(() => {
+              const choices = parseOptions(formData.text);
+              return choices.length > 0 ? (
+                <div data-testid="detected-choices" style={{ fontSize: "14px", color: "var(--color-text)" }}>
+                  <span data-testid="detected-choices-count">{choices.length} choice{choices.length !== 1 ? "s" : ""} detected</span>
+                  <div style={{ marginTop: "4px", display: "flex", flexDirection: "column", gap: "2px" }}>
+                    {choices.map((choice, index) => (
+                      <div key={index}>{choice}</div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div data-testid="detected-choices" style={{ fontSize: "14px", color: "var(--color-text-muted)" }}>
+                  No choices detected
+                </div>
+              );
+            })()}
+          </div>
+        )}
 
         <div>
           <div


### PR DESCRIPTION
## Summary

- Fix the `parseOptions()` parser to prefer lettered choices (`A`, `B`, `C`, `D`) over numeric options when both are present, preventing numbered question stems like `1. — Could I use your bike?` from being incorrectly treated as answer options.
- Add a "Detected Choices" preview to the IngestionWizard editing and confirming steps for `single-choice` and `multi-choice` problem types, so users can see how many choices will be derived before confirming the problem.

## Linked Issue

Closes #201

## Issue Alignment

This PR implements the issue by:

- Updating `parseOptions()` in `AnswerInput.tsx` to collect lettered and numeric options separately, returning lettered options when present and falling back to numeric only when no lettered options exist.
- Adding `parseOptions` import to `IngestionWizard.tsx` and inserting "Detected Choices" preview panels in both the `EditingStep` and `ConfirmingStep` components.
- Preview only appears for `single-choice` and `multi-choice` problem types, showing the count and listing each detected choice.
- Adding unit tests for `parseOptions()` and `extractOptionKey()` covering the reported bug and edge cases.

Scope covered:

- Improving the shared frontend option parser used by practice and exam.
- Preventing numbered question stems from being treated as options when lettered choices are present.
- Reusing the same parser in ingestion so the preview matches actual practice/exam behavior.
- Showing the detected choices/count during ingestion for objective problem types.
- Adding regression tests for the reported case.

Out of scope / intentionally not included:

- Adding a backend `options` field or changing the problem persistence schema.
- Changing the VLM extraction schema to return structured choices.
- Rewriting ingestion from scratch.
- Redesigning the full practice, exam, or ingestion UI.
- Changing answer grading behavior.

## Implementation Notes

- The parser fix is backward-compatible: `ActivePracticePage` and `ActiveExamPage` already import `parseOptions` from `AnswerInput`, so they automatically get the fixed behavior without code changes.
- The preview uses an IIFE (`{(() => { ... })()}`) pattern to compute choices inline, matching the existing pattern used for `GraphSandbox` rendering in the wizard.
- `data-testid="detected-choices"` and `data-testid="detected-choices-count"` are set on preview elements for future E2E testing.

## Tests

Commands run:

- `npm test -- AnswerInput.test.tsx --run` — 10/10 passed
- `npm test -- IngestionWizard.test.tsx --run` — 12/12 passed
- `npm run build` — succeeded

Automated tests added or updated:

- **New file** `frontend/src/components/AnswerInput.test.tsx`: 10 tests covering:
  - Lettered choices returned when both lettered and numeric options present
  - Numeric question stems ignored when lettered choices exist
  - Numeric-only fallback when no lettered choices exist
  - Empty input returns empty array
  - A/B-only choices, parenthesis format, colon format
  - `extractOptionKey` letter key, numeric key, and no-marker cases
- **Updated** `frontend/src/components/IngestionWizard.test.tsx`: Added "choice preview" describe block verifying wizard renders with single-choice draft data

Manual verification:

- Build passes. The reported example (`1. — Could I use your bike?` + `A-D` options) now returns exactly 4 choices in `parseOptions()`. Full manual verification in the ingestion UI should be done by the reviewer.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly.

## Follow-Up Work

Per the issue, possible future work (not part of this PR):
- Add explicit structured `choices` to the backend/VLM extraction schema and migrate existing objective problems.
- Add user-editable structured choices in ingestion instead of deriving choices from text.