### PR TITLE
refactor: move load_source_image_base64 to infrastructure storage

### DIFF
--- a/backend/app/infrastructure/storage/s3.py
+++ b/backend/app/infrastructure/storage/s3.py
@@ -1,3 +1,4 @@
+from base64 import b64encode
 from collections.abc import Callable
 from typing import Any, BinaryIO, Protocol, cast
 from uuid import UUID, uuid4
@@ -133,3 +134,21 @@ class S3StorageAdapter:
             raise
 
         return True
+
+
+def load_source_image_base64(
+    source_image: dict[str, Any] | None,
+    storage: S3StorageAdapter,
+) -> str | None:
+    """Load image from S3 and return as base64 string, or None if not found."""
+    if not source_image:
+        return None
+    bucket = source_image.get("bucket")
+    object_key = source_image.get("objectKey")
+    if not bucket or not object_key:
+        return None
+    try:
+        image_bytes = storage.get_object(str(bucket), str(object_key))
+    except StorageObjectNotFoundError:
+        return None
+    return b64encode(image_bytes).decode("ascii")

--- a/backend/app/infrastructure/worker/solution_worker.py
+++ b/backend/app/infrastructure/worker/solution_worker.py
@@ -17,8 +17,7 @@ from app.infrastructure.storage.mongo import (
     CANONICAL_SOLUTIONS_COLLECTION,
     SOLUTION_GENERATION_TASKS_COLLECTION,
 )
-from app.infrastructure.storage.s3 import S3StorageAdapter
-from app.presentation.helpers import load_source_image_base64
+from app.infrastructure.storage.s3 import S3StorageAdapter, load_source_image_base64
 from app.presentation.solution_generation import _safe_get_collection
 
 logger = logging.getLogger(__name__)

--- a/backend/app/presentation/exam_grading.py
+++ b/backend/app/presentation/exam_grading.py
@@ -7,9 +7,8 @@ from typing import Any
 
 from app.domain.models import GradingStatus, ProblemType
 from app.domain.normalization import compare_answers, normalize_answer
-from app.infrastructure.storage.s3 import S3StorageAdapter
+from app.infrastructure.storage.s3 import S3StorageAdapter, load_source_image_base64
 from app.infrastructure.vlm.client import VLMClient, VLMError
-from app.presentation.helpers import load_source_image_base64
 
 
 def build_grading_result(

--- a/backend/app/presentation/helpers.py
+++ b/backend/app/presentation/helpers.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from base64 import b64encode
 from typing import Any
 
 from bson import ObjectId
 from pymongo.asynchronous.database import AsyncDatabase
 
 from app.infrastructure.storage.mongo import Document
-from app.infrastructure.storage.s3 import S3StorageAdapter, StorageObjectNotFoundError
 from app.presentation.errors import ApiError
 
 
@@ -53,19 +51,3 @@ async def get_owned_problem(
     return problem
 
 
-def load_source_image_base64(
-    source_image: dict[str, Any] | None,
-    storage: S3StorageAdapter,
-) -> str | None:
-    """Load image from S3 and return as base64 string, or None if not found."""
-    if not source_image:
-        return None
-    bucket = source_image.get("bucket")
-    object_key = source_image.get("objectKey")
-    if not bucket or not object_key:
-        return None
-    try:
-        image_bytes = storage.get_object(str(bucket), str(object_key))
-    except StorageObjectNotFoundError:
-        return None
-    return b64encode(image_bytes).decode("ascii")

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -26,7 +26,8 @@ from app.presentation.deps import (
     get_grading_vlm_client,
     get_s3_storage,
 )
-from app.presentation.helpers import build_problem_image_url, load_source_image_base64, parse_object_id
+from app.infrastructure.storage.s3 import load_source_image_base64
+from app.presentation.helpers import build_problem_image_url, parse_object_id
 from app.presentation.exam_helpers import problem_document_to_model
 from app.presentation.errors import ApiError
 


### PR DESCRIPTION
## Summary

Move the S3-backed `load_source_image_base64` helper out of `app.presentation.helpers` and into `app.infrastructure.storage.s3` to fix the layer inversion described in the issue. The function signature, return values, and S3 error handling are preserved exactly.

## Linked Issue

Closes #251

## Issue Alignment

This PR implements the issue by:

- Moving `load_source_image_base64` to `backend/app/infrastructure/storage/s3.py`.
- Updating imports in `solution_worker.py`, `exam_grading.py`, and `practice.py` to use the new location.
- Removing the now-stale S3-related imports from `backend/app/presentation/helpers.py`.

Scope covered:

- Signature-preserving relocation of the helper.
- Import updates for all worker and presentation callers.
- Verification that existing behavior (missing image, missing bucket/key, missing S3 object) still returns `None`.

Out of scope / intentionally not included:

- Moving `_safe_get_collection` (covered by #252).
- Changing S3 access patterns or making the helper async.
- Changing source image field names or error handling.
- Refactoring unrelated storage code.

## Implementation Notes

- The helper is placed in `s3.py` because it depends directly on `S3StorageAdapter` and `StorageObjectNotFoundError`.
- No production logic was changed; this is a pure move.
- The observability test in `tests/domain/test_observability.py` continues to monkey-patch `sw.load_source_image_base64` because the worker module still exposes the imported name.

## Tests

Commands run:

- `cd backend && python -c "import app.infrastructure.worker.solution_worker"` — passed
- `cd backend && uv run --frozen pytest tests/worker/test_solution_worker.py -v` — **8 passed**
- `cd backend && uv run --frozen pytest tests/presentation/test_exam_grading.py -v` — **21 passed**
- `cd backend && uv run --frozen pytest tests/integration/test_exam_workflow.py -v` — **7 passed**
- `cd backend && uv run --frozen pytest tests/domain/test_observability.py -v` — **6 passed**
- `cd backend && uv run --frozen pytest -x` — **380 passed, 1 skipped**

Automated tests added or updated:

- No new tests were required; existing tests already cover the helper behavior through `solution_worker.py`, `exam_grading.py`, and the observability test path.

Manual verification:

- Confirmed `load_source_image_base64` is no longer defined in `app.presentation.helpers`.
- Confirmed all callers import from `app.infrastructure.storage.s3`.
- Confirmed worker import smoke test succeeds after the move.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
