### PR TITLE
Avoid closing Helper VLM client twice on ingestion classification failure

### DIFF
--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -208,7 +208,6 @@ async def create_preview(
                 },
             },
         )
-        await _maybe_close_vlm_client(helper_vlm_client)
         return PreviewResponse(preview=serialize_preview(preview))
     finally:
         await _maybe_close_vlm_client(helper_vlm_client)

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -206,7 +206,11 @@ class FakeVLMClient:
         self._model = model
         self.responses: list[Any] = []
         self.calls: list[dict[str, Any]] = []
-        self.closed = False
+        self.close_count = 0
+
+    @property
+    def closed(self) -> bool:
+        return self.close_count > 0
 
     @property
     def model(self) -> str:
@@ -240,7 +244,7 @@ class FakeVLMClient:
         return response
 
     async def aclose(self) -> None:
-        self.closed = True
+        self.close_count += 1
 
 
 def make_png_bytes() -> bytes:
@@ -1217,6 +1221,34 @@ async def test_helper_failure_marks_preview_vlm_failed(
     assert len(english_vlm.calls) == 0
 
 
+@pytest.mark.asyncio
+async def test_helper_failure_closes_helper_client_exactly_once(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    helper_vlm: FakeVLMClient = ingestion_app.state.fake_helper_vlm_client
+
+    helper_vlm.responses = [
+        VLMError(
+            "Helper VLM failed",
+            code="helper-error",
+            retryable=False,
+            raw_provider_response={"detail": "bad request"},
+        )
+    ]
+
+    image_bytes = make_png_bytes()
+    create_response = await authenticated_client.post(
+        "/api/v1/ingestion-previews",
+        files={"image": ("test.png", image_bytes, "image/png")},
+    )
+
+    assert create_response.status_code == 201
+    assert create_response.json()["preview"]["status"] == "vlm-failed"
+    assert helper_vlm.close_count == 1
+
+
+@pytest.mark.asyncio
 async def test_helper_failure_recovery_via_manual_subject_and_retry(
     ingestion_app: FastAPI,
     authenticated_client: AsyncClient,


### PR DESCRIPTION
## Summary

- Remove duplicate `_maybe_close_vlm_client(helper_vlm_client)` call from the `except VLMError` block in ingestion preview creation
- Let the existing `finally` block handle cleanup for both success and failure paths
- Update `FakeVLMClient` to track close-call count instead of boolean flag
- Add regression test asserting helper client is closed exactly once on failure

## Linked Issue

Closes #232

## Issue Alignment

This PR implements the issue by:

- Removing the explicit close call from the `except VLMError` branch (line 211)
- Keeping the `finally` block as the single cleanup path
- Adding a regression test that would fail against the old code (close_count would be 2)

Scope covered:

- Remove duplicate close call from helper-classification failure path
- Add regression test for close-call count
- Preserve all existing helper-failure response and persistence behavior

Out of scope / intentionally not included:

- Reworking all VLM client lifecycle management
- Changing dependency injection ownership semantics
- Changing Helper VLM classification behavior
- Changing frontend helper-failure recovery behavior

## Implementation Notes

- The fix is 1 line removed: `await _maybe_close_vlm_client(helper_vlm_client)` in the `except VLMError` block
- The `finally` block already calls `_maybe_close_vlm_client(helper_vlm_client)` for both success and failure paths
- Updated `FakeVLMClient.aclose()` to increment `close_count` instead of setting `closed = True`
- Added `closed` as a computed property (`close_count > 0`) for backward compatibility

## Tests

Commands run:

- `uv run --frozen pytest tests/api/test_ingestion.py` — 31 tests passed
- `uv run --frozen pytest` — 311 passed, 1 skipped (full backend suite)

Automated tests added or updated:

- `test_helper_failure_closes_helper_client_exactly_once` — asserts `helper_vlm.close_count == 1` after helper failure

Manual verification:

- The new test would fail against the old code because `close_count` would be 2

## Deviations From Issue Plan

None.

## Follow-Up Work

None.