### PR TITLE
Allow semicolon to create tags in tag input

### DIFF
--- a/frontend/src/components/TagInput.test.tsx
+++ b/frontend/src/components/TagInput.test.tsx
@@ -246,6 +246,106 @@ describe("TagInput", () => {
     });
   });
 
+  describe("semicolon-separated input", () => {
+    it("creates a tag when semicolon is pressed", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={["math"]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "geometry;");
+
+      expect(onChange).toHaveBeenCalledWith(["math", "geometry"]);
+    });
+
+    it("does not include semicolon in the tag name", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "Grade4;");
+
+      expect(onChange).toHaveBeenCalledWith(["Grade4"]);
+      expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+    });
+
+    it("clears input after semicolon commit", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "vocabulary;");
+
+      expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+    });
+
+    it("creates multiple tags from semicolon-separated batch input", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "Grade4; grammar; vocabulary{enter}");
+
+      expect(onChange).toHaveBeenCalledTimes(3);
+      expect(onChange).toHaveBeenNthCalledWith(1, ["Grade4"]);
+      expect(onChange).toHaveBeenNthCalledWith(2, ["grammar"]);
+      expect(onChange).toHaveBeenNthCalledWith(3, ["vocabulary"]);
+    });
+
+    it("does not create empty tags from repeated semicolons", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "Grade4;; grammar;{enter}");
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenNthCalledWith(1, ["Grade4"]);
+      expect(onChange).toHaveBeenNthCalledWith(2, ["grammar"]);
+    });
+
+    it("does not create empty tag from semicolon with only whitespace", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "   ;");
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+    });
+
+    it("skips duplicate tags when using semicolon", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={["math"]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "math;");
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByTestId("tags-input-field")).toHaveValue("");
+    });
+
+    it("creates tags from mixed comma and semicolon input", async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+
+      render(<TagInput tags={[]} onChange={onChange} testId="tags-input" />);
+
+      await user.type(screen.getByTestId("tags-input-field"), "algebra; geometry, calculus{enter}");
+
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(onChange).toHaveBeenNthCalledWith(1, ["algebra"]);
+      expect(onChange).toHaveBeenNthCalledWith(2, ["geometry", "calculus"]);
+    });
+  });
+
   describe("accessibility", () => {
     it("has combobox role on the input", () => {
       render(<TagInput tags={[]} onChange={vi.fn()} testId="tags-input" />);

--- a/frontend/src/components/TagInput.tsx
+++ b/frontend/src/components/TagInput.tsx
@@ -72,7 +72,7 @@ export function TagInput({
   };
 
   const addTag = (value: string) => {
-    const segments = value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+    const segments = value.split(/[,;]/).map((s) => s.trim()).filter((s) => s.length > 0);
 
     if (segments.length === 0) {
       setInputValue("");
@@ -130,6 +130,12 @@ export function TagInput({
         return;
       }
 
+      addTag(inputValue);
+      return;
+    }
+
+    if (event.key === ";") {
+      event.preventDefault();
       addTag(inputValue);
       return;
     }


### PR DESCRIPTION
## Summary

- Add semicolon (`;`) as a tag delimiter and commit key in the shared `TagInput` component, so pressing `;` immediately creates a tag from the current input text.
- Update batch input splitting to handle both commas and semicolons as separators.

## Linked Issue

Closes #203

## Issue Alignment

This PR implements the issue by:

- Updating `addTag()` in `TagInput.tsx` to split on both `,` and `;` using the regex `/[,;]/`.
- Adding a `;` key handler in `handleKeyDown()` that prevents the semicolon from being inserted and commits the current input value immediately.
- Adding 8 new component tests for semicolon behavior.

Scope covered:

- Updating shared `TagInput` delimiter behavior.
- Treating `;` as a commit key in `handleKeyDown`.
- Splitting input on both commas and semicolons.
- Preserving existing suggestion, `Enter`, comma, duplicate, empty segment, `Escape`, and `Backspace` behavior.
- Adding focused component tests.

Out of scope / intentionally not included:

- Backend API changes.
- Tag database schema changes.
- Tag rename/delete behavior on the Tags page.
- Redesigning the tag UI.
- Supporting semicolons as valid characters inside tag names.

## Implementation Notes

- The change is confined entirely to the shared `TagInput` component. Both `IngestionWizard` and `ProblemDetailPage` already use `TagInput` and inherit the new behavior automatically.
- `addTag()` now uses `/[,;]/` regex split instead of `","`, making both delimiters behave identically for batch input.
- The `;` key handler calls `addTag(inputValue)` and prevents default, identical to the `Enter` key behavior minus the suggestion dropdown logic.
- Empty tags from repeated semicolons are already prevented by the existing `.filter((s) => s.length > 0)` in `addTag()`.

## Tests

Commands run:

- `npm test -- TagInput.test.tsx --run` — 32/32 passed (24 existing + 8 new)
- `npm run build` — succeeded

Automated tests added or updated:

- **Updated** `frontend/src/components/TagInput.test.tsx`: Added "semicolon-separated input" describe block with 8 tests:
  - Creates a tag when semicolon is pressed
  - Does not include semicolon in the tag name
  - Clears input after semicolon commit
  - Creates multiple tags from semicolon-separated batch input
  - Does not create empty tags from repeated semicolons
  - Does not create empty tag from semicolon with only whitespace
  - Skips duplicate tags when using semicolon
  - Creates tags from mixed comma and semicolon input

Manual verification:

- Build passes. The `Grade4;` input now produces a `Grade4` tag bubble without the semicolon. Full manual verification in the ingestion UI and problem editing should be done by the reviewer.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly.

## Follow-Up Work

None.