### PR TITLE
Preserve CJK punctuation around inline LaTeX in math ingestion

### DIFF
--- a/backend/app/infrastructure/vlm/prompts.py
+++ b/backend/app/infrastructure/vlm/prompts.py
@@ -17,6 +17,10 @@ Text formatting:
 - Use `$...$` for inline math and `$$...$$` for display math.
 - Put whitespace around inline `$...$` when it is adjacent to words, numbers, or other
   non-punctuation text. For example, write `Find $x$ when $x+1=2$`, not `Find$x$when$x+1=2$`.
+- Do not add spaces between inline `$...$` and Chinese/Japanese-style punctuation such as
+  `，`, `。`, `、`, `；`, `：`, `？`, or `！`. For example, write `$A$、$B$、$C$` and
+  `$80\\text{km}/\\text{h}$，$70\\text{km}/\\text{h}$`, not `$A$ 、 $B$` or
+  `$80\\text{km}/\\text{h}$ ， $70\\text{km}/\\text{h}$`.
 - For single-choice and multi-choice problems, place each option (e.g. A, B, C, D) on its own line.
 
 ## JSXGraph DSL rules

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -488,6 +488,12 @@ def test_math_extraction_prompt_instructs_options_on_own_line() -> None:
     assert "own line" in MATH_EXTRACTION_SYSTEM_PROMPT.lower() or "own line" in MATH_EXTRACTION_SYSTEM_PROMPT
 
 
+def test_math_extraction_prompt_preserves_cjk_punctuation_next_to_inline_latex() -> None:
+    assert "Do not add spaces between inline `$...$` and Chinese/Japanese-style punctuation" in MATH_EXTRACTION_SYSTEM_PROMPT
+    assert "$A$、$B$、$C$" in MATH_EXTRACTION_SYSTEM_PROMPT
+    assert "$80\\text{km}/\\text{h}$，$70\\text{km}/\\text{h}$" in MATH_EXTRACTION_SYSTEM_PROMPT
+
+
 def test_english_extraction_prompt_instructs_options_on_own_line() -> None:
     assert "each option" in ENGLISH_EXTRACTION_SYSTEM_PROMPT.lower() or "each option" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
     assert "own line" in ENGLISH_EXTRACTION_SYSTEM_PROMPT.lower() or "own line" in ENGLISH_EXTRACTION_SYSTEM_PROMPT


### PR DESCRIPTION
## Summary

- Clarify the math ingestion prompt so inline LaTeX stays adjacent to CJK punctuation such as `，`, `。`, and `、`
- Add examples for `$A$、$B$、$C$` and speed values separated by Chinese commas
- Add a prompt regression test to keep the spacing rule in place

## Tests

```bash
uv run --directory backend pytest tests/infrastructure/test_vlm.py -q
# 29 passed in 0.04s
```
