### PR TITLE
feat(#247): add minimum problem age rule to practice and exam selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,8 @@ PRACTICE_COOLDOWN_DAYS=7
 PRACTICE_LAST_WRONG_WEIGHT=1.0
 PRACTICE_FAILURE_RATE_WEIGHT=1.0
 PRACTICE_RECENCY_WEIGHT=1.0
+
+## Problem selection minimum age (days)
+## Problems newer than this threshold are excluded from practice and exam selection.
+## Set to 0 to allow newly created problems to appear immediately.
+PROBLEM_SELECTION_MIN_AGE_DAYS=3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -223,6 +223,7 @@ The canonical template lives in `.env.example`.
 | `PRACTICE_LAST_WRONG_WEIGHT` | Weight for problems last answered incorrectly | `1.0` |
 | `PRACTICE_FAILURE_RATE_WEIGHT` | Weight for problems with high failure rates | `1.0` |
 | `PRACTICE_RECENCY_WEIGHT` | Weight for recently tested problems | `1.0` |
+| `PROBLEM_SELECTION_MIN_AGE_DAYS` | Minimum age (days) before a problem appears in practice or exams | `3` |
 
 ### AI tutoring VLM notes
 

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -120,6 +120,7 @@ class ClientMeta(BaseModel):
 class SelectionPolicyConfig(BaseModel):
     recencyWeight: float
     failureWeight: float
+    minProblemAgeDays: int = 3
 
 
 class ExamConfigSnapshot(BaseModel):

--- a/backend/app/domain/practice_selection.py
+++ b/backend/app/domain/practice_selection.py
@@ -13,6 +13,7 @@ class PracticeSelectionConfig:
     last_wrong_weight: float = 1.0
     failure_rate_weight: float = 1.0
     recency_weight: float = 1.0
+    min_problem_age_days: int = 3
 
 
 @dataclass
@@ -32,6 +33,11 @@ def get_eligible_practice_problems(
             continue
         if not p.correctAnswer or not p.correctAnswer.normalizedText:
             continue
+        if config.min_problem_age_days > 0:
+            created_at = ensure_utc(p.createdAt)
+            age_cutoff = now - timedelta(days=config.min_problem_age_days)
+            if created_at > age_cutoff:
+                continue
         if p.tracking.lastTestedAt:
             last_tested = ensure_utc(p.tracking.lastTestedAt)
             cutoff = now - timedelta(days=config.cooldown_days)

--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from typing import List
 import random
 from .models import Problem, SelectionPolicyConfig
@@ -16,15 +16,21 @@ def select_problems(
     config: SelectionPolicyConfig,
     rng: random.Random | None = None
 ) -> List[Problem]:
-    eligible = [
-        p for p in problems
-        if not p.isDeleted
-    ]
+    now = datetime.now(timezone.utc)
+    eligible = []
+    for p in problems:
+        if p.isDeleted:
+            continue
+        if config.minProblemAgeDays > 0:
+            created_at = ensure_utc(p.createdAt)
+            age_cutoff = now - timedelta(days=config.minProblemAgeDays)
+            if created_at > age_cutoff:
+                continue
+        eligible.append(p)
 
     if not eligible:
         return []
 
-    now = datetime.now(timezone.utc)
     weighted = []
 
     for problem in eligible:

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -87,6 +87,9 @@ class Settings(BaseSettings):
     practice_failure_rate_weight: float = Field(default=1.0, ge=0)
     practice_recency_weight: float = Field(default=1.0, ge=0)
 
+    # Problem selection minimum age
+    problem_selection_min_age_days: int = Field(default=3, ge=0)
+
     # Teacher password configuration
     teacher_password_default: str = Field(default="default-teacher-password")
 

--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -63,6 +63,7 @@ class ExamItemPayload(BaseModel):
 class SelectionPolicyPayload(BaseModel):
     recencyWeight: float
     failureWeight: float
+    minProblemAgeDays: int = 3
 
 
 class ExamConfigSnapshotPayload(BaseModel):
@@ -200,6 +201,7 @@ def serialize_exam(exam: Mapping[str, Any]) -> ExamPayload:
             selectionPolicy=SelectionPolicyPayload(
                 recencyWeight=float(selection_policy.get("recencyWeight", 1.0)),
                 failureWeight=float(selection_policy.get("failureWeight", 1.0)),
+                minProblemAgeDays=int(selection_policy.get("minProblemAgeDays", 3)),
             ),
             generatedAt=config_snapshot["generatedAt"],
         ),

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -8,9 +8,10 @@ from typing import Annotated, Any
 from bson import ObjectId
 from fastapi import APIRouter, Depends, Query
 
-from app.domain.models import ExamState, GradingStatus, ProblemType
+from app.domain.models import ExamState, GradingStatus, ProblemType, SelectionPolicyConfig
 from app.domain.selection import select_problems
 from app.domain.state import transition_exam_state
+from app.infrastructure.config.settings import Settings, get_settings
 from app.infrastructure.storage.mongo import Document, MongoClientAdapter, get_mongo_adapter
 from app.presentation.exam_grading import build_tracking_update, grade_item
 from app.presentation.exam_helpers import (
@@ -49,6 +50,7 @@ router = APIRouter(prefix="/exams", tags=["exams"])
 
 
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
+SettingsDependency = Annotated[Settings, Depends(get_settings)]
 
 
 def get_exam_mongo_adapter() -> MongoClientAdapter:
@@ -67,8 +69,14 @@ async def create_exam(
     database: DatabaseDependency,
     current_user: CurrentUserDependency,
     adapter: AdapterDependency,
+    settings: SettingsDependency,
 ) -> CreateExamResponse:
     query = {"userId": current_user["_id"], "state": ExamState.IN_PROGRESS.value}
+    selection_policy = SelectionPolicyConfig(
+        recencyWeight=1.0,
+        failureWeight=1.0,
+        minProblemAgeDays=settings.problem_selection_min_age_days,
+    )
 
     async def _transaction(session: Any) -> dict[str, Any]:
         existing = await database["exams"].find_one(query, session=session)
@@ -91,7 +99,7 @@ async def create_exam(
         selected_models = select_problems(
             [problem_document_to_model(problem) for problem in eligible_documents],
             payload.maxProblemCount,
-            DEFAULT_SELECTION_POLICY,
+            selection_policy,
             rng=Random(),
         )
         if not selected_models:
@@ -115,7 +123,7 @@ async def create_exam(
             "state": ExamState.IN_PROGRESS.value,
             "configSnapshot": {
                 "maxProblemCount": payload.maxProblemCount,
-                "selectionPolicy": DEFAULT_SELECTION_POLICY.model_dump(),
+                "selectionPolicy": selection_policy.model_dump(),
                 "generatedAt": now,
             },
             "items": items,

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -15,7 +15,6 @@ from app.infrastructure.config.settings import Settings, get_settings
 from app.infrastructure.storage.mongo import Document, MongoClientAdapter, get_mongo_adapter
 from app.presentation.exam_grading import build_tracking_update, grade_item
 from app.presentation.exam_helpers import (
-    DEFAULT_SELECTION_POLICY,
     build_exam_summary,
     find_item,
     get_owned_exam,

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -101,7 +101,10 @@ async def get_practice_stats(
     ).to_list(length=None)
 
     problem_models = [problem_document_to_model(p) for p in problem_documents]
-    config = PracticeSelectionConfig(cooldown_days=settings.practice_cooldown_days)
+    config = PracticeSelectionConfig(
+        cooldown_days=settings.practice_cooldown_days,
+        min_problem_age_days=settings.problem_selection_min_age_days,
+    )
     now = datetime.now(UTC)
     eligible = get_eligible_practice_problems(problem_models, config, now)
 
@@ -133,6 +136,7 @@ async def get_next_practice_problem(
         last_wrong_weight=settings.practice_last_wrong_weight,
         failure_rate_weight=settings.practice_failure_rate_weight,
         recency_weight=settings.practice_recency_weight,
+        min_problem_age_days=settings.problem_selection_min_age_days,
     )
 
     problem_models = [problem_document_to_model(p) for p in eligible_documents]

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -14,6 +14,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.infrastructure.vlm.client import VLMError
 from app.main import create_app
+from app.infrastructure.config.settings import Settings, get_settings
 from app.presentation.deps import get_current_user, get_database
 from app.presentation.exams import (
     get_exam_mongo_adapter,
@@ -270,8 +271,10 @@ async def exams_app() -> FastAPI:
     application.state.fake_vlm = vlm
     application.state.primary_user = user
 
+    settings = Settings(problem_selection_min_age_days=0)
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
+    application.dependency_overrides[get_settings] = lambda: settings
     application.dependency_overrides[get_exam_mongo_adapter] = lambda: adapter
     application.dependency_overrides[get_exam_storage] = lambda: storage
     application.dependency_overrides[get_exam_vlm_client] = lambda: vlm
@@ -302,7 +305,7 @@ async def test_create_exam_snapshots_selected_problems(exams_app: FastAPI, clien
     assert response.status_code == 201
     body = response.json()["exam"]
     assert body["state"] == "in-progress"
-    assert body["configSnapshot"]["selectionPolicy"] == {"recencyWeight": 1.0, "failureWeight": 1.0}
+    assert body["configSnapshot"]["selectionPolicy"] == {"recencyWeight": 1.0, "failureWeight": 1.0, "minProblemAgeDays": 0}
     assert len(body["items"]) == 2
     assert body["items"][0]["problem"]["correctAnswer"] is None
     stored_exam = database["exams"]._documents[0]
@@ -620,3 +623,75 @@ async def test_submit_exam_marks_pending_review_after_vlm_retry_and_self_report_
     }
     assert database["problems"]._documents[0]["tracking"]["exposureCount"] == 5
     assert database["problems"]._documents[0]["tracking"]["failedCount"] == 3
+
+
+@pytest_asyncio.fixture
+async def exams_app_with_min_age() -> FastAPI:
+    application = create_app()
+    database = FakeDatabase()
+    adapter = FakeMongoAdapter()
+    storage = FakeStorage()
+    vlm = FakeVLMClient()
+    user = make_user()
+
+    settings = Settings(problem_selection_min_age_days=3)
+
+    application.state.fake_database = database
+    application.state.fake_adapter = adapter
+    application.state.fake_storage = storage
+    application.state.fake_grading_vlm = vlm
+    application.state.fake_vlm = vlm
+    application.state.primary_user = user
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
+    application.dependency_overrides[get_settings] = lambda: settings
+    application.dependency_overrides[get_exam_mongo_adapter] = lambda: adapter
+    application.dependency_overrides[get_exam_storage] = lambda: storage
+    application.dependency_overrides[get_exam_vlm_client] = lambda: vlm
+    return application
+
+
+@pytest_asyncio.fixture
+async def client_with_min_age(exams_app_with_min_age: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=exams_app_with_min_age)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_create_exam_rejects_when_all_too_new(
+    exams_app_with_min_age: FastAPI,
+    client_with_min_age: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app_with_min_age.state.fake_database
+    user_id = exams_app_with_min_age.state.primary_user["_id"]
+    new_problem = make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    database["problems"].seed(new_problem)
+
+    response = await client_with_min_age.post("/api/v1/exams", json={"maxProblemCount": 1})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "NO_ELIGIBLE_PROBLEMS"
+
+
+@pytest.mark.asyncio
+async def test_create_exam_succeeds_with_old_problems_and_records_min_age(
+    exams_app_with_min_age: FastAPI,
+    client_with_min_age: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app_with_min_age.state.fake_database
+    storage: FakeStorage = exams_app_with_min_age.state.fake_storage
+    user_id = exams_app_with_min_age.state.primary_user["_id"]
+    old = datetime.now(UTC) - timedelta(days=10)
+    old_problem = make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4", last_tested_at=old)
+    old_problem["createdAt"] = old
+    database["problems"].seed(old_problem)
+    storage.seed(old_problem["sourceImage"]["bucket"], old_problem["sourceImage"]["objectKey"], b"img")
+
+    response = await client_with_min_age.post("/api/v1/exams", json={"maxProblemCount": 1})
+
+    assert response.status_code == 201
+    body = response.json()["exam"]
+    assert body["configSnapshot"]["selectionPolicy"]["minProblemAgeDays"] == 3
+    assert len(body["items"]) == 1

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -20,7 +20,7 @@ from tests.api.conftest import FakeDatabase, make_user, make_problem
 def practice_app() -> FastAPI:
     application = create_app()
     database = FakeDatabase()
-    settings = Settings(practice_cooldown_days=7)
+    settings = Settings(practice_cooldown_days=7, problem_selection_min_age_days=0)
     user = make_user(ObjectId(), "student")
 
     application.state.fake_database = database
@@ -259,3 +259,59 @@ async def test_next_problem_without_graph_dsl(
     data = response.json()
     assert data["status"] == "ok"
     assert "graphDsl" not in data["problem"]
+
+
+@pytest.fixture
+def practice_app_with_min_age() -> FastAPI:
+    application = create_app()
+    database = FakeDatabase()
+    settings = Settings(practice_cooldown_days=7, problem_selection_min_age_days=3)
+    user = make_user(ObjectId(), "student")
+
+    application.state.fake_database = database
+    application.state.user = user
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_app_settings] = lambda: settings
+    application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
+    return application
+
+
+@pytest_asyncio.fixture
+async def client_with_min_age(practice_app_with_min_age: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=practice_app_with_min_age)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_stats_excludes_too_new_problems(
+    practice_app_with_min_age: FastAPI,
+    client_with_min_age: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app_with_min_age.state.fake_database
+    user_id = practice_app_with_min_age.state.user["_id"]
+    old_problem = make_problem(user_id, text="Old", correct_answer_display="1")
+    old_problem["createdAt"] = datetime.now(UTC) - timedelta(days=10)
+    new_problem = make_problem(user_id, text="New", correct_answer_display="2")
+    database.seed("problems", [old_problem, new_problem])
+
+    response = await client_with_min_age.get("/api/v1/practice/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["practiceableCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_next_returns_no_eligible_when_all_too_new(
+    practice_app_with_min_age: FastAPI,
+    client_with_min_age: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app_with_min_age.state.fake_database
+    user_id = practice_app_with_min_age.state.user["_id"]
+    new_problem = make_problem(user_id, text="New", correct_answer_display="1")
+    database.seed("problems", [new_problem])
+
+    response = await client_with_min_age.post("/api/v1/practice/next")
+    assert response.status_code == 200
+    assert response.json()["status"] == "no_eligible"

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -20,6 +20,7 @@ def _make_problem(
     exposure_count: int = 0,
     correct_count: int | None = None,
     failed_count: int = 0,
+    created_at: datetime | None = None,
 ) -> Problem:
     cc = correct_count if correct_count is not None else max(0, exposure_count - failed_count)
     return Problem(
@@ -41,6 +42,7 @@ def _make_problem(
             lastAttemptCorrect=last_attempt_correct,
         ),
         isDeleted=is_deleted,
+        createdAt=created_at or datetime.now(UTC) - timedelta(days=30),
     )
 
 
@@ -294,3 +296,80 @@ def test_get_eligible_all_in_cooldown():
     config = PracticeSelectionConfig(cooldown_days=7)
     eligible = get_eligible_practice_problems(problems, config, now)
     assert eligible == []
+
+
+def test_min_age_excludes_too_new():
+    now = datetime.now(UTC)
+    too_new = now - timedelta(days=1)
+    old_enough = now - timedelta(days=5)
+    problems = [
+        _make_problem("new", created_at=too_new),
+        _make_problem("old", created_at=old_enough),
+    ]
+    config = PracticeSelectionConfig(min_problem_age_days=3)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "old"
+
+
+def test_min_age_boundary_at_threshold():
+    now = datetime.now(UTC)
+    exactly_at = now - timedelta(days=3)
+    problems = [_make_problem("boundary", created_at=exactly_at)]
+    config = PracticeSelectionConfig(min_problem_age_days=3)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "boundary"
+
+
+def test_min_age_allows_old_problems():
+    now = datetime.now(UTC)
+    old = now - timedelta(days=10)
+    problems = [_make_problem("old", created_at=old)]
+    config = PracticeSelectionConfig(min_problem_age_days=3)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "old"
+
+
+def test_min_age_zero_allows_immediate():
+    now = datetime.now(UTC)
+    just_created = now - timedelta(seconds=10)
+    problems = [_make_problem("fresh", created_at=just_created)]
+    config = PracticeSelectionConfig(min_problem_age_days=0)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "ok"
+    assert result.selected_problem.id == "fresh"
+
+
+def test_min_age_no_eligible_when_all_too_new():
+    now = datetime.now(UTC)
+    too_new = now - timedelta(days=1)
+    problems = [
+        _make_problem("a", created_at=too_new),
+        _make_problem("b", created_at=too_new),
+    ]
+    config = PracticeSelectionConfig(min_problem_age_days=3)
+    result = select_practice_problem(problems, config, now)
+
+    assert result.status == "no_eligible"
+
+
+def test_get_eligible_excludes_too_new():
+    now = datetime.now(UTC)
+    too_new = now - timedelta(days=1)
+    old_enough = now - timedelta(days=5)
+    problems = [
+        _make_problem("new", created_at=too_new),
+        _make_problem("old", created_at=old_enough),
+    ]
+    config = PracticeSelectionConfig(min_problem_age_days=3)
+    eligible = get_eligible_practice_problems(problems, config, now)
+
+    ids = [p.id for p in eligible]
+    assert "old" in ids
+    assert "new" not in ids

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -14,6 +14,7 @@ def create_test_problem(
     last_tested_days_ago: int | None = None,
     failed_count: int = 0,
     exposure_count: int = 1,
+    created_at: datetime | None = None,
 ) -> Problem:
     from app.domain import Tracking
     tracking = Tracking(
@@ -31,6 +32,7 @@ def create_test_problem(
         correctAnswer=CorrectAnswer(display="a", normalizedText="a", normalizedSet=[], format="single"),
         isDeleted=is_deleted,
         tracking=tracking,
+        createdAt=created_at or datetime.now(timezone.utc) - timedelta(days=30),
     )
 
 
@@ -69,3 +71,58 @@ def test_selects_top_weighted():
         assert selected_ids == ["3", "2"]
     finally:
         random.sample = original_random_sample
+
+
+def test_min_age_excludes_too_new():
+    now = datetime.now(timezone.utc)
+    too_new = now - timedelta(days=1)
+    old_enough = now - timedelta(days=5)
+    problems = [
+        create_test_problem("new", created_at=too_new),
+        create_test_problem("old", created_at=old_enough),
+    ]
+    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=3)
+    selected = select_problems(problems, 2, config)
+
+    assert len(selected) == 1
+    assert selected[0].id == "old"
+
+
+def test_min_age_boundary_at_threshold():
+    now = datetime.now(timezone.utc)
+    exactly_at = now - timedelta(days=3)
+    problems = [create_test_problem("boundary", created_at=exactly_at)]
+    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=3)
+    selected = select_problems(problems, 1, config)
+
+    assert len(selected) == 1
+    assert selected[0].id == "boundary"
+
+
+def test_min_age_zero_allows_immediate():
+    now = datetime.now(timezone.utc)
+    just_created = now - timedelta(seconds=10)
+    problems = [create_test_problem("fresh", created_at=just_created)]
+    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=0)
+    selected = select_problems(problems, 1, config)
+
+    assert len(selected) == 1
+    assert selected[0].id == "fresh"
+
+
+def test_min_age_all_too_new_returns_empty():
+    now = datetime.now(timezone.utc)
+    too_new = now - timedelta(days=1)
+    problems = [
+        create_test_problem("a", created_at=too_new),
+        create_test_problem("b", created_at=too_new),
+    ]
+    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=3)
+    selected = select_problems(problems, 2, config)
+
+    assert selected == []
+
+
+def test_min_age_default_value():
+    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0)
+    assert config.minProblemAgeDays == 3

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -13,7 +13,7 @@ from bson import ObjectId
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from app.infrastructure.config.settings import Settings
+from app.infrastructure.config.settings import Settings, get_settings
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
 from app.infrastructure.vlm.client import ClassificationResult, ExtractionResult
 from app.main import create_app
@@ -431,6 +431,7 @@ async def exams_app() -> AsyncIterator[FastAPI]:
         math_ingestion_vlm_timeout_seconds=1.0,
         english_ingestion_vlm_model="english-model",
         english_ingestion_vlm_timeout_seconds=1.0,
+        problem_selection_min_age_days=0,
     )
 
     primary_user = {
@@ -448,6 +449,7 @@ async def exams_app() -> AsyncIterator[FastAPI]:
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_app_settings] = lambda: settings
+    application.dependency_overrides[get_settings] = lambda: settings
     application.dependency_overrides[get_current_user] = lambda: primary_user
     application.dependency_overrides[get_exam_storage] = lambda: storage
     application.dependency_overrides[get_exam_mongo_adapter] = lambda: adapter
@@ -480,6 +482,7 @@ async def app() -> AsyncIterator[FastAPI]:
         math_ingestion_vlm_timeout_seconds=1.0,
         english_ingestion_vlm_model="english-model",
         english_ingestion_vlm_timeout_seconds=1.0,
+        problem_selection_min_age_days=0,
     )
 
     application.state.fake_database = database
@@ -493,6 +496,7 @@ async def app() -> AsyncIterator[FastAPI]:
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_app_settings] = lambda: settings
+    application.dependency_overrides[get_settings] = lambda: settings
     application.dependency_overrides[get_problem_storage] = lambda: storage
     application.dependency_overrides[get_exam_storage] = lambda: storage
     application.dependency_overrides[get_exam_mongo_adapter] = lambda: adapter


### PR DESCRIPTION
## Summary

- Add a configurable minimum problem age rule to exclude newly created problems from practice and exam selection
- Default threshold: 3 days; set to 0 for immediate eligibility
- Applies consistently to practice stats, practice next, and exam creation
- Exam config snapshots now record the minimum-age policy used

## Linked Issue

Closes #247

## Issue Alignment

This PR implements the issue by:

- Adding `problem_selection_min_age_days` setting to backend config (env var: `PROBLEM_SELECTION_MIN_AGE_DAYS`, default: 3, ge=0)
- Updating `PracticeSelectionConfig` and `get_eligible_practice_problems()` to filter by problem age
- Updating `SelectionPolicyConfig` and `select_problems()` to filter by problem age
- Wiring the setting into `/practice/stats`, `/practice/next`, and `/exams` creation
- Recording `minProblemAgeDays` in exam `configSnapshot.selectionPolicy`

Scope covered:

- Shared backend configuration setting for minimum problem age
- Practice eligibility filtering
- Exam selection filtering
- Practice stats consistency
- Exam selection policy snapshot persistence
- Automated tests for domain and API selection behavior
- Developer documentation and env example updates

Out of scope / intentionally not included:

- Frontend UI changes
- Per-user or per-mode settings screens
- Database migrations for existing problems
- Retuning recency or failure scoring weights
- Changing existing `tracking.lastTestedAt` cooldown semantics

## Implementation Notes

- Age is computed as `now - createdAt` using UTC-normalized datetimes
- A problem exactly at the threshold (e.g., 3 days old) is eligible
- A value of 0 disables the minimum age filter entirely
- Existing exam records without `minProblemAgeDays` in their `selectionPolicy` remain readable (Pydantic default: 3)
- `SelectionPolicyPayload` serialization includes `minProblemAgeDays` so API responses reflect the policy used

## Tests

Commands run:

- `cd backend && uv run pytest tests/ -v` — **350 passed, 1 skipped**

Automated tests added or updated:

Domain tests:
- `test_min_age_excludes_too_new` — practice excludes problems newer than threshold
- `test_min_age_boundary_at_threshold` — practice includes problems exactly at threshold
- `test_min_age_allows_old_problems` — practice includes old-enough problems
- `test_min_age_zero_allows_immediate` — threshold 0 allows fresh problems
- `test_min_age_no_eligible_when_all_too_new` — returns no_eligible when all too new
- `test_get_eligible_excludes_too_new` — eligible list excludes too-new problems
- `test_min_age_excludes_too_new` — exam selection excludes too-new problems
- `test_min_age_boundary_at_threshold` — exam includes problems at threshold boundary
- `test_min_age_zero_allows_immediate` — exam threshold 0 allows fresh problems
- `test_min_age_all_too_new_returns_empty` — exam returns empty when all too new
- `test_min_age_default_value` — SelectionPolicyConfig defaults to 3 days

API tests:
- `test_stats_excludes_too_new_problems` — practice stats exclude too-new problems
- `test_next_returns_no_eligible_when_all_too_new` — practice next returns no_eligible when all too new
- `test_create_exam_rejects_when_all_too_new` — exam creation returns NO_ELIGIBLE_PROBLEMS for too-new problems
- `test_create_exam_succeeds_with_old_problems_and_records_min_age` — exam creation with old-enough problems records minProblemAgeDays

Fixture/serialization fixes:
- `practice_app` fixture: set `problem_selection_min_age_days=0` to preserve existing test intent
- `exams_app` fixture (API + integration): override `get_settings` with `problem_selection_min_age_days=0`
- `app` fixture (integration): override `get_settings` with `problem_selection_min_age_days=0`
- `test_create_exam_snapshots_selected_problems`: updated assertion to include `minProblemAgeDays`
- `SelectionPolicyPayload`: added `minProblemAgeDays` field (default 3)
- `serialize_exam`: pass `minProblemAgeDays` from stored config to API response payload
- Removed unused `DEFAULT_SELECTION_POLICY` import from `exams.py`

Manual verification:

- All 350 backend tests pass (1 skipped — visual graph rendering corpus test, unrelated)
- Existing tests pass without modification (fixtures override min_age to 0 or use old-enough problems)

## Deviations From Issue Plan

None.

## Follow-Up Work

None.