### PR TITLE
Reject invalid Helper VLM subject classification output

### DIFF
--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -102,8 +102,8 @@ class _ExtractionProviderPayload(BaseModel):
 class _ClassificationProviderPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
-    subject: str
-    confidence: float
+    subject: Literal["math", "english"]
+    confidence: float = Field(ge=0, le=1)
     reason: str
     provider_metadata: dict[str, Any] = Field(default_factory=dict, alias="providerMetadata")
 
@@ -163,8 +163,8 @@ class ExtractionResult(BaseModel):
 class ClassificationResult(BaseModel):
     request_type: Literal["subject-classification"]
     model: str
-    subject: str
-    confidence: float
+    subject: Literal["math", "english"]
+    confidence: float = Field(ge=0, le=1)
     reason: str
     provider_metadata: dict[str, Any]
     raw_provider_response: dict[str, Any]

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -13,6 +13,7 @@ from app.infrastructure.vlm.client import (
     FAILURE_CODE_PROVIDER_REJECTED,
     FAILURE_CODE_STALE_PREVIEW,
     FAILURE_CODE_TIMEOUT,
+    ClassificationResult,
     ExtractionResult,
     GradingResult,
     VLMClient,
@@ -423,3 +424,90 @@ def test_recover_stale_preview_ignores_fresh_extractions() -> None:
     }
 
     assert recover_stale_preview(preview, now=now, extracting_window_seconds=30) is None
+
+
+def _classification_handler(subject: str, confidence: float) -> httpx.AsyncClient:
+    """Build a mock VLM client that returns a classification response."""
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "subject": subject,
+                                    "confidence": confidence,
+                                    "reason": "test",
+                                    "providerMetadata": {"provider": "demo"},
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    return _build_client(handler)
+
+
+@pytest.mark.asyncio
+async def test_vlm_classification_happy_path_math() -> None:
+    client = _classification_handler("math", 0.95)
+    result = await client.classify_subject(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert isinstance(result, ClassificationResult)
+    assert result.subject == "math"
+    assert result.confidence == 0.95
+
+
+@pytest.mark.asyncio
+async def test_vlm_classification_happy_path_english() -> None:
+    client = _classification_handler("english", 0.8)
+    result = await client.classify_subject(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert isinstance(result, ClassificationResult)
+    assert result.subject == "english"
+    assert result.confidence == 0.8
+
+
+@pytest.mark.asyncio
+async def test_vlm_classification_rejects_invalid_subject() -> None:
+    client = _classification_handler("science", 0.9)
+
+    with pytest.raises(VLMError) as exc_info:
+        await client.classify_subject(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_vlm_classification_rejects_confidence_below_zero() -> None:
+    client = _classification_handler("math", -0.1)
+
+    with pytest.raises(VLMError) as exc_info:
+        await client.classify_subject(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_vlm_classification_rejects_confidence_above_one() -> None:
+    client = _classification_handler("english", 1.5)
+
+    with pytest.raises(VLMError) as exc_info:
+        await client.classify_subject(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False


### PR DESCRIPTION
## Summary

- Constrain `_ClassificationProviderPayload.subject` and `ClassificationResult.subject` to `Literal["math", "english"]`
- Constrain `confidence` to `Field(ge=0, le=1)` on both payload and result models
- Invalid VLM output (bad subject or out-of-range confidence) now raises `VLMError(code="vlm-invalid-response")` via existing `_validate_response` error handling

## Linked Issue

Closes #223

## Issue Alignment

This PR implements the issue by:

- Using Pydantic `Literal["math", "english"]` for subject validation
- Using Pydantic `Field(ge=0, le=1)` for confidence validation
- Relying on the existing `_validate_response` method which catches `ValidationError` and raises `VLMError(code="vlm-invalid-response")`
- Adding regression tests for invalid subject and invalid confidence values

Scope covered:

- Subject constrained to `math` or `english`
- Confidence constrained to `[0.0, 1.0]`
- Invalid output raises `VLMError` with `vlm-invalid-response`
- Tests for valid and invalid classifier responses

Out of scope / intentionally not included:

- Helper failure fallback behavior changes
- New subjects beyond `math` and `english`
- Ingestion routing changes
- Frontend subject selector behavior

## Implementation Notes

- The fix is 4 lines of production code changes (2 field declarations × 2 models)
- Pydantic validation is enforced at model construction time, so `_validate_response` already handles the `ValidationError` → `VLMError` translation
- No new error handling code needed — the existing `_validate_response` catch block handles it

## Tests

Commands run:

- `uv run --frozen pytest tests/infrastructure/test_vlm.py` — 20 tests passed
- `uv run --frozen pytest tests/api/test_ingestion.py` — 29 tests passed
- `uv run --frozen pytest` — 304 passed, 1 skipped (full backend suite)

Automated tests added or updated:

- `test_vlm_classification_happy_path_math` — valid `math` response works
- `test_vlm_classification_happy_path_english` — valid `english` response works
- `test_vlm_classification_rejects_invalid_subject` — `"science"` raises `vlm-invalid-response`
- `test_vlm_classification_rejects_confidence_below_zero` — `-0.1` raises `vlm-invalid-response`
- `test_vlm_classification_rejects_confidence_above_one` — `1.5` raises `vlm-invalid-response`

Manual verification:

- `rg -n "subject: str\|confidence: float" backend/app/infrastructure/vlm/client.py` — no bare `str`/`float` on classification models; all use `Literal` or `Field` constraints

## Deviations From Issue Plan

None.

## Follow-Up Work

None.