### PR TITLE
feat(#236): show solution generation status on problem detail page

### DIFF
--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/api/client", () => ({
     patch: vi.fn(),
     delete: vi.fn(),
     verifyTeacherPassword: vi.fn(),
+    getSolutionStatus: vi.fn(),
   },
 }));
 
@@ -80,7 +81,11 @@ describe("ProblemDetailPage", () => {
     vi.mocked(api.patch).mockReset();
     vi.mocked(api.delete).mockReset();
     vi.mocked(api.verifyTeacherPassword).mockReset();
+    vi.mocked(api.getSolutionStatus).mockReset();
     mockNavigate.mockReset();
+
+    // Default: no solution status
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "none" });
   });
 
   it("renders problem details", async () => {
@@ -494,5 +499,96 @@ describe("ProblemDetailPage", () => {
 
     // Edit Answer button should still be visible (teacher-password gated)
     expect(screen.getByTestId("edit-answer-button")).toBeInTheDocument();
+  });
+
+  it("renders Solution Generated and AI Explain button when status is ready", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "ready" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("solution-status")).toHaveTextContent("Solution Generated");
+    });
+    expect(screen.getByTestId("ai-explain-button")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-explain-button")).toHaveTextContent("AI Explain");
+  });
+
+  it("clicking AI Explain navigates to coaching page with from state", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "ready" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-explain-button")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("ai-explain-button"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/coaching/abc123", {
+      state: { from: "/problems/abc123" },
+    });
+  });
+
+  it("renders Solution Pending and no AI Explain button when status is pending", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "pending" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("solution-status")).toHaveTextContent("Solution Pending");
+    });
+    expect(screen.queryByTestId("ai-explain-button")).not.toBeInTheDocument();
+  });
+
+  it("renders Solution Generating and no AI Explain button when status is generating", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "generating" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("solution-status")).toHaveTextContent("Solution Generating");
+    });
+    expect(screen.queryByTestId("ai-explain-button")).not.toBeInTheDocument();
+  });
+
+  it("renders Solution Failed and no AI Explain button when status is failed", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "failed" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("solution-status")).toHaveTextContent("Solution Failed");
+    });
+    expect(screen.queryByTestId("ai-explain-button")).not.toBeInTheDocument();
+  });
+
+  it("renders Solution Not Started when status is none", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "none" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("solution-status")).toHaveTextContent("Solution Not Started");
+    });
+    expect(screen.queryByTestId("ai-explain-button")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -90,6 +90,26 @@ export function ProblemDetailPage() {
     enabled: !!problemId,
   });
 
+  const { data: solutionStatusData } = useQuery({
+    queryKey: ["solution-status", problemId],
+    queryFn: () => api.getSolutionStatus(problemId),
+    enabled: !!problemId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return (status === "pending" || status === "generating") ? 2000 : false;
+    },
+  });
+
+  const solutionStatus = solutionStatusData?.status;
+
+  const solutionStatusLabel: Record<string, string> = {
+    ready: "Solution Generated",
+    pending: "Solution Pending",
+    generating: "Solution Generating",
+    failed: "Solution Failed",
+    none: "Solution Not Started",
+  };
+
   const updateMutation = useMutation({
     mutationFn: (data: UpdateProblemInput) =>
       api.patch<ProblemResponse>(`/problems/${problemId}`, data),
@@ -206,7 +226,7 @@ export function ProblemDetailPage() {
               Reference: {problem.id}
             </div>
           </div>
-          <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
             {problem.isDeleted && (
               <span
                 style={{
@@ -217,6 +237,43 @@ export function ProblemDetailPage() {
               >
                 Deleted
               </span>
+            )}
+            {solutionStatus && (
+              <span
+                data-testid="solution-status"
+                style={{
+                  padding: "0.25rem 0.5rem",
+                  borderRadius: "4px",
+                  fontSize: "0.8125rem",
+                  fontWeight: 600,
+                  ...(solutionStatus === "ready"
+                    ? { background: "var(--color-success-bg)", color: "var(--color-success-text)" }
+                    : solutionStatus === "failed"
+                      ? { background: "var(--color-danger-bg)", color: "var(--color-text-danger-secondary)" }
+                      : { background: "var(--color-warning-bg)", color: "var(--color-warning-text)" }),
+                }}
+              >
+                {solutionStatusLabel[solutionStatus] ?? solutionStatus}
+              </span>
+            )}
+            {solutionStatus === "ready" && (
+              <button
+                type="button"
+                onClick={() => navigate(`/coaching/${problemId}`, { state: { from: `/problems/${problemId}` } })}
+                data-testid="ai-explain-button"
+                style={{
+                  padding: "0.375rem 0.75rem",
+                  borderRadius: "0.25rem",
+                  fontSize: "0.8125rem",
+                  fontWeight: 600,
+                  background: "linear-gradient(135deg, var(--color-link), var(--color-primary))",
+                  color: "white",
+                  border: "none",
+                  cursor: "pointer",
+                }}
+              >
+                AI Explain
+              </button>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Add solution generation status display and AI Explain button to the problem detail page.

## Linked Issue

Closes #236

## Issue Alignment

This PR implements the issue by:

- Adding a React Query call for `api.getSolutionStatus(problemId)` in `ProblemDetailPage`.
- Polling every 2 seconds while status is `pending` or `generating`, matching existing patterns in `ActivePracticePage`, `PracticePage`, and `ExamDetailPage`.
- Mapping backend statuses to user-facing labels: `ready` → `Solution Generated`, `pending` → `Solution Pending`, `generating` → `Solution Generating`, `failed` → `Solution Failed`, `none` → `Solution Not Started`.
- Rendering a status badge in the problem header area with color coding (green for ready, red for failed, yellow/warning for pending/generating/none).
- Rendering an `AI Explain` button beside the status only when status is `ready`.
- On click, navigating to `/coaching/${problemId}` with router state `{ from: `/problems/${problemId}` }`.

Scope covered:

- Solution status fetching with polling.
- Status label rendering for all 5 states.
- AI Explain button for ready status only.
- Navigation to coaching page with from state.
- Frontend tests for all status states and navigation.

Out of scope / intentionally not included:

- Backend changes.
- Coaching page changes.
- Manual retry/regenerate controls.
- Full page redesign.

## Implementation Notes

- Reuses the existing `api.getSolutionStatus(problemId)` API wrapper — no new backend endpoints.
- The `refetchInterval` pattern matches `ActivePracticePage` exactly: returns `2000` for `pending`/`generating`, `false` otherwise.
- Status badge uses the same CSS variable patterns as the rest of the page (`--color-success-bg`, `--color-danger-bg`, `--color-warning-bg`).
- The AI Explain button uses a gradient style consistent with the practice page.

## Tests

Commands run:

- `cd frontend && npx vitest run src/pages/ProblemDetailPage.test.tsx` — 22 passed
- `cd frontend && npm run build` — succeeded

Automated tests added or updated:

- 6 new tests added in `ProblemDetailPage.test.tsx`:
  - `ready` status renders `Solution Generated` and `AI Explain` button.
  - Clicking `AI Explain` navigates to coaching page with correct from state.
  - `pending` status renders `Solution Pending` and no `AI Explain` button.
  - `generating` status renders `Solution Generating` and no `AI Explain` button.
  - `failed` status renders `Solution Failed` and no `AI Explain` button.
  - `none` status renders `Solution Not Started` and no `AI Explain` button.

Manual verification:

- Build passes without errors or type issues.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.