### PR TITLE
Close subject-routed solution VLM clients in the worker

### DIFF
--- a/backend/app/infrastructure/worker/solution_worker.py
+++ b/backend/app/infrastructure/worker/solution_worker.py
@@ -60,12 +60,14 @@ async def process_task(
         log_solution_generation_event("failed", problem_id, failure_reason="Problem not found")
         return
 
+    owned_client = False
     if client is not None:
         task_client = client
     else:
         settings = get_settings()
         subject = problem.get("subject", "math")
         task_client = SolutionVLMClient(settings=settings, subject=subject)
+        owned_client = True
 
     try:
         source_image = problem.get("sourceImage")
@@ -156,6 +158,9 @@ async def process_task(
             }
         )
         log_solution_generation_event("failed", problem_id, failure_reason=str(exc))
+    finally:
+        if owned_client:
+            await task_client.aclose()
 
 async def run_solution_worker(database: Any, stop_event: asyncio.Event | None = None) -> None:
     settings = get_settings()

--- a/backend/tests/worker/test_solution_worker.py
+++ b/backend/tests/worker/test_solution_worker.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 from bson import ObjectId
@@ -88,15 +89,16 @@ class FakeSolutionVLMClient:
             raw_provider_response={}
         )
         self.calls = []
+        self.closed = False
 
     async def generate_solution(self, request):
         self.calls.append(request)
         if self.error_to_raise:
             raise self.error_to_raise
         return self.result_to_return
-        
+
     async def aclose(self):
-        pass
+        self.closed = True
 
 class FakeStorage:
     def get_object(self, bucket, key):
@@ -119,11 +121,12 @@ async def test_process_task_success():
     tasks_col.seed(task)
     
     await process_task(task, client, storage, tasks_col, solutions_col, problems_col, 3)
-    
+
     updated_task = await tasks_col.find_one({"_id": task_id})
     assert updated_task["status"] == "ready"
     assert len(solutions_col._documents) == 1
     assert len(client.calls) == 1
+    assert not client.closed  # injected client must not be closed
 
 @pytest.mark.asyncio
 async def test_process_task_retry_and_fail():
@@ -155,6 +158,7 @@ async def test_process_task_retry_and_fail():
     updated = await tasks_col.find_one({"_id": task_id})
     assert updated["status"] == "failed"
     assert updated["retry_count"] == 4
+    assert not client.closed  # injected client must not be closed
 
 @pytest.mark.asyncio
 async def test_run_worker_stuck_task_recovery():
@@ -285,3 +289,88 @@ async def test_process_task_no_image():
     assert len(solutions_col._documents) == 1
     assert len(client.calls) == 1
     assert client.calls[0].image_base64 is None
+    assert not client.closed  # injected client must not be closed
+
+
+@pytest.mark.asyncio
+async def test_process_task_closes_internal_client_on_success():
+    """When process_task creates its own client, it must close it after success."""
+    internal_client = FakeSolutionVLMClient()
+    storage = FakeStorage()
+    tasks_col = FakeCollection()
+    solutions_col = FakeCollection()
+    problems_col = FakeCollection()
+
+    problem_id = str(ObjectId())
+    user_id = str(ObjectId())
+    task_id = ObjectId()
+
+    problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    task = {"_id": task_id, "problem_id": problem_id, "user_id": user_id, "status": "pending"}
+    tasks_col.seed(task)
+
+    with patch(
+        "app.infrastructure.worker.solution_worker.SolutionVLMClient",
+        return_value=internal_client,
+    ):
+        await process_task(task, None, storage, tasks_col, solutions_col, problems_col, 3)
+
+    updated_task = await tasks_col.find_one({"_id": task_id})
+    assert updated_task["status"] == "ready"
+    assert internal_client.closed
+
+
+@pytest.mark.asyncio
+async def test_process_task_closes_internal_client_on_vlm_failure():
+    """When process_task creates its own client, it must close it after VLM error."""
+    internal_client = FakeSolutionVLMClient()
+    internal_client.error_to_raise = SolutionCoachingVLMError("err", code="err", retryable=True)
+    storage = FakeStorage()
+    tasks_col = FakeCollection()
+    solutions_col = FakeCollection()
+    problems_col = FakeCollection()
+
+    problem_id = str(ObjectId())
+    task_id = ObjectId()
+
+    problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    task = {"_id": task_id, "problem_id": problem_id, "user_id": "u", "status": "pending", "retry_count": 3}
+    tasks_col.seed(task)
+
+    with patch(
+        "app.infrastructure.worker.solution_worker.SolutionVLMClient",
+        return_value=internal_client,
+    ):
+        await process_task(task, None, storage, tasks_col, solutions_col, problems_col, 3)
+
+    updated = await tasks_col.find_one({"_id": task_id})
+    assert updated["status"] == "failed"
+    assert internal_client.closed
+
+
+@pytest.mark.asyncio
+async def test_process_task_closes_internal_client_on_unexpected_failure():
+    """When process_task creates its own client, it must close it after unexpected error."""
+    internal_client = FakeSolutionVLMClient()
+    internal_client.error_to_raise = RuntimeError("boom")
+    storage = FakeStorage()
+    tasks_col = FakeCollection()
+    solutions_col = FakeCollection()
+    problems_col = FakeCollection()
+
+    problem_id = str(ObjectId())
+    task_id = ObjectId()
+
+    problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    task = {"_id": task_id, "problem_id": problem_id, "user_id": "u", "status": "pending"}
+    tasks_col.seed(task)
+
+    with patch(
+        "app.infrastructure.worker.solution_worker.SolutionVLMClient",
+        return_value=internal_client,
+    ):
+        await process_task(task, None, storage, tasks_col, solutions_col, problems_col, 3)
+
+    updated = await tasks_col.find_one({"_id": task_id})
+    assert updated["status"] == "failed"
+    assert internal_client.closed


### PR DESCRIPTION
## Summary

- Add ownership tracking to `process_task` so internally created `SolutionVLMClient` instances are always closed
- Close owned clients in a `finally` block covering success, VLM failure, and unexpected failure paths
- Preserve injected client behavior: callers who pass a client retain ownership

## Linked Issue

Closes #224

## Issue Alignment

This PR implements the issue by:

- Adding an `owned_client` flag that is `True` when `process_task` creates its own `SolutionVLMClient`
- Wrapping task processing in `try`/`finally` with `await task_client.aclose()` for owned clients
- Adding tests that prove internally created clients are closed on success, VLM failure, and unexpected failure
- Adding assertions that injected clients are NOT closed

Scope covered:

- Ownership tracking in `process_task`
- Client closure in `finally` block
- Tests for all client lifecycle paths

Out of scope / intentionally not included:

- Worker loop refactoring
- Retry/backoff changes
- Subject routing changes
- Long-lived client cache

## Implementation Notes

- The fix is 3 lines of production code: one `owned_client = False` flag, one `owned_client = True` assignment, and a 2-line `finally` block.
- Used `unittest.mock.patch` to intercept `SolutionVLMClient` construction for testing the "internally created" path.

## Tests

Commands run:

- `uv run --frozen pytest tests/worker/test_solution_worker.py` — 8 tests passed
- `uv run --frozen pytest` — 299 passed, 1 skipped (full backend suite)

Automated tests added or updated:

- Updated `FakeSolutionVLMClient` to track `closed` state via `aclose()`
- Added `assert not client.closed` to 3 existing tests verifying injected clients survive
- Added `test_process_task_closes_internal_client_on_success`
- Added `test_process_task_closes_internal_client_on_vlm_failure`
- Added `test_process_task_closes_internal_client_on_unexpected_failure`

Manual verification:

- `rg -n "aclose\|owned_client" backend/app/infrastructure/worker/solution_worker.py` confirms the ownership flag and cleanup are in place

## Deviations From Issue Plan

None.

## Follow-Up Work

None.