### PR TITLE
Align dark page backgrounds with Ingest across Exams, Tags, and Practice

### DIFF
--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -140,7 +140,8 @@ export function ExamsPage() {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
 
   return (
-    <main style={{ maxWidth: "960px", margin: "2rem auto", padding: "1rem" }}>
+    <main style={{ minHeight: "calc(100vh - 60px)", backgroundColor: "var(--color-surface-muted)", color: "var(--color-text)", padding: "1rem" }}>
+      <div style={{ maxWidth: "960px", margin: "2rem auto" }}>
       <div
         style={{
           display: "flex",
@@ -282,6 +283,7 @@ export function ExamsPage() {
           />
         </>
       )}
+      </div>
     </main>
   );
 }

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -299,7 +299,8 @@ export function PracticePage() {
   const items = data?.items ?? [];
 
   return (
-    <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+    <main style={{ minHeight: "calc(100vh - 60px)", backgroundColor: "var(--color-surface-muted)", color: "var(--color-text)", padding: "1rem" }}>
+      <div style={{ maxWidth: "800px", margin: "0 auto" }}>
       <div
         style={{
           display: "flex",
@@ -387,6 +388,7 @@ export function PracticePage() {
           ))}
         </div>
       )}
+      </div>
     </main>
   );
 }

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -439,7 +439,7 @@ export function ProblemsPage() {
   };
 
   return (
-    <main style={{ padding: "1rem", minHeight: "calc(100vh - 60px)", backgroundColor: "var(--color-bg)", color: "var(--color-text)" }}>
+    <main style={{ padding: "1rem", minHeight: "calc(100vh - 60px)", backgroundColor: "var(--color-surface-muted)", color: "var(--color-text)" }}>
       <h1>Problems</h1>
 
       {feedback && (

--- a/frontend/src/pages/TagsPage.tsx
+++ b/frontend/src/pages/TagsPage.tsx
@@ -116,7 +116,8 @@ export function TagsPage() {
   };
 
   return (
-    <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+    <main style={{ minHeight: "calc(100vh - 60px)", backgroundColor: "var(--color-surface-muted)", color: "var(--color-text)", padding: "1rem" }}>
+      <div style={{ maxWidth: "800px", margin: "0 auto" }}>
       <h1>Tags</h1>
 
       <form
@@ -366,6 +367,7 @@ export function TagsPage() {
           </div>
         </Modal>
       )}
+      </div>
     </main>
   );
 }

--- a/frontend/tests/theme.spec.ts
+++ b/frontend/tests/theme.spec.ts
@@ -255,6 +255,27 @@ test.describe("Problems Page Theme", () => {
     // Verify page heading remains visible
     await expect(page.getByRole("heading", { name: "Problems" })).toBeVisible();
   });
+
+  test("problems page dark theme background matches Ingest page surface-muted", async ({ page, request }) => {
+    const session = await createSession(request, "problems_dark_surface_muted");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/problems");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByRole("heading", { name: "Problems" })).toBeVisible();
+  });
 });
 
 test.describe("Problem Detail Page Theme", () => {
@@ -333,6 +354,28 @@ test.describe("Tags Page Theme", () => {
     // Verify create tag button is visible
     await expect(page.getByRole("button", { name: "Create Tag" })).toBeVisible();
   });
+
+  test("tags page dark theme paints a full-page themed background", async ({ page, request }) => {
+    const session = await createSession(request, "tags_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/tags");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByRole("heading", { name: "Tags" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Tag" })).toBeVisible();
+  });
 });
 
 test.describe("Settings Page Theme", () => {
@@ -407,6 +450,28 @@ test.describe("Practice Page Theme", () => {
     await expect(page.getByRole("heading", { name: "Practice" })).toBeVisible();
 
     // Verify start practice button is visible
+    await expect(page.getByTestId("start-practice-button")).toBeVisible();
+  });
+
+  test("practice page dark theme paints a full-page themed background", async ({ page, request }) => {
+    const { session } = await createSessionWithProblem(request, "practice_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/practice");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByRole("heading", { name: "Practice" })).toBeVisible();
     await expect(page.getByTestId("start-practice-button")).toBeVisible();
   });
 });
@@ -490,6 +555,35 @@ test.describe("Exams Page Theme", () => {
 
     // Verify start new exam button is visible
     await expect(page.getByRole("button", { name: "Start New Exam" })).toBeVisible();
+  });
+
+  test("exams page dark theme paints a full-page themed background", async ({ page, request }) => {
+    const session = await createSession(request, "exams_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/exams");
+
+    // Verify theme is dark
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    // Get --color-surface-muted from the page
+    const surfaceMuted = await page.evaluate(() => {
+      return window.getComputedStyle(document.documentElement).getPropertyValue("--color-surface-muted").trim();
+    });
+
+    // Verify the main element has the themed background
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    // Verify heading is still visible
+    await expect(page.getByRole("heading", { name: "Exam History" })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Summary

Fix dark-theme page backgrounds for `/exams`, `/tags`, `/practice`, and `/problems` so they match the Ingest page pattern. Follow-up to PR #202 which only partially fixed the problem (Problems page used a different dark tone, and Exams/Tags/Practice had no full-viewport themed canvas at all).

## Linked Issue

Closes #205

## Issue Alignment

This PR implements the issue by:

1. **ExamsPage**: Wrapping content in an outer full-width `<main>` with `minHeight: "calc(100vh - 60px)"`, `backgroundColor: "var(--color-surface-muted)"`, `color: "var(--color-text)"`, and an inner centered `<div>` with `maxWidth: "960px"`.
2. **TagsPage**: Same outer main + inner div pattern with `maxWidth: "800px"`.
3. **PracticePage**: Same outer main + inner div pattern with `maxWidth: "800px"`.
4. **ProblemsPage**: Changed `backgroundColor` from `var(--color-bg)` to `var(--color-surface-muted)` to match Ingest.
5. Added 4 new E2E dark-background tests.

Scope covered:

- Full-viewport themed page canvas for Exams, Tags, Practice in dark mode.
- Consistent dark background tone matching Ingest (`var(--color-surface-muted)`).
- E2E tests verifying dark backgrounds are not white/transparent.

Out of scope / intentionally not included:

- Changing theme CSS tokens.
- Modifying the Ingest page.
- Changing light theme appearance.
- Modifying active session pages (`/practice/active`, `/exams/active`).
- Refactoring page business logic or component structure.

## Implementation Notes

- The "outer main + inner div" pattern exactly follows how IngestPage already styles its root `<main>` — full viewport with `var(--color-surface-muted)`, content centered inside.
- In dark mode, `--color-surface-muted` = `#1e293b` (Ingest background), while `--color-bg` = `#0f172a` (darker). The Ingest tone is the correct reference per the issue.
- The header height is 60px, so `calc(100vh - 60px)` ensures the page canvas fills the viewport below the header.
- Cards and panels remain on `var(--color-surface)` so they stay visually distinct from the page canvas.

## Tests

Commands run:

- `npx vitest run --reporter=verbose` — 242/242 passed
- `npm run build` — succeeded

Automated tests added:

- **Exams Page Theme** → "exams page dark theme paints a full-page themed background"
- **Tags Page Theme** → "tags page dark theme paints a full-page themed background"
- **Practice Page Theme** → "practice page dark theme paints a full-page themed background"
- **Problems Page Theme** → "problems page dark theme background matches Ingest page surface-muted"

Each test:
1. Sets dark theme, navigates to the page
2. Verifies `html` has `data-theme="dark"`
3. Gets the computed `backgroundColor` of the `<main>` element
4. Asserts it is not white and not transparent
5. Verifies the page heading remains visible

## Deviations From Issue Plan

None. Implementation follows the chosen approach exactly.

## Follow-Up Work

None.