### PR TITLE
feat(#235): make coaching whiteboard collapsible to expand chat

### DIFF
--- a/frontend/src/pages/CoachingPage.test.tsx
+++ b/frontend/src/pages/CoachingPage.test.tsx
@@ -572,4 +572,112 @@ describe("CoachingPage", () => {
     expect(coachReply).toBeTruthy();
     expect(coachReply!.textContent).toContain("The answer is x = 2.");
   });
+
+  it("whiteboard starts expanded by default with collapse button visible", async () => {
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard")).toBeInTheDocument();
+    });
+
+    // Full whiteboard canvas/empty state is visible
+    expect(screen.getByTestId("whiteboard-empty")).toBeInTheDocument();
+    // Collapse button is present
+    expect(screen.getByTestId("whiteboard-collapse")).toBeInTheDocument();
+    // Expand button (in rail) is not present
+    expect(screen.queryByTestId("whiteboard-expand")).not.toBeInTheDocument();
+  });
+
+  it("clicking collapse hides full whiteboard and shows compact rail with expand button", async () => {
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationWithMessages);
+
+    const user = userEvent.setup();
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard-collapse")).toBeInTheDocument();
+    });
+
+    // Collapse the whiteboard
+    await user.click(screen.getByTestId("whiteboard-collapse"));
+
+    // The whiteboard should no longer contain the full graph-sandbox canvas
+    const whiteboard = screen.getByTestId("whiteboard");
+    expect(within(whiteboard).queryByTestId("graph-sandbox")).not.toBeInTheDocument();
+    // Expand button should now be present
+    expect(screen.getByTestId("whiteboard-expand")).toBeInTheDocument();
+    // Vertical label is shown
+    expect(whiteboard.textContent).toContain("Whiteboard");
+  });
+
+  it("clicking expand restores full whiteboard content after collapsing", async () => {
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(mockConversationWithMessages);
+
+    const user = userEvent.setup();
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard-collapse")).toBeInTheDocument();
+    });
+
+    // Collapse
+    await user.click(screen.getByTestId("whiteboard-collapse"));
+    expect(screen.getByTestId("whiteboard-expand")).toBeInTheDocument();
+
+    // Expand
+    await user.click(screen.getByTestId("whiteboard-expand"));
+
+    // Full whiteboard is restored with graph sandbox
+    const whiteboard = screen.getByTestId("whiteboard");
+    await waitFor(() => {
+      expect(within(whiteboard).getByTestId("whiteboard-collapse")).toBeInTheDocument();
+    });
+    expect(within(whiteboard).getByTestId("graph-sandbox")).toBeInTheDocument();
+    expect(screen.queryByTestId("whiteboard-expand")).not.toBeInTheDocument();
+  });
+
+  it("whiteboard pagination and DSL rendering still work after re-expansion", async () => {
+    const conversationWithMultipleWhiteboards: CoachingConversation = {
+      problem_id: "prob-123",
+      user_id: "user-456",
+      messages: [
+        {
+          role: "coach",
+          content: "Drawing 1",
+          whiteboard_dsl: "board.create('circle', [[0,0], 2]);",
+          created_at: "2026-05-25T12:31:00Z",
+        },
+        {
+          role: "coach",
+          content: "Drawing 2",
+          whiteboard_dsl: "board.create('circle', [[1,1], 3]);",
+          created_at: "2026-05-25T12:32:00Z",
+        },
+      ],
+      created_at: "2026-05-25T12:30:00Z",
+      updated_at: "2026-05-25T12:32:00Z",
+    };
+
+    vi.spyOn(api, "getCoachingConversation").mockResolvedValue(conversationWithMultipleWhiteboards);
+
+    const user = userEvent.setup();
+    renderCoachingPage("prob-123", "/practice");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard-collapse")).toBeInTheDocument();
+    });
+
+    // Collapse and re-expand
+    await user.click(screen.getByTestId("whiteboard-collapse"));
+    await user.click(screen.getByTestId("whiteboard-expand"));
+
+    // Pagination still works on the latest page
+    await waitFor(() => {
+      expect(screen.getByTestId("whiteboard-page-indicator")).toHaveTextContent("2 / 2");
+    });
+
+    // Navigate to previous page
+    await user.click(screen.getByTestId("whiteboard-prev"));
+    expect(screen.getByTestId("whiteboard-page-indicator")).toHaveTextContent("1 / 2");
+  });
 });

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -81,6 +81,9 @@ export function CoachingPage() {
   const [whiteboardError, setWhiteboardError] = useState<string | null>(null);
   const [chatError, setChatError] = useState<string | null>(null);
 
+  // Whiteboard collapse state
+  const [isWhiteboardCollapsed, setIsWhiteboardCollapsed] = useState(false);
+
   // Active whiteboard page index
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
 
@@ -291,7 +294,7 @@ export function CoachingPage() {
       </div>
 
       {/* Main split layout container */}
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 1.2fr", gap: "1.5rem", flex: 1, minHeight: "650px", alignItems: "stretch" }}>
+      <div style={{ display: "grid", gridTemplateColumns: isWhiteboardCollapsed ? "1fr 48px" : "1fr 1.2fr", gap: "1.5rem", flex: 1, minHeight: "650px", alignItems: "stretch" }}>
         
         {/* Left side: Context + Chat Area */}
         <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
@@ -589,6 +592,44 @@ export function CoachingPage() {
         </div>
 
         {/* Right side: Interactive Whiteboard Area */}
+        {isWhiteboardCollapsed ? (
+          <div
+            data-testid="whiteboard"
+            style={{
+              backgroundColor: "var(--color-surface)",
+              borderRadius: "0.75rem",
+              border: "1px solid var(--color-border)",
+              boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+              padding: "0.5rem",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "flex-start",
+              gap: "0.5rem",
+              minHeight: "650px",
+            }}
+          >
+            <button
+              onClick={() => setIsWhiteboardCollapsed(false)}
+              data-testid="whiteboard-expand"
+              aria-label="Expand whiteboard"
+              style={{
+                padding: "0.375rem",
+                borderRadius: "0.25rem",
+                border: "1px solid var(--color-border)",
+                backgroundColor: "var(--color-surface)",
+                cursor: "pointer",
+                fontSize: "1rem",
+                lineHeight: 1,
+              }}
+            >
+              ◀
+            </button>
+            <span style={{ writingMode: "vertical-rl", fontSize: "0.75rem", fontWeight: 600, color: "var(--color-text-muted)", letterSpacing: "0.05em" }}>
+              🎨 Whiteboard
+            </span>
+          </div>
+        ) : (
         <div
           data-testid="whiteboard"
           style={{
@@ -609,54 +650,74 @@ export function CoachingPage() {
               <strong style={{ fontSize: "1rem", color: "var(--color-text)", fontWeight: 700 }}>Interactive Whiteboard</strong>
             </div>
 
-            {/* Whiteboard pagination controls */}
-            {dslPages.length > 0 && (
-              <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-                <button
-                  onClick={() => {
-                    setCurrentPageIndex((prev) => Math.max(0, prev - 1));
-                    setWhiteboardError(null);
-                  }}
-                  disabled={currentPageIndex === 0}
-                  data-testid="whiteboard-prev"
-                  style={{
-                    padding: "0.25rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    border: "1px solid var(--color-border)",
-                    backgroundColor: "var(--color-surface)",
-                    cursor: currentPageIndex === 0 ? "not-allowed" : "pointer",
-                    fontSize: "0.875rem",
-                    fontWeight: 600,
-                  }}
-                >
-                  ◀
-                </button>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              {/* Whiteboard pagination controls */}
+              {dslPages.length > 0 && (
+                <>
+                  <button
+                    onClick={() => {
+                      setCurrentPageIndex((prev) => Math.max(0, prev - 1));
+                      setWhiteboardError(null);
+                    }}
+                    disabled={currentPageIndex === 0}
+                    data-testid="whiteboard-prev"
+                    style={{
+                      padding: "0.25rem 0.5rem",
+                      borderRadius: "0.25rem",
+                      border: "1px solid var(--color-border)",
+                      backgroundColor: "var(--color-surface)",
+                      cursor: currentPageIndex === 0 ? "not-allowed" : "pointer",
+                      fontSize: "0.875rem",
+                      fontWeight: 600,
+                    }}
+                  >
+                    ◀
+                  </button>
 
-                <span data-testid="whiteboard-page-indicator" style={{ fontSize: "0.875rem", fontWeight: 600, color: "var(--color-text-muted)" }}>
-                  {currentPageIndex + 1} / {dslPages.length}
-                </span>
+                  <span data-testid="whiteboard-page-indicator" style={{ fontSize: "0.875rem", fontWeight: 600, color: "var(--color-text-muted)" }}>
+                    {currentPageIndex + 1} / {dslPages.length}
+                  </span>
 
-                <button
-                  onClick={() => {
-                    setCurrentPageIndex((prev) => Math.min(dslPages.length - 1, prev + 1));
-                    setWhiteboardError(null);
-                  }}
-                  disabled={currentPageIndex === dslPages.length - 1}
-                  data-testid="whiteboard-next"
-                  style={{
-                    padding: "0.25rem 0.5rem",
-                    borderRadius: "0.25rem",
-                    border: "1px solid var(--color-border)",
-                    backgroundColor: "var(--color-surface)",
-                    cursor: currentPageIndex === dslPages.length - 1 ? "not-allowed" : "pointer",
-                    fontSize: "0.875rem",
-                    fontWeight: 600,
-                  }}
-                >
-                  ▶
-                </button>
-              </div>
-            )}
+                  <button
+                    onClick={() => {
+                      setCurrentPageIndex((prev) => Math.min(dslPages.length - 1, prev + 1));
+                      setWhiteboardError(null);
+                    }}
+                    disabled={currentPageIndex === dslPages.length - 1}
+                    data-testid="whiteboard-next"
+                    style={{
+                      padding: "0.25rem 0.5rem",
+                      borderRadius: "0.25rem",
+                      border: "1px solid var(--color-border)",
+                      backgroundColor: "var(--color-surface)",
+                      cursor: currentPageIndex === dslPages.length - 1 ? "not-allowed" : "pointer",
+                      fontSize: "0.875rem",
+                      fontWeight: 600,
+                    }}
+                  >
+                    ▶
+                  </button>
+                </>
+              )}
+
+              {/* Collapse button */}
+              <button
+                onClick={() => setIsWhiteboardCollapsed(true)}
+                data-testid="whiteboard-collapse"
+                aria-label="Collapse whiteboard"
+                style={{
+                  padding: "0.25rem 0.5rem",
+                  borderRadius: "0.25rem",
+                  border: "1px solid var(--color-border)",
+                  backgroundColor: "var(--color-surface)",
+                  cursor: "pointer",
+                  fontSize: "0.875rem",
+                  fontWeight: 600,
+                }}
+              >
+                ▶
+              </button>
+            </div>
           </div>
 
           {/* Canvas area wrapper */}
@@ -729,6 +790,7 @@ export function CoachingPage() {
             }
           </div>
         </div>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

- Add a collapse/expand toggle to the coaching whiteboard so students can hide it and expand the chat/context area.

## Linked Issue

Closes #235

## Issue Alignment

This PR implements the issue by:

- Adding local `isWhiteboardCollapsed` state to `CoachingPage`.
- Rendering a collapse button (▶) in the expanded whiteboard header bar.
- When collapsed, rendering a narrow 48px right-side rail with a vertical "🎨 Whiteboard" label and an expand button (◀).
- Dynamically adjusting the grid layout: expanded uses `1fr 1.2fr`, collapsed uses `1fr 48px`.
- Preserving existing whiteboard behavior (DSL rendering, pagination, empty state, error display) when expanded.

Scope covered:

- Local UI state for collapse/expand.
- Accessible collapse/expand controls with `aria-label` and `data-testid`.
- Dynamic grid layout adjustment.
- Compact right-side rail when collapsed.
- Preservation of expanded whiteboard behavior.

Out of scope / intentionally not included:

- Persisting collapsed state across reloads or sessions.
- Backend changes.
- Chat bubble or message redesign.
- Keyboard shortcuts for toggling.

## Implementation Notes

- The collapsed rail renders only a vertical label and expand button; no `GraphSandbox` canvas is rendered in the narrow rail, avoiding layout issues.
- The grid column for the collapsed state uses a fixed `48px` width, which is wide enough for the expand button and vertical text.
- The collapse state is purely local React state — no persistence, no context, no routing changes.

## Tests

Commands run:

- `cd frontend && npx vitest run src/pages/CoachingPage.test.tsx` — 20 passed
- `cd frontend && npm run build` — succeeded

Automated tests added or updated:

- 4 new tests added in `CoachingPage.test.tsx`:
  - Whiteboard starts expanded by default with collapse button visible.
  - Clicking collapse hides full whiteboard and shows compact rail with expand button.
  - Clicking expand restores full whiteboard content after collapsing.
  - Whiteboard pagination and DSL rendering still work after re-expansion.

Manual verification:

- Build passes without errors or type issues.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.