### PR TITLE
Fix Settings page contract for subject-specific VLM settings

### DIFF
--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -32,25 +32,45 @@ const mockSettings = {
   app: { env: "development", host: "0.0.0.0", port: 8000, log_level: "INFO" },
   database: { name: "learnloop" },
   storage: { endpoint: "http://localhost:9000", bucket: "media", region: "us-east-1", force_path_style: true },
-  ingestion_vlm: {
-    endpoint: "https://ingestion.example.com",
-    model: "ingestion-model",
+  preview_extracting_window_seconds: 150,
+  helper_vlm: {
+    endpoint: "https://helper.example.com",
+    model: "helper-model",
+    timeout_seconds: 30,
+  },
+  math_ingestion_vlm: {
+    endpoint: "https://math-ingestion.example.com",
+    model: "math-ingestion-model",
     timeout_seconds: 120,
-    preview_extracting_window_seconds: 150,
+  },
+  english_ingestion_vlm: {
+    endpoint: "https://english-ingestion.example.com",
+    model: "english-ingestion-model",
+    timeout_seconds: 120,
   },
   grading_vlm: {
     endpoint: "https://grading.example.com",
     model: "grading-model",
     timeout_seconds: 60,
   },
-  solution_vlm: {
-    endpoint: "https://solution.example.com",
-    model: "solution-model",
+  math_solution_vlm: {
+    endpoint: "https://math-solution.example.com",
+    model: "math-solution-model",
     timeout_seconds: 90,
   },
-  coaching_vlm: {
-    endpoint: "https://coaching.example.com",
-    model: "coaching-model",
+  english_solution_vlm: {
+    endpoint: "https://english-solution.example.com",
+    model: "english-solution-model",
+    timeout_seconds: 90,
+  },
+  math_coaching_vlm: {
+    endpoint: "https://math-coaching.example.com",
+    model: "math-coaching-model",
+    timeout_seconds: 45,
+  },
+  english_coaching_vlm: {
+    endpoint: "https://english-coaching.example.com",
+    model: "english-coaching-model",
     timeout_seconds: 45,
   },
   session: { cookie_name: "ll_session", secure: false, samesite: "lax" },
@@ -93,16 +113,32 @@ describe("SettingsPage", () => {
     expect(await screen.findByText("http://localhost:9000")).toBeInTheDocument();
   });
 
-  it("renders explicit AI settings sections", async () => {
+  it("renders all VLM settings sections", async () => {
     renderWithProviders();
-    expect(await screen.findByText("Ingestion VLM")).toBeInTheDocument();
+    expect(await screen.findByText("Helper VLM")).toBeInTheDocument();
+    expect(await screen.findByText("Math Ingestion VLM")).toBeInTheDocument();
+    expect(await screen.findByText("English Ingestion VLM")).toBeInTheDocument();
     expect(await screen.findByText("Grading VLM")).toBeInTheDocument();
-    expect(await screen.findByText("Solution VLM")).toBeInTheDocument();
-    expect(await screen.findByText("Coaching VLM")).toBeInTheDocument();
-    expect(await screen.findByText("ingestion-model")).toBeInTheDocument();
+    expect(await screen.findByText("Math Solution VLM")).toBeInTheDocument();
+    expect(await screen.findByText("English Solution VLM")).toBeInTheDocument();
+    expect(await screen.findByText("Math Coaching VLM")).toBeInTheDocument();
+    expect(await screen.findByText("English Coaching VLM")).toBeInTheDocument();
+    expect(await screen.findByText("helper-model")).toBeInTheDocument();
+    expect(await screen.findByText("math-ingestion-model")).toBeInTheDocument();
+    expect(await screen.findByText("english-ingestion-model")).toBeInTheDocument();
     expect(await screen.findByText("grading-model")).toBeInTheDocument();
-    expect(await screen.findByText("solution-model")).toBeInTheDocument();
-    expect(await screen.findByText("coaching-model")).toBeInTheDocument();
+    expect(await screen.findByText("math-solution-model")).toBeInTheDocument();
+    expect(await screen.findByText("english-solution-model")).toBeInTheDocument();
+    expect(await screen.findByText("math-coaching-model")).toBeInTheDocument();
+    expect(await screen.findByText("english-coaching-model")).toBeInTheDocument();
+  });
+
+  it("does not reference stale VLM keys", async () => {
+    renderWithProviders();
+    await screen.findByText("Settings");
+    expect(screen.queryByText("Ingestion VLM")).not.toBeInTheDocument();
+    expect(screen.queryByText("Solution VLM")).not.toBeInTheDocument();
+    expect(screen.queryByText("Coaching VLM")).not.toBeInTheDocument();
   });
 
   it("renders session settings section", async () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -20,23 +20,43 @@ interface SettingsResponse {
     region: string;
     force_path_style: boolean;
   };
-  ingestion_vlm: {
+  preview_extracting_window_seconds: number;
+  helper_vlm: {
     endpoint: string;
     model: string;
     timeout_seconds: number;
-    preview_extracting_window_seconds: number;
+  };
+  math_ingestion_vlm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
+  };
+  english_ingestion_vlm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
   };
   grading_vlm: {
     endpoint: string;
     model: string;
     timeout_seconds: number;
   };
-  solution_vlm: {
+  math_solution_vlm: {
     endpoint: string;
     model: string;
     timeout_seconds: number;
   };
-  coaching_vlm: {
+  english_solution_vlm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
+  };
+  math_coaching_vlm: {
+    endpoint: string;
+    model: string;
+    timeout_seconds: number;
+  };
+  english_coaching_vlm: {
     endpoint: string;
     model: string;
     timeout_seconds: number;
@@ -95,6 +115,22 @@ function SettingSection({
       </h2>
       <div>{children}</div>
     </section>
+  );
+}
+
+function VlmSection({
+  title,
+  vlm,
+}: {
+  title: string;
+  vlm: { endpoint: string; model: string; timeout_seconds: number };
+}) {
+  return (
+    <SettingSection title={title}>
+      <SettingRow label="Endpoint" value={vlm.endpoint} />
+      <SettingRow label="Model" value={vlm.model} />
+      <SettingRow label="Timeout (seconds)" value={vlm.timeout_seconds} />
+    </SettingSection>
   );
 }
 
@@ -374,45 +410,18 @@ export function SettingsPage() {
         />
       </SettingSection>
 
-      <SettingSection title="Ingestion VLM">
-        <SettingRow label="Endpoint" value={data.ingestion_vlm.endpoint} />
-        <SettingRow label="Model" value={data.ingestion_vlm.model} />
-        <SettingRow
-          label="Timeout (seconds)"
-          value={data.ingestion_vlm.timeout_seconds}
-        />
-        <SettingRow
-          label="Preview Window (seconds)"
-          value={data.ingestion_vlm.preview_extracting_window_seconds}
-        />
+      <SettingSection title="Preview">
+        <SettingRow label="Preview Window (seconds)" value={data.preview_extracting_window_seconds} />
       </SettingSection>
 
-      <SettingSection title="Grading VLM">
-        <SettingRow label="Endpoint" value={data.grading_vlm.endpoint} />
-        <SettingRow label="Model" value={data.grading_vlm.model} />
-        <SettingRow
-          label="Timeout (seconds)"
-          value={data.grading_vlm.timeout_seconds}
-        />
-      </SettingSection>
-
-      <SettingSection title="Solution VLM">
-        <SettingRow label="Endpoint" value={data.solution_vlm.endpoint} />
-        <SettingRow label="Model" value={data.solution_vlm.model} />
-        <SettingRow
-          label="Timeout (seconds)"
-          value={data.solution_vlm.timeout_seconds}
-        />
-      </SettingSection>
-
-      <SettingSection title="Coaching VLM">
-        <SettingRow label="Endpoint" value={data.coaching_vlm.endpoint} />
-        <SettingRow label="Model" value={data.coaching_vlm.model} />
-        <SettingRow
-          label="Timeout (seconds)"
-          value={data.coaching_vlm.timeout_seconds}
-        />
-      </SettingSection>
+      <VlmSection title="Helper VLM" vlm={data.helper_vlm} />
+      <VlmSection title="Math Ingestion VLM" vlm={data.math_ingestion_vlm} />
+      <VlmSection title="English Ingestion VLM" vlm={data.english_ingestion_vlm} />
+      <VlmSection title="Grading VLM" vlm={data.grading_vlm} />
+      <VlmSection title="Math Solution VLM" vlm={data.math_solution_vlm} />
+      <VlmSection title="English Solution VLM" vlm={data.english_solution_vlm} />
+      <VlmSection title="Math Coaching VLM" vlm={data.math_coaching_vlm} />
+      <VlmSection title="English Coaching VLM" vlm={data.english_coaching_vlm} />
 
       <SettingSection title="Session">
         <SettingRow label="Cookie Name" value={data.session.cookie_name} />


### PR DESCRIPTION
## Summary

- Update `SettingsResponse` interface to match the current backend `/api/v1/settings` response shape
- Replace stale `ingestion_vlm`, `solution_vlm`, `coaching_vlm` with `helper_vlm`, `math_ingestion_vlm`, `english_ingestion_vlm`, `math_solution_vlm`, `english_solution_vlm`, `math_coaching_vlm`, `english_coaching_vlm`
- Move `preview_extracting_window_seconds` to a top-level field
- Add `VlmSection` helper component to reduce rendering repetition

## Linked Issue

Closes #219

## Issue Alignment

This PR implements the issue by:

- Updating the frontend `SettingsResponse` interface to mirror `backend/app/presentation/settings.py`
- Replacing all stale VLM key references with the new subject-specific keys
- Updating the test mock to match the real backend response
- Adding a regression test that verifies stale keys are no longer used

Scope covered:

- `SettingsResponse` interface updated
- Rendered sections/labels updated for all 8 VLM profiles
- Frontend settings tests updated with current response shape
- Regression test for stale keys added

Out of scope / intentionally not included:

- Backend changes (not needed)
- `.env` variable name changes
- Settings editing
- Unrelated settings page UI refactoring
- Documentation or Playwright config (tracked separately)

## Implementation Notes

- Added a `VlmSection` helper component since all 8 VLM profiles share the same shape (endpoint, model, timeout_seconds). This reduces the JSX from ~60 lines of repeated sections to ~8 lines.
- `preview_extracting_window_seconds` is displayed in its own "Preview" section since the backend returns it as a top-level field.

## Tests

Commands run:

- `npx vitest --run src/pages/SettingsPage.test.tsx` — 16 tests passed
- `npx vitest --run` — 252 tests passed (full frontend suite)
- `npm run build` — built successfully

Automated tests added or updated:

- Updated `mockSettings` to match current backend response shape
- Updated test "renders all VLM settings sections" to check all 8 VLM profiles
- Added test "does not reference stale VLM keys" — regression test verifying old keys are absent

Manual verification:

- `rg -n "ingestion_vlm|solution_vlm|coaching_vlm" frontend/src` — only shows `math_*` and `english_*` prefixed keys, no stale bare keys

## Deviations From Issue Plan

None.

## Follow-Up Work

None.