### PR TITLE
fix: apply Ingest-like dark page canvas to remaining protected routes

### DIFF
--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -166,10 +166,24 @@ export function ActiveExamPage() {
     createExamMutation.mutate({ maxProblemCount: 10 });
   }, [createExamMutation]);
 
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-surface-muted)",
+    color: "var(--color-text)",
+    padding: "1rem",
+  };
+
+  const contentWrapperStyle: React.CSSProperties = {
+    maxWidth: "800px",
+    margin: "0 auto",
+  };
+
   if (isLoadingExam) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem", textAlign: "center" }}>
-        <div>Loading...</div>
+      <main style={pageCanvasStyle}>
+        <div style={{ ...contentWrapperStyle, textAlign: "center" }}>
+          <div>Loading...</div>
+        </div>
       </main>
     );
   }
@@ -177,31 +191,33 @@ export function ActiveExamPage() {
   const isNotFoundError = examError instanceof Error && examError.message.includes("404");
   if (isNotFoundError || !exam) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
-        <h1>Active Exam</h1>
-        <div style={{ textAlign: "center", padding: "3rem", backgroundColor: "var(--color-surface-muted)", border: "1px solid var(--color-border)", borderRadius: "0.5rem" }}>
-          <p>No active exam found.</p>
-          <button
-            onClick={handleCreateExam}
-            disabled={createExamMutation.isPending}
-            style={{
-              padding: "0.75rem 1.5rem",
-              backgroundColor: createExamMutation.isPending ? "var(--color-primary-disabled)" : "var(--color-primary)",
-              color: "white",
-              border: "none",
-              borderRadius: "0.25rem",
-              cursor: createExamMutation.isPending ? "not-allowed" : "pointer",
-              fontSize: "1rem",
-              marginTop: "1rem",
-            }}
-          >
-            {createExamMutation.isPending ? "Creating..." : "Start New Exam"}
-          </button>
-          {createExamMutation.error && (
-            <p style={{ color: "var(--color-text-danger)", marginTop: "1rem" }}>
-              {(createExamMutation.error as Error).message}
-            </p>
-          )}
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <h1>Active Exam</h1>
+          <div style={{ textAlign: "center", padding: "3rem", backgroundColor: "var(--color-surface)", border: "1px solid var(--color-border)", borderRadius: "0.5rem" }}>
+            <p>No active exam found.</p>
+            <button
+              onClick={handleCreateExam}
+              disabled={createExamMutation.isPending}
+              style={{
+                padding: "0.75rem 1.5rem",
+                backgroundColor: createExamMutation.isPending ? "var(--color-primary-disabled)" : "var(--color-primary)",
+                color: "white",
+                border: "none",
+                borderRadius: "0.25rem",
+                cursor: createExamMutation.isPending ? "not-allowed" : "pointer",
+                fontSize: "1rem",
+                marginTop: "1rem",
+              }}
+            >
+              {createExamMutation.isPending ? "Creating..." : "Start New Exam"}
+            </button>
+            {createExamMutation.error && (
+              <p style={{ color: "var(--color-text-danger)", marginTop: "1rem" }}>
+                {(createExamMutation.error as Error).message}
+              </p>
+            )}
+          </div>
         </div>
       </main>
     );
@@ -209,9 +225,11 @@ export function ActiveExamPage() {
 
   if (examError) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
-        <div style={{ color: "var(--color-text-danger)", padding: "1rem", backgroundColor: "var(--color-danger-bg)", borderRadius: "0.25rem" }}>
-          Error loading exam: {(examError as Error).message}
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <div style={{ color: "var(--color-text-danger)", padding: "1rem", backgroundColor: "var(--color-danger-bg)", borderRadius: "0.25rem" }}>
+            Error loading exam: {(examError as Error).message}
+          </div>
         </div>
       </main>
     );
@@ -219,8 +237,10 @@ export function ActiveExamPage() {
 
   if (!currentItem) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
-        <div>No items in this exam.</div>
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <div>No items in this exam.</div>
+        </div>
       </main>
     );
   }
@@ -230,7 +250,8 @@ export function ActiveExamPage() {
   const isLastItem = currentItemIndex === items.length - 1;
 
   return (
-    <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
+    <main style={pageCanvasStyle}>
+      <div style={contentWrapperStyle}>
       <div style={{ marginBottom: "1.5rem" }}>
         <h1>Active Exam</h1>
         <p style={{ color: "var(--color-text-muted)" }}>
@@ -411,6 +432,7 @@ export function ActiveExamPage() {
           </div>
         </Modal>
       )}
+      </div>
     </main>
   );
 }

--- a/frontend/src/pages/ActivePracticePage.tsx
+++ b/frontend/src/pages/ActivePracticePage.tsx
@@ -95,15 +95,34 @@ export function ActivePracticePage() {
     navigate("/practice");
   };
 
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-surface-muted)",
+    color: "var(--color-text)",
+    padding: "1rem",
+  };
+
+  const contentWrapperStyle: React.CSSProperties = {
+    maxWidth: "800px",
+    margin: "0 auto",
+  };
+
   if (!currentProblem) {
-    return null;
+    return (
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <div>No active problem.</div>
+        </div>
+      </main>
+    );
   }
 
   const options = parseOptions(currentProblem.text);
   const isMutating = submitMutation.isPending || nextMutation.isPending;
 
   return (
-    <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
+    <main style={pageCanvasStyle}>
+      <div style={contentWrapperStyle}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "1.5rem", flexWrap: "wrap", gap: "1rem" }}>
         <h1 style={{ margin: 0 }}>Practice</h1>
         <div style={{ display: "flex", gap: "0.5rem" }}>
@@ -358,6 +377,7 @@ export function ActivePracticePage() {
           </button>
         </div>
       )}
+      </div>
     </main>
   );
 }

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -199,9 +199,16 @@ export function CoachingPage() {
     handleSendMessage(predefinedMessages[shortcutType]);
   };
 
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-surface-muted)",
+    color: "var(--color-text)",
+    padding: "1.5rem",
+  };
+
   if (isLoadingProblem || isLoadingConversation) {
     return (
-      <main style={{ padding: "2rem", display: "flex", justifyContent: "center", alignItems: "center", minHeight: "80vh" }}>
+      <main style={{ ...pageCanvasStyle, display: "flex", justifyContent: "center", alignItems: "center" }}>
         <div style={{ fontSize: "1.25rem", color: "var(--color-link)", fontWeight: 600, display: "flex", alignItems: "center", gap: "0.5rem" }}>
           <div style={{ width: "24px", height: "24px", borderRadius: "50%", border: "3px solid var(--color-tag-bg)", borderTopColor: "var(--color-link)", animation: "spin 1s linear infinite" }} />
           Loading coaching page...
@@ -213,13 +220,15 @@ export function CoachingPage() {
 
   if (!problem) {
     return (
-      <main style={{ padding: "2rem", maxWidth: "600px", margin: "2rem auto" }}>
-        <div style={{ padding: "1.5rem", backgroundColor: "var(--color-danger-bg)", border: "1px solid var(--color-danger-border)", borderRadius: "0.5rem", textAlign: "center" }}>
-          <div style={{ color: "var(--color-text-danger)", fontWeight: 600, fontSize: "1.125rem", marginBottom: "0.5rem" }}>Problem Not Found</div>
-          <p style={{ color: "var(--color-text-danger-secondary)", margin: "0 0 1.5rem 0" }}>The problem you are trying to access does not exist or has been deleted.</p>
-          <button onClick={() => navigate(fromRoute)} style={{ padding: "0.5rem 1.5rem", backgroundColor: "var(--color-danger)", color: "white", border: "none", borderRadius: "0.25rem", cursor: "pointer", fontWeight: 600 }}>
-            Go Back
-          </button>
+      <main style={pageCanvasStyle}>
+        <div style={{ maxWidth: "600px", margin: "0 auto" }}>
+          <div style={{ padding: "1.5rem", backgroundColor: "var(--color-danger-bg)", border: "1px solid var(--color-danger-border)", borderRadius: "0.5rem", textAlign: "center" }}>
+            <div style={{ color: "var(--color-text-danger)", fontWeight: 600, fontSize: "1.125rem", marginBottom: "0.5rem" }}>Problem Not Found</div>
+            <p style={{ color: "var(--color-text-danger-secondary)", margin: "0 0 1.5rem 0" }}>The problem you are trying to access does not exist or has been deleted.</p>
+            <button onClick={() => navigate(fromRoute)} style={{ padding: "0.5rem 1.5rem", backgroundColor: "var(--color-danger)", color: "white", border: "none", borderRadius: "0.25rem", cursor: "pointer", fontWeight: 600 }}>
+              Go Back
+            </button>
+          </div>
         </div>
       </main>
     );

--- a/frontend/src/pages/ExamDetailPage.tsx
+++ b/frontend/src/pages/ExamDetailPage.tsx
@@ -285,26 +285,42 @@ export function ExamDetailPage() {
     selfReportMutation.mutate({ itemId, request: { isCorrect } });
   };
 
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-surface-muted)",
+    color: "var(--color-text)",
+    padding: "1rem",
+  };
+
+  const contentWrapperStyle: React.CSSProperties = {
+    maxWidth: "800px",
+    margin: "0 auto",
+  };
+
   if (isLoading) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem", textAlign: "center" }}>
-        <div>Loading exam details...</div>
+      <main style={pageCanvasStyle}>
+        <div style={{ ...contentWrapperStyle, textAlign: "center" }}>
+          <div>Loading exam details...</div>
+        </div>
       </main>
     );
   }
 
   if (error) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
-        <div style={{ color: "var(--color-text-danger)", padding: "1rem", backgroundColor: "var(--color-danger-bg)", borderRadius: "0.25rem" }}>
-          Error loading exam: {(error as Error).message}
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <div style={{ color: "var(--color-text-danger)", padding: "1rem", backgroundColor: "var(--color-danger-bg)", borderRadius: "0.25rem" }}>
+            Error loading exam: {(error as Error).message}
+          </div>
+          <button
+            onClick={() => navigate("/exams")}
+            style={{ marginTop: "1rem", padding: "0.5rem 1rem" }}
+          >
+            Back to Exams
+          </button>
         </div>
-        <button
-          onClick={() => navigate("/exams")}
-          style={{ marginTop: "1rem", padding: "0.5rem 1rem" }}
-        >
-          Back to Exams
-        </button>
       </main>
     );
   }
@@ -312,14 +328,16 @@ export function ExamDetailPage() {
   const exam = examData?.exam;
   if (!exam) {
     return (
-      <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
-        <div>Exam not found.</div>
-        <button
-          onClick={() => navigate("/exams")}
-          style={{ marginTop: "1rem", padding: "0.5rem 1rem" }}
-        >
-          Back to Exams
-        </button>
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <div>Exam not found.</div>
+          <button
+            onClick={() => navigate("/exams")}
+            style={{ marginTop: "1rem", padding: "0.5rem 1rem" }}
+          >
+            Back to Exams
+          </button>
+        </div>
       </main>
     );
   }
@@ -327,7 +345,8 @@ export function ExamDetailPage() {
   const hasPendingReview = exam.items.some((item) => item.grading.status === "pending-review");
 
   return (
-    <main style={{ maxWidth: "800px", margin: "2rem auto", padding: "1rem" }}>
+    <main style={pageCanvasStyle}>
+      <div style={contentWrapperStyle}>
       <div style={{ marginBottom: "1.5rem" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.5rem" }}>
           <h1 style={{ margin: 0 }}>Exam Results</h1>
@@ -412,6 +431,7 @@ export function ExamDetailPage() {
           setPendingRevealItemId(null);
         }}
       />
+      </div>
     </main>
   );
 }

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -143,9 +143,16 @@ export function ProblemDetailPage() {
     }
   };
 
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-surface-muted)",
+    color: "var(--color-text)",
+    padding: "1rem",
+  };
+
   if (isLoadingProblem) {
     return (
-      <main style={{ padding: "1rem" }}>
+      <main style={pageCanvasStyle}>
         <div>Loading...</div>
       </main>
     );
@@ -153,7 +160,7 @@ export function ProblemDetailPage() {
 
   if (problemError || !problem) {
     return (
-      <main style={{ padding: "1rem" }}>
+      <main style={pageCanvasStyle}>
         <div style={{ color: "var(--color-text-danger)" }}>
           Error loading problem: {problemError?.message || "Problem not found"}
         </div>
@@ -163,7 +170,7 @@ export function ProblemDetailPage() {
   }
 
   return (
-    <main style={{ padding: "1rem" }}>
+    <main style={pageCanvasStyle}>
       <div style={{ marginBottom: "1rem" }}>
         <button onClick={() => navigate("/problems")}>Back to Problems</button>
       </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -275,26 +275,43 @@ export function SettingsPage() {
     queryFn: async () => api.get<SettingsResponse>("/settings"),
   });
 
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-surface-muted)",
+    color: "var(--color-text)",
+    padding: "1rem",
+  };
+
+  const contentWrapperStyle: React.CSSProperties = {
+    maxWidth: "800px",
+    margin: "0 auto",
+  };
+
   if (isLoading) {
     return (
-      <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
-        <h1 style={{ marginBottom: "1rem" }}>Settings</h1>
-        <p style={{ color: "var(--color-text-muted)" }}>Loading settings...</p>
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <h1 style={{ marginBottom: "1rem" }}>Settings</h1>
+          <p style={{ color: "var(--color-text-muted)" }}>Loading settings...</p>
+        </div>
       </main>
     );
   }
 
   if (error || !data) {
     return (
-      <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
-        <h1 style={{ marginBottom: "1rem" }}>Settings</h1>
-        <p style={{ color: "var(--color-text-danger)" }}>Failed to load settings.</p>
+      <main style={pageCanvasStyle}>
+        <div style={contentWrapperStyle}>
+          <h1 style={{ marginBottom: "1rem" }}>Settings</h1>
+          <p style={{ color: "var(--color-text-danger)" }}>Failed to load settings.</p>
+        </div>
       </main>
     );
   }
 
   return (
-    <main style={{ padding: "1rem", maxWidth: "800px", margin: "0 auto" }}>
+    <main style={pageCanvasStyle}>
+      <div style={contentWrapperStyle}>
       <h1 style={{ marginBottom: "1.5rem" }}>Settings</h1>
       <p
         style={{
@@ -424,6 +441,7 @@ export function SettingsPage() {
           setTimeout(() => setSuccessMessage(null), 5000);
         }}
       />
+      </div>
     </main>
   );
 }

--- a/frontend/tests/theme.spec.ts
+++ b/frontend/tests/theme.spec.ts
@@ -28,6 +28,7 @@ async function createSessionWithProblem(request: APIRequestContext, prefix: stri
 
 // Helper to set theme before navigation
 async function setTheme(page: Page, theme: "light" | "dark") {
+  await page.goto("/");
   await page.evaluate((t) => localStorage.setItem("learnloop-theme", t), theme);
 }
 
@@ -75,7 +76,7 @@ test.describe("Theme E2E", () => {
     await addAuthenticatedSession(page, session);
 
     // Pre-set localStorage to dark
-    await page.evaluate(() => localStorage.setItem("learnloop-theme", "dark"));
+    await setTheme(page, "dark");
 
     await page.goto("/problems");
 
@@ -123,7 +124,7 @@ test.describe("Theme E2E", () => {
     await addAuthenticatedSession(page, session);
 
     // Pre-set localStorage to dark, then toggle to light
-    await page.evaluate(() => localStorage.setItem("learnloop-theme", "dark"));
+    await setTheme(page, "dark");
 
     await page.goto("/problems");
     await expect(page.getByRole("button", { name: "Toggle theme" })).toHaveText("Light");
@@ -316,6 +317,27 @@ test.describe("Problem Detail Page Theme", () => {
     await expect(page.getByRole("button", { name: "Edit" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Delete" })).toBeVisible();
   });
+
+  test("problem detail page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const { session, problem } = await createSessionWithProblem(request, "problem_detail_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto(`/problems/${problem.id}`);
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByText("What is 2+2?")).toBeVisible();
+  });
 });
 
 test.describe("Tags Page Theme", () => {
@@ -413,6 +435,27 @@ test.describe("Settings Page Theme", () => {
 
     // Verify change password button is visible
     await expect(page.getByRole("button", { name: "Change Teacher Password" })).toBeVisible();
+  });
+
+  test("settings page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const session = await createSession(request, "settings_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/settings");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
   });
 });
 
@@ -517,6 +560,134 @@ test.describe("Active Practice Page Theme", () => {
     // Verify submit and skip buttons are visible
     await expect(page.getByTestId("submit-button")).toBeVisible();
     await expect(page.getByTestId("skip-button")).toBeVisible();
+  });
+
+  test("active practice page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const { session } = await createSessionWithProblem(request, "active_practice_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    // Navigate to practice and start
+    await page.goto("/practice");
+    await page.getByTestId("start-practice-button").click();
+
+    // Wait for active practice page
+    await expect(page.getByTestId("problem-text")).toBeVisible();
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByTestId("problem-text")).toBeVisible();
+  });
+});
+
+test.describe("Exam Detail Page Theme", () => {
+  test("exam detail page renders in light theme", async ({ page, request }) => {
+    const session = await createSession(request, "exam_detail_light");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "light");
+
+    // Use a non-existent exam id to reach the not-found/error state
+    await page.goto("/exams/00000000-0000-0000-0000-000000000000");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("light");
+
+    // Either error or not-found state should show the Back to Exams button
+    await expect(page.getByRole("button", { name: "Back to Exams" })).toBeVisible({ timeout: 15000 });
+  });
+
+  test("exam detail page renders in dark theme", async ({ page, request }) => {
+    const session = await createSession(request, "exam_detail_dark");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/exams/00000000-0000-0000-0000-000000000000");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    await expect(page.getByRole("button", { name: "Back to Exams" })).toBeVisible({ timeout: 15000 });
+  });
+
+  test("exam detail page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const session = await createSession(request, "exam_detail_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/exams/00000000-0000-0000-0000-000000000000");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByRole("button", { name: "Back to Exams" })).toBeVisible({ timeout: 15000 });
+  });
+});
+
+test.describe("Active Exam Page Theme", () => {
+  test("active exam page renders in light theme", async ({ page, request }) => {
+    const session = await createSession(request, "active_exam_light");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "light");
+
+    await page.goto("/exams/active");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("light");
+
+    await expect(page.getByText("No active exam found.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Start New Exam" })).toBeVisible();
+  });
+
+  test("active exam page renders in dark theme", async ({ page, request }) => {
+    const session = await createSession(request, "active_exam_dark");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/exams/active");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    await expect(page.getByText("No active exam found.")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Start New Exam" })).toBeVisible();
+  });
+
+  test("active exam page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const session = await createSession(request, "active_exam_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/exams/active");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByText("No active exam found.")).toBeVisible();
   });
 });
 
@@ -626,5 +797,26 @@ test.describe("Coaching Page Theme", () => {
     // Verify context bar and whiteboard are visible
     await expect(page.getByTestId("context-bar")).toBeVisible();
     await expect(page.getByTestId("whiteboard")).toBeVisible();
+  });
+
+  test("coaching page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const { session, problem } = await createSessionWithProblem(request, "coaching_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto(`/coaching/${problem.id}`);
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    await expect(page.getByRole("heading", { name: "AI Coach" })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Applies the full-page dark-theme canvas pattern established in IngestPage to all remaining protected routes that still showed white viewport bands in dark mode.

## Linked Issue

Closes #208

## Issue Alignment

This PR implements the issue by:

- Adding `minHeight: calc(100vh - 60px)`, `backgroundColor: var(--color-surface-muted)`, and `color: var(--color-text)` to the root `<main>` element on all affected pages.
- Preserving existing inner content layouts by moving `maxWidth` / `margin` styles into an inner wrapper `<div>` where needed.
- Ensuring loading, error, empty, not-found, and loaded states all share the same themed full-page canvas behavior.
- Adding E2E tests for the newly covered routes to verify dark-theme background is not white/transparent.

Scope covered:

- `ProblemDetailPage` (loading, error, loaded)
- `ExamDetailPage` (loading, error, not-found, loaded)
- `ActiveExamPage` (loading, error, no-active-exam, no-items, loaded)
- `ActivePracticePage` (no-problem, loaded)
- `SettingsPage` (loading, error, loaded)
- `CoachingPage` (loading, not-found)

Out of scope / intentionally not included:

- Reworking #205 pages (not requested)
- Full redesign of detail/active/settings pages
- Changing dark theme palette tokens
- Changing business logic or API behavior
- Public auth pages (not in scope per issue)

## Implementation Notes

- Used a consistent local `pageCanvasStyle` object in each page component to avoid duplicating the same style values inline.
- For pages that previously centered content with `maxWidth: "800px"` and `margin: "2rem auto"`, those styles were moved to an inner `contentWrapperStyle` so the outer `<main>` spans the full viewport.
- Fixed a pre-existing test helper issue where `setTheme` used `page.evaluate` before `page.goto`, causing `SecurityError` on `localStorage` access. Changed to navigate first, then set localStorage.
- Fixed pre-existing tests that directly called `page.evaluate(() => localStorage.setItem(...))` before navigation by routing them through the updated `setTheme` helper.

## Tests

Commands run:

- `cd frontend && npm run build` — passed
- `cd frontend && npx playwright test tests/theme.spec.ts` — 35 passed, 3 pre-existing unrelated failures

Automated tests added or updated:

- `problem detail page dark theme paints a non-white full-page background`
- `exam detail page renders in light theme`
- `exam detail page renders in dark theme`
- `exam detail page dark theme paints a non-white full-page background`
- `active exam page renders in light theme`
- `active exam page renders in dark theme`
- `active exam page dark theme paints a non-white full-page background`
- `active practice page dark theme paints a non-white full-page background`
- `settings page dark theme paints a non-white full-page background`
- `coaching page dark theme paints a non-white full-page background`

Manual verification:

- Verified build compiles cleanly.
- Verified all newly added E2E tests pass.
- Confirmed light theme remains visually normal on affected pages via existing test coverage.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
