### PR TITLE
Add problem subject model and editable ingestion subject

### DIFF
--- a/backend/app/domain/__init__.py
+++ b/backend/app/domain/__init__.py
@@ -1,6 +1,7 @@
 """Domain layer packages."""
 
 from .models import (
+    ProblemSubject,
     ProblemType,
     ExamState,
     IngestionPreviewStatus,
@@ -42,6 +43,7 @@ from .state import (
 from .scoring import compute_summary
 
 __all__ = [
+    "ProblemSubject",
     "ProblemType",
     "ExamState",
     "IngestionPreviewStatus",

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -12,6 +12,11 @@ class ProblemType(str, Enum):
     SHORT_ANSWER = "short-answer"
 
 
+class ProblemSubject(str, Enum):
+    MATH = "math"
+    ENGLISH = "english"
+
+
 class ExamState(str, Enum):
     IN_PROGRESS = "in-progress"
     SUBMITTED = "submitted"
@@ -76,6 +81,7 @@ class Extraction(BaseModel):
     rawText: Optional[str] = None
     rawProblemType: Optional[ProblemType] = None
     rawGraphDsl: Optional[str] = None
+    rawSubject: Optional[ProblemSubject] = None
     rawProviderResponse: Optional[Dict[str, Any]] = None
     failureCode: Optional[str] = None
     failureMessage: Optional[str] = None
@@ -87,6 +93,7 @@ class EditableDraft(BaseModel):
     graphDsl: Optional[str] = None
     correctAnswer: Optional[str] = None
     tags: List[str] = Field(default_factory=list)
+    subject: ProblemSubject = ProblemSubject.MATH
 
 
 class Origin(BaseModel):
@@ -127,6 +134,7 @@ class ProblemSnapshot(BaseModel):
     graphDsl: Optional[str] = None
     correctAnswer: CorrectAnswer
     sourceImage: Optional[SourceImage] = None
+    subject: ProblemSubject = ProblemSubject.MATH
 
 
 class ExamItemAnswer(BaseModel):
@@ -213,6 +221,7 @@ class Problem(BaseModel):
     userId: str
     text: str
     problemType: ProblemType
+    subject: ProblemSubject = ProblemSubject.MATH
     graphDsl: Optional[str] = None
     correctAnswer: CorrectAnswer
     tags: List[str] = Field(default_factory=list)

--- a/backend/app/presentation/exam_helpers.py
+++ b/backend/app/presentation/exam_helpers.py
@@ -25,6 +25,7 @@ def problem_document_to_model(problem: Mapping[str, Any]) -> Problem:
                 "userId": str(problem["userId"]),
                 "text": problem["text"],
                 "problemType": problem["problemType"],
+                "subject": problem.get("subject", "math"),
                 "graphDsl": problem.get("graphDsl"),
                 "correctAnswer": problem["correctAnswer"],
                 "tags": list(problem.get("tags", [])),
@@ -70,6 +71,7 @@ def make_exam_item(problem: Mapping[str, Any], *, order: int) -> dict[str, Any]:
         "problemSnapshot": {
             "text": problem["text"],
             "problemType": problem["problemType"],
+            "subject": problem.get("subject", "math"),
             "graphDsl": problem.get("graphDsl"),
             "correctAnswer": deepcopy(problem["correctAnswer"]),
             "sourceImage": deepcopy(problem.get("sourceImage")),

--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -26,6 +26,7 @@ class SelfReportRequest(BaseModel):
 class ExamProblemPayload(BaseModel):
     text: str
     problemType: ProblemType
+    subject: str = "math"
     graphDsl: str | None = None
     correctAnswer: CorrectAnswerPayload | None = None
     sourceImage: SourceImagePayload | None = None
@@ -154,6 +155,7 @@ def serialize_exam_item(
         problem=ExamProblemPayload(
             text=str(snapshot.get("text", "")),
             problemType=ProblemType(snapshot["problemType"]),
+            subject=str(snapshot.get("subject", "math")),
             graphDsl=snapshot.get("graphDsl"),
             correctAnswer=(
                 CorrectAnswerPayload.model_validate(snapshot.get("correctAnswer", {}))

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter, Depends, File, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from app.domain import IngestionPreviewStatus, ProblemType, normalize_answer
+from app.domain import IngestionPreviewStatus, ProblemSubject, ProblemType, normalize_answer
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
@@ -49,6 +49,7 @@ class PreviewDraftPatchRequest(BaseModel):
     graphDsl: str | None = None
     correctAnswer: str | None = None
     tags: list[str] | None = None
+    subject: ProblemSubject | None = None
 
 
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
@@ -148,6 +149,7 @@ async def create_preview(
             "graphDsl": None,
             "correctAnswer": None,
             "tags": [],
+            "subject": ProblemSubject.MATH.value,
         },
         "createdAt": now,
         "updatedAt": now,
@@ -201,6 +203,8 @@ async def patch_preview(
             draft[key] = normalize_tags(value)
         elif key in {"text", "correctAnswer"}:
             draft[key] = clean_optional_text(value)
+        elif key == "subject":
+            draft[key] = value.value if hasattr(value, "value") else value
         else:
             draft[key] = value
 
@@ -215,6 +219,7 @@ async def patch_preview(
                     "graphDsl": draft.get("graphDsl"),
                     "correctAnswer": draft.get("correctAnswer"),
                     "tags": normalize_tags(list(draft.get("tags", []))),
+                    "subject": str(draft.get("subject", ProblemSubject.MATH.value)),
                 },
                 "updatedAt": now,
                 "expiresAt": preview_expires_at(now),
@@ -311,12 +316,14 @@ async def confirm_preview(
         raise ApiError(400, "INVALID_PREVIEW", "Preview draft is missing required fields")
 
     problem_type = ProblemType(problem_type_value)
+    subject_value = draft.get("subject", ProblemSubject.MATH.value)
     normalized_answer = normalize_answer(correct_answer, problem_type)
     problem: Document = {
         "_id": ObjectId(),
         "userId": user["_id"],
         "text": text,
         "problemType": problem_type.value,
+        "subject": str(subject_value),
         "graphDsl": draft.get("graphDsl"),
         "correctAnswer": normalized_answer.model_dump(),
         "tags": normalize_tags(list(draft.get("tags", []))),

--- a/backend/app/presentation/ingestion_serialization.py
+++ b/backend/app/presentation/ingestion_serialization.py
@@ -15,6 +15,7 @@ class PreviewDraftPayload(BaseModel):
     graphDsl: str | None = None
     correctAnswer: str | None = None
     tags: list[str] = Field(default_factory=list)
+    subject: str = "math"
 
 
 class PreviewExtractionPayload(BaseModel):
@@ -25,6 +26,7 @@ class PreviewExtractionPayload(BaseModel):
     rawText: str | None = None
     rawProblemType: str | None = None
     rawGraphDsl: str | None = None
+    rawSubject: str | None = None
     rawProviderResponse: dict[str, Any] | None = None
     failureCode: str | None = None
     failureMessage: str | None = None
@@ -49,6 +51,7 @@ class ProblemPayload(BaseModel):
     id: str
     text: str
     problemType: str
+    subject: str = "math"
     graphDsl: str | None = None
     correctAnswer: CorrectAnswerPayload
     tags: list[str] = Field(default_factory=list)
@@ -80,6 +83,7 @@ def serialize_preview(preview: Mapping[str, Any]) -> PreviewPayload:
                 "graphDsl": draft.get("graphDsl"),
                 "correctAnswer": draft.get("correctAnswer"),
                 "tags": list(draft.get("tags", [])),
+                "subject": str(draft.get("subject", "math")),
             },
             "extraction": {
                 "requestModel": extraction.get("requestModel"),
@@ -89,6 +93,7 @@ def serialize_preview(preview: Mapping[str, Any]) -> PreviewPayload:
                 "rawText": extraction.get("rawText"),
                 "rawProblemType": _enum_value(extraction.get("rawProblemType")),
                 "rawGraphDsl": extraction.get("rawGraphDsl"),
+                "rawSubject": _enum_value(extraction.get("rawSubject")),
                 "rawProviderResponse": extraction.get("rawProviderResponse"),
                 "failureCode": extraction.get("failureCode"),
                 "failureMessage": extraction.get("failureMessage"),
@@ -106,6 +111,7 @@ def serialize_problem(problem: Mapping[str, Any]) -> ProblemPayload:
             "id": str(problem["_id"]),
             "text": problem["text"],
             "problemType": _enum_value(problem["problemType"]),
+            "subject": str(problem.get("subject", "math")),
             "graphDsl": problem.get("graphDsl"),
             "correctAnswer": problem["correctAnswer"],
             "tags": list(problem.get("tags", [])),

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -49,6 +49,7 @@ class ProblemSummaryPayload(BaseModel):
     id: str
     text: str
     problemType: ProblemType
+    subject: str = "math"
     graphDsl: str | None = None
     tags: list[str]
     tracking: TrackingPayload
@@ -148,6 +149,7 @@ def _serialize_problem_summary(problem: dict[str, Any]) -> ProblemSummaryPayload
         id=str(problem["_id"]),
         text=str(problem["text"]),
         problemType=ProblemType(problem["problemType"]),
+        subject=str(problem.get("subject", "math")),
         graphDsl=problem.get("graphDsl"),
         tags=[str(tag) for tag in problem.get("tags", [])],
         tracking=_serialize_tracking(problem),

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -208,6 +208,7 @@ def make_problem(
         "userId": user_id,
         "text": text,
         "problemType": problem_type,
+        "subject": "math",
         "graphDsl": None,
         "correctAnswer": {
             "display": correct_answer,

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -287,6 +287,7 @@ def make_preview(
             "graphDsl": None,
             "correctAnswer": "4",
             "tags": ["draft"],
+            "subject": "math",
         },
         "createdAt": now,
         "updatedAt": refreshed_at,
@@ -513,6 +514,7 @@ async def test_patch_preview_persists_draft_and_extends_ttl(
         "graphDsl": "graph TD; A-->B",
         "correctAnswer": "B, A ,B",
         "tags": ["logic", "sets"],
+        "subject": "math",
     }
     assert parse_datetime(body["expiresAt"]) > old_expires_at
 
@@ -524,8 +526,34 @@ async def test_patch_preview_persists_draft_and_extends_ttl(
         "graphDsl": "graph TD; A-->B",
         "correctAnswer": "B, A ,B",
         "tags": ["logic", "sets"],
+        "subject": "math",
     }
     assert stored_preview["expiresAt"] > old_expires_at
+
+
+@pytest.mark.asyncio
+async def test_patch_preview_accepts_subject_change_to_english(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    database: FakeDatabase = ingestion_app.state.fake_database
+    owner = await database["users"].find_one({"username": "student1"})
+    assert owner is not None
+    preview = make_preview(owner["_id"], status="ready")
+    database["ingestion_previews"].seed(preview)
+
+    response = await authenticated_client.patch(
+        f"/api/v1/ingestion-previews/{preview['_id']}",
+        json={"subject": "english"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["preview"]
+    assert body["draft"]["subject"] == "english"
+
+    stored_preview = await database["ingestion_previews"].find_one({"_id": preview["_id"]})
+    assert stored_preview is not None
+    assert stored_preview["editableDraft"]["subject"] == "english"
 
 
 @pytest.mark.asyncio
@@ -619,6 +647,38 @@ async def test_confirm_preview_creates_problem_from_confirmed_draft(
     assert solution_task["retry_count"] == 0
     assert solution_task["failure_reason"] is None
     assert solution_task["started_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_preview_persists_english_subject_from_draft(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    database: FakeDatabase = ingestion_app.state.fake_database
+    owner = await database["users"].find_one({"username": "student1"})
+    assert owner is not None
+    preview = make_preview(owner["_id"], status="ready")
+    preview["editableDraft"] = {
+        "text": "Read the passage and answer",
+        "problemType": "short-answer",
+        "graphDsl": None,
+        "correctAnswer": "Paris",
+        "tags": ["english"],
+        "subject": "english",
+    }
+    database["ingestion_previews"].seed(preview)
+
+    response = await authenticated_client.post(
+        f"/api/v1/ingestion-previews/{preview['_id']}/confirm"
+    )
+
+    assert response.status_code == 201
+    body = response.json()["problem"]
+    assert body["subject"] == "english"
+
+    stored_problem = await database["problems"].find_one({"_id": ObjectId(body["id"])})
+    assert stored_problem is not None
+    assert stored_problem["subject"] == "english"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -229,6 +229,7 @@ def make_preview(user_id: ObjectId, *, status: str = "ready") -> dict[str, Any]:
             "graphDsl": None,
             "correctAnswer": "draft",
             "tags": ["draft"],
+            "subject": "math",
         },
         "createdAt": now,
         "updatedAt": now,
@@ -252,6 +253,7 @@ def make_problem(
         "userId": user_id,
         "text": text,
         "problemType": problem_type,
+        "subject": "math",
         "graphDsl": None,
         "correctAnswer": {
             "display": "4",
@@ -346,6 +348,27 @@ async def test_confirm_preview_creates_problem_and_canonicalizes_answer(
     assert stored_problem["origin"]["previewId"] == str(preview["_id"])
     assert stored_problem["correctAnswer"]["normalizedSet"] == ["a", "c"]
     assert database["ingestion_previews"]._documents[0]["status"] == "confirmed"
+
+
+@pytest.mark.asyncio
+async def test_problem_detail_defaults_missing_subject_to_math(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    old_problem = make_problem(
+        user_id,
+        text="Legacy problem without subject",
+        problem_type="short-answer",
+    )
+    del old_problem["subject"]
+    database["problems"].seed(old_problem)
+
+    response = await client.get(f"/api/v1/problems/{old_problem['_id']}")
+    assert response.status_code == 200
+    body = response.json()["problem"]
+    assert body["subject"] == "math"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_ingestion_workflow.py
+++ b/backend/tests/integration/test_ingestion_workflow.py
@@ -106,6 +106,7 @@ async def test_wf_ing_1_clipboard_ingestion_creates_preview_and_confirms_problem
         "graphDsl": None,
         "correctAnswer": "4",
         "tags": ["math", "chapter-1"],
+        "subject": "math",
     }
 
     confirm_response = await client.post(f"/api/v1/ingestion-previews/{preview_id}/confirm")

--- a/frontend/src/components/IngestionWizard.test.tsx
+++ b/frontend/src/components/IngestionWizard.test.tsx
@@ -283,4 +283,52 @@ describe("IngestionWizard", () => {
       expect(screen.getByTestId("ingestion-wizard")).toBeInTheDocument();
     });
   });
+
+  describe("subject selector", () => {
+    it("renders subject selector with default math", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "ready",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {
+                text: "What is 2+2?",
+                problemType: "short-answer",
+                graphDsl: null,
+                correctAnswer: "4",
+                tags: [],
+                subject: "math",
+              },
+              extraction: {
+                rawText: "What is 2+2?",
+                rawProblemType: "short-answer",
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("subject-input")).toBeInTheDocument();
+      });
+
+      const subjectSelect = screen.getByTestId("subject-input") as HTMLSelectElement;
+      expect(subjectSelect.value).toBe("math");
+    });
+  });
 });

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -22,6 +22,7 @@ interface PreviewDraft {
   graphDsl: string | null;
   correctAnswer: string | null;
   tags: string[];
+  subject: string;
 }
 
 interface PreviewExtraction {
@@ -93,6 +94,7 @@ function mapPreviewToFormData(preview: IngestionPreview) {
     graphDsl: preview.draft.graphDsl || "",
     correctAnswer: preview.draft.correctAnswer || "",
     tags: preview.draft.tags,
+    subject: preview.draft.subject || "math",
   };
 }
 
@@ -104,6 +106,7 @@ export interface WizardFormData {
   graphDsl: string;
   correctAnswer: string;
   tags: string[];
+  subject: string;
 }
 
 interface IngestionWizardProps {
@@ -141,6 +144,7 @@ interface PreviewUpdateData {
   graphDsl?: string;
   correctAnswer?: string;
   tags?: string[];
+  subject?: string;
 }
 
 async function updatePreview(id: string, data: PreviewUpdateData): Promise<IngestionPreview> {
@@ -588,6 +592,39 @@ function EditingStep({
             color: "var(--color-text)",
           }}
         >
+          Subject
+        </label>
+        <select
+          value={formData.subject}
+          onChange={(e) => onFieldChange("subject", e.target.value)}
+          style={{
+            width: "100%",
+            padding: "10px 12px",
+            border: "1px solid var(--color-border-muted)",
+            borderRadius: "6px",
+            fontSize: "14px",
+            fontFamily: "inherit",
+            boxSizing: "border-box",
+            backgroundColor: "var(--color-surface)",
+            color: "var(--color-text)",
+          }}
+          data-testid="subject-input"
+        >
+          <option value="math">Math</option>
+          <option value="english">English</option>
+        </select>
+      </div>
+
+      <div style={{ marginBottom: "24px" }}>
+        <label
+          style={{
+            display: "block",
+            marginBottom: "6px",
+            fontSize: "14px",
+            fontWeight: 500,
+            color: "var(--color-text)",
+          }}
+        >
           Problem Type
         </label>
         <select
@@ -885,6 +922,24 @@ function ConfirmingStep({
               marginBottom: "4px",
             }}
           >
+            Subject
+          </div>
+          <div style={{ fontSize: "14px", color: "var(--color-text)" }}>
+            {formData.subject || "(empty)"}
+          </div>
+        </div>
+
+        <div style={{ marginBottom: "16px" }}>
+          <div
+            style={{
+              fontSize: "12px",
+              fontWeight: 600,
+              color: "var(--color-text-muted)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              marginBottom: "4px",
+            }}
+          >
             Graph DSL
           </div>
           <div
@@ -1067,6 +1122,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
     graphDsl: "",
     correctAnswer: "",
     tags: [],
+    subject: "math",
   });
 
   const [graphError, setGraphError] = useState<string>("");
@@ -1084,6 +1140,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
           graphDsl: draft.graphDsl || "",
           correctAnswer: draft.correctAnswer || "",
           tags: Array.isArray(draft.tags) ? draft.tags : [],
+          subject: draft.subject || "math",
         });
       } catch {
       }
@@ -1264,6 +1321,7 @@ export function IngestionWizard({ onConfirm, onCancel }: IngestionWizardProps) {
         graphDsl: formData.graphDsl,
         correctAnswer: formData.correctAnswer,
         tags: formData.tags,
+        subject: formData.subject,
       });
 
       const result = await confirmPreview(previewId);

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -79,6 +79,7 @@ function normalizePreviewResponse(data: unknown): IngestionPreview {
       graphDsl: candidate.graphDsl ?? null,
       correctAnswer: candidate.correctAnswer ?? null,
       tags: candidate.tags ?? [],
+      subject: "math",
     },
     extraction: candidate.extraction ?? {},
     createdAt: candidate.createdAt ?? "",


### PR DESCRIPTION
## Summary

Add a persisted problem `subject` field (`math` or `english`) across the domain model, ingestion preview flow, API serialization, and ingestion confirmation UI, including a user-editable subject override before a preview is confirmed.

## Linked Issue

Closes #211

## Issue Alignment

This PR implements the issue by:

- Adding `ProblemSubject` enum with values `math` and `english` to the domain model.
- Adding `subject` to `Problem`, `ProblemSnapshot`, ingestion preview `EditableDraft`, and `Extraction`.
- Adding `subject` to ingestion preview draft/extraction payload and problem API response serialization.
- Initializing new preview drafts with default subject `math`.
- Allowing patching `subject` on an ingestion preview before confirmation.
- Persisting the final draft subject on the confirmed problem.
- Defaulting missing `subject` to `math` in all read/serialization paths so existing records keep working.
- Adding a subject selector to the frontend ingestion confirmation UI.

Scope covered:

- Domain model changes for subject.
- Backend API serialization and ingestion flow subject handling.
- Frontend ingestion wizard subject selector.
- Tests for subject behavior, defaulting, and override.

Out of scope / intentionally not included:

- Helper VLM image classification (issue #213).
- Subject-specific ingestion VLM routing (issue #213).
- Subject-specific solution/coaching routing (issue #214).
- Dedicated English or math grading VLMs (issue #212).

## Implementation Notes

- `subject` is stored separately from `problemType` and does not replace answer-format semantics.
- The `EditableDraft` model defaults `subject` to `ProblemSubject.MATH`.
- All serialization paths use `str(problem.get("subject", "math"))` for backward compatibility.
- The frontend `IngestionWizard` includes a subject selector in the editing step and displays subject in the confirmation step.
- Enum values are properly handled in the patch endpoint to avoid serializing as `ProblemSubject.ENGLISH`.

## Tests

Commands run:

- `cd backend && uv run --frozen pytest` — 288 passed, 1 skipped
- `cd frontend && npm test -- --run` — 251 passed

Automated tests added or updated:

- `test_patch_preview_accepts_subject_change_to_english` — verifies preview patch accepts subject override.
- `test_confirm_preview_persists_english_subject_from_draft` — verifies confirmed problem persists english subject.
- `test_problem_detail_defaults_missing_subject_to_math` — verifies old records without subject default to math.
- `test_patch_preview_persists_draft_and_extends_ttl` — updated to include subject in assertions.
- `test_wf_ing_1_clipboard_ingestion_creates_preview_and_confirms_problem` — updated to include subject in assertions.
- Frontend `IngestionWizard.test.tsx` — added subject selector rendering test.

Manual verification:

- Verified backend tests pass with new subject field and old records compatibility.
- Verified frontend tests pass with subject selector.

## Deviations From Issue Plan

None.

## Follow-Up Work

- Issue #213: Helper VLM subject classification and ingestion routing.
- Issue #214: Subject-specific solution/coaching routing.
- Issue #212: Pass problem subject into generic grading VLM context.
