### PR TITLE
Make Helper VLM classification failures explicit and recoverable

### DIFF
--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -196,6 +196,20 @@ async def create_preview(
             "failureCode": exc.code,
             "failureMessage": str(exc),
         }
+        preview["status"] = IngestionPreviewStatus.VLM_FAILED.value
+        preview["updatedAt"] = utc_now()
+        await database["ingestion_previews"].update_one(
+            {"_id": preview["_id"]},
+            {
+                "$set": {
+                    "status": preview["status"],
+                    "helperDetection": preview["helperDetection"],
+                    "updatedAt": preview["updatedAt"],
+                },
+            },
+        )
+        await _maybe_close_vlm_client(helper_vlm_client)
+        return PreviewResponse(preview=serialize_preview(preview))
     finally:
         await _maybe_close_vlm_client(helper_vlm_client)
 

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -1182,7 +1182,7 @@ async def test_retry_uses_edited_subject_for_routing(
 
 
 @pytest.mark.asyncio
-async def test_helper_failure_records_failure_metadata_and_falls_back_to_math(
+async def test_helper_failure_marks_preview_vlm_failed(
     ingestion_app: FastAPI,
     authenticated_client: AsyncClient,
 ) -> None:
@@ -1198,7 +1198,6 @@ async def test_helper_failure_records_failure_metadata_and_falls_back_to_math(
             raw_provider_response={"detail": "bad request"},
         )
     ]
-    math_vlm.responses = [make_extraction_result(text="Fallback math result")]
 
     image_bytes = make_png_bytes()
     create_response = await authenticated_client.post(
@@ -1208,15 +1207,66 @@ async def test_helper_failure_records_failure_metadata_and_falls_back_to_math(
 
     assert create_response.status_code == 201
     preview = create_response.json()["preview"]
-    assert preview["status"] == "ready"
-    assert preview["draft"]["text"] == "Fallback math result"
-    assert preview["draft"]["subject"] == "math"
+    assert preview["status"] == "vlm-failed"
     assert preview["helperDetection"]["subject"] is None
     assert preview["helperDetection"]["failureCode"] == "helper-error"
     assert preview["helperDetection"]["failureMessage"] == "Helper VLM failed"
 
-    assert len(math_vlm.calls) == 1
+    # No extraction attempted
+    assert len(math_vlm.calls) == 0
     assert len(english_vlm.calls) == 0
+
+
+async def test_helper_failure_recovery_via_manual_subject_and_retry(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    helper_vlm: FakeVLMClient = ingestion_app.state.fake_helper_vlm_client
+    math_vlm: FakeVLMClient = ingestion_app.state.fake_math_ingestion_vlm_client
+    english_vlm: FakeVLMClient = ingestion_app.state.fake_english_ingestion_vlm_client
+
+    # Helper fails
+    helper_vlm.responses = [
+        VLMError(
+            "Helper VLM failed",
+            code="helper-error",
+            retryable=False,
+            raw_provider_response={"detail": "bad request"},
+        )
+    ]
+
+    image_bytes = make_png_bytes()
+    create_response = await authenticated_client.post(
+        "/api/v1/ingestion-previews",
+        files={"image": ("test.png", image_bytes, "image/png")},
+    )
+
+    assert create_response.status_code == 201
+    preview = create_response.json()["preview"]
+    preview_id = preview["id"]
+    assert preview["status"] == "vlm-failed"
+
+    # User manually selects English subject
+    patch_response = await authenticated_client.patch(
+        f"/api/v1/ingestion-previews/{preview_id}",
+        json={"subject": "english"},
+    )
+    assert patch_response.status_code == 200
+    assert patch_response.json()["preview"]["draft"]["subject"] == "english"
+
+    # Retry with manually selected subject
+    english_vlm.responses = [make_extraction_result(text="English passage")]
+    retry_response = await authenticated_client.post(
+        f"/api/v1/ingestion-previews/{preview_id}/retry",
+    )
+    assert retry_response.status_code == 200
+    retried = retry_response.json()["preview"]
+    assert retried["status"] == "ready"
+    assert retried["draft"]["text"] == "English passage"
+    assert retried["draft"]["subject"] == "english"
+
+    assert len(english_vlm.calls) == 1
+    assert len(math_vlm.calls) == 0
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/IngestionWizard.test.tsx
+++ b/frontend/src/components/IngestionWizard.test.tsx
@@ -265,6 +265,45 @@ describe("IngestionWizard", () => {
 
       expect(screen.queryByText("View error details")).not.toBeInTheDocument();
     });
+
+    it("shows helper classification failure message when helperDetection has failureCode", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "vlm-failed",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {},
+              helperDetection: {
+                subject: null,
+                failureCode: "vlm-timeout",
+                failureMessage: "Helper VLM request timed out",
+              },
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test"], "test.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Subject Classification Failed/)).toBeInTheDocument();
+      });
+      expect(screen.getByText(/select the subject manually/)).toBeInTheDocument();
+    });
   });
 
   describe("choice preview", () => {

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -36,12 +36,23 @@ interface PreviewExtraction {
   [key: string]: unknown;
 }
 
+interface PreviewHelperDetection {
+  subject?: string | null;
+  confidence?: number | null;
+  reason?: string | null;
+  model?: string | null;
+  failureCode?: string | null;
+  failureMessage?: string | null;
+  [key: string]: unknown;
+}
+
 export interface IngestionPreview {
   id: string;
   status: "extracting" | "ready" | "vlm-failed" | "graph-error";
   sourceImage: PreviewSourceImage;
   draft: PreviewDraft;
   extraction: PreviewExtraction;
+  helperDetection?: PreviewHelperDetection;
   createdAt: string;
   updatedAt: string;
   expiresAt: string;
@@ -359,7 +370,15 @@ function PreviewStep({ preview, isLoading, onRetry, setFormData, setCurrentStep,
           />
         </div>
       )}
-      {preview?.status === "vlm-failed" && (
+      {preview?.status === "vlm-failed" && (() => {
+        const isHelperFailure = preview?.helperDetection?.failureCode;
+        const failureCode = isHelperFailure
+          ? preview.helperDetection.failureCode
+          : preview?.extraction?.failureCode;
+        const failureMessage = isHelperFailure
+          ? preview.helperDetection.failureMessage
+          : preview?.extraction?.failureMessage;
+        return (
         <div
           style={{
             padding: "16px",
@@ -369,12 +388,14 @@ function PreviewStep({ preview, isLoading, onRetry, setFormData, setCurrentStep,
           }}
         >
           <div style={{ color: "var(--color-text-danger)", fontWeight: 600, marginBottom: "8px" }}>
-            ⚠️ Extraction Failed
+            ⚠️ {isHelperFailure ? "Subject Classification Failed" : "Extraction Failed"}
           </div>
           <p style={{ color: "var(--color-text-danger-secondary)", fontSize: "14px", margin: "0 0 12px" }}>
-            The AI was unable to extract problem data from the image.
+            {isHelperFailure
+              ? "The AI could not determine the subject (math or English). Please select the subject manually and retry."
+              : "The AI was unable to extract problem data from the image."}
           </p>
-          {(preview?.extraction?.failureCode || preview?.extraction?.failureMessage) && (
+          {(failureCode || failureMessage) && (
             <details style={{ marginBottom: "12px" }}>
               <summary style={{ cursor: "pointer", color: "var(--color-text-danger-secondary)", fontSize: "13px" }}>
                 View error details
@@ -389,16 +410,16 @@ function PreviewStep({ preview, isLoading, onRetry, setFormData, setCurrentStep,
                   fontFamily: "monospace",
                 }}
               >
-                {preview.extraction.failureCode && (
+                {failureCode && (
                   <div style={{ marginBottom: "8px" }}>
-                    <span style={{ fontWeight: 600 }}>Code:</span> {preview.extraction.failureCode}
+                    <span style={{ fontWeight: 600 }}>Code:</span> {failureCode}
                   </div>
                 )}
-                {preview.extraction.failureMessage && (
+                {failureMessage && (
                   <div>
                     <span style={{ fontWeight: 600 }}>Message:</span>{" "}
                     <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
-                      {preview.extraction.failureMessage}
+                      {failureMessage}
                     </pre>
                   </div>
                 )}
@@ -442,7 +463,8 @@ function PreviewStep({ preview, isLoading, onRetry, setFormData, setCurrentStep,
             </button>
           </div>
         </div>
-      )}
+        );
+      })()}
       {preview?.status === "graph-error" && (
         <div
           style={{

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -371,12 +371,13 @@ function PreviewStep({ preview, isLoading, onRetry, setFormData, setCurrentStep,
         </div>
       )}
       {preview?.status === "vlm-failed" && (() => {
-        const isHelperFailure = preview?.helperDetection?.failureCode;
+        const helperDetection = preview?.helperDetection;
+        const isHelperFailure = helperDetection?.failureCode;
         const failureCode = isHelperFailure
-          ? preview.helperDetection.failureCode
+          ? helperDetection.failureCode
           : preview?.extraction?.failureCode;
         const failureMessage = isHelperFailure
-          ? preview.helperDetection.failureMessage
+          ? helperDetection.failureMessage
           : preview?.extraction?.failureMessage;
         return (
         <div


### PR DESCRIPTION
## Summary

- Mark preview as vlm-failed when helper classification fails (no silent fallback to math)
- Return early with failed preview — no extraction attempted on helper failure
- Add helperDetection to frontend IngestionPreview interface
- Show "Subject Classification Failed" when failure is from helper, "Extraction Failed" when from extraction
- User can manually select subject and retry after helper failure

## Linked Issue

Closes #221

## Issue Alignment

This PR implements the issue by:

- Changing helper failure behavior from silent fallback-to-math to explicit vlm-failed status
- Storing helper failure details in helperDetection field (already existed in backend)
- Exposing helperDetection in frontend IngestionPreview interface
- Showing distinct error messages for helper vs extraction failures
- Preserving the manual subject selection + retry recovery path

Scope covered:

- Helper failure marks preview as vlm-failed
- Helper failure is visible in API response and frontend
- User can recover by manually selecting subject and retrying
- Backend and frontend tests updated

Out of scope / intentionally not included:

- Validating classifier payload values (tracked separately)
- Changing subject-specific ingestion prompts
- Changing solution/coaching routing
- Adding more than two subjects

## Implementation Notes

- Backend change is minimal: in the except VLMError block, set status to vlm-failed and return early instead of continuing with math extraction
- Frontend uses an IIFE in JSX to compute isHelperFailure and show the appropriate message
- The existing patch_preview and retry_preview endpoints already support the recovery flow (subject change + retry on vlm-failed status)

## Tests

Commands run:

- uv run --frozen pytest tests/api/test_ingestion.py — 30 tests passed
- uv run --frozen pytest — 310 passed, 1 skipped (full backend suite)
- npx vitest --run src/components/IngestionWizard.test.tsx — 14 tests passed
- npx vitest --run — 253 passed (full frontend suite)

Automated tests added or updated:

- test_helper_failure_marks_preview_vlm_failed — verifies preview status is vlm-failed, no extraction attempted
- test_helper_failure_recovery_via_manual_subject_and_retry — verifies manual subject selection + retry works end-to-end
- Frontend test: shows "Subject Classification Failed" when helperDetection has failureCode

Manual verification:

- rg helperDetection backend/app frontend/src — confirms helper failure data flows from backend to frontend

## Deviations From Issue Plan

None.

## Follow-Up Work

None.