### PR TITLE
test(#253): add fence-stripping characterization tests and extract shareable VLM models

### DIFF
--- a/backend/app/infrastructure/vlm/_models.py
+++ b/backend/app/infrastructure/vlm/_models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class _ChatMessageContentText(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class _ChatMessageContentImageUrl(BaseModel):
+    type: Literal["image_url"]
+    image_url: dict[str, str]
+
+
+class _ChatMessage(BaseModel):
+    role: Literal["system", "user", "assistant"]
+    content: list[_ChatMessageContentText | _ChatMessageContentImageUrl] | str
+
+
+class _ChatCompletionRequest(BaseModel):
+    model: str
+    messages: list[_ChatMessage]

--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -9,6 +9,12 @@ from typing import Any, Literal
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from app.infrastructure.vlm._models import (
+    _ChatCompletionRequest,
+    _ChatMessage,
+    _ChatMessageContentImageUrl,
+    _ChatMessageContentText,
+)
 from app.infrastructure.vlm.prompts import (
     ENGLISH_EXTRACTION_SYSTEM_PROMPT,
     GRADING_SYSTEM_PROMPT,
@@ -115,26 +121,6 @@ class _GradingProviderPayload(BaseModel):
     is_correct: bool = Field(alias="isCorrect")
     feedback: str
     provider_metadata: dict[str, Any] = Field(default_factory=dict, alias="providerMetadata")
-
-
-class _ChatMessageContentText(BaseModel):
-    type: Literal["text"]
-    text: str
-
-
-class _ChatMessageContentImageUrl(BaseModel):
-    type: Literal["image_url"]
-    image_url: dict[str, str]
-
-
-class _ChatMessage(BaseModel):
-    role: Literal["system", "user", "assistant"]
-    content: list[_ChatMessageContentText | _ChatMessageContentImageUrl] | str
-
-
-class _ChatCompletionRequest(BaseModel):
-    model: str
-    messages: list[_ChatMessage]
 
 
 class _ChatCompletionMessage(BaseModel):

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -8,6 +8,12 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from app.infrastructure.config.settings import Settings, get_settings
+from app.infrastructure.vlm._models import (
+    _ChatCompletionRequest,
+    _ChatMessage,
+    _ChatMessageContentImageUrl,
+    _ChatMessageContentText,
+)
 from app.infrastructure.vlm.client import (
     FAILURE_CODE_INVALID_RESPONSE,
     FAILURE_CODE_NETWORK,
@@ -103,26 +109,6 @@ class SolutionCoachingVLMError(Exception):
         self.retryable = retryable
         self.status_code = status_code
         self.raw_provider_response = raw_provider_response
-
-
-class _ChatMessageContentText(BaseModel):
-    type: Literal["text"]
-    text: str
-
-
-class _ChatMessageContentImageUrl(BaseModel):
-    type: Literal["image_url"]
-    image_url: dict[str, str]
-
-
-class _ChatMessage(BaseModel):
-    role: Literal["system", "user", "assistant"]
-    content: list[_ChatMessageContentText | _ChatMessageContentImageUrl] | str
-
-
-class _ChatCompletionRequest(BaseModel):
-    model: str
-    messages: list[_ChatMessage]
 
 
 class _ChatCompletionMessage(BaseModel):

--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -578,3 +578,55 @@ async def test_coaching_vlm_client_reasoning_content_none_when_absent() -> None:
 
     assert result.text == "简单回答。"
     assert result.reasoning_content is None
+
+
+def test_solution_coaching_strip_json_code_fences_leaves_plain_json_unchanged() -> None:
+    plain = '{"text":"hello"}'
+
+    assert SolutionVLMClient._strip_json_code_fences(plain) == plain
+
+
+def test_solution_coaching_strip_json_code_fences_strips_json_fence() -> None:
+    fenced = '```json\n{"text":"hello"}\n```'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_solution_coaching_strip_json_code_fences_strips_plain_fence() -> None:
+    fenced = '```\n{"text":"hello"}\n```'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_solution_coaching_strip_json_code_fences_strips_any_fence_language() -> None:
+    fenced = '```python\n{"text":"hello"}\n```'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_solution_coaching_strip_json_code_fences_preserves_incomplete_closing_fence() -> None:
+    fenced = '```json\n{"text":"hello"}'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == fenced
+
+
+def test_solution_coaching_strip_json_code_fences_preserves_single_line_fence() -> None:
+    fenced = '```json {"text":"hello"} ```'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == fenced
+
+
+def test_solution_coaching_strip_json_code_fences_returns_empty_string_for_empty_input() -> None:
+    assert SolutionVLMClient._strip_json_code_fences("") == ""
+
+
+def test_solution_coaching_strip_json_code_fences_strips_fence_with_whitespace_in_opening() -> None:
+    fenced = '``` json\n{"text":"hello"}\n```'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_solution_coaching_strip_json_code_fences_strips_multiline_json_content() -> None:
+    fenced = '```json\n{\n  "text": "hello",\n  "value": 42\n}\n```'
+
+    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{\n  "text": "hello",\n  "value": 42\n}'

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -365,6 +365,58 @@ def test_strip_json_code_fences_leaves_plain_json_unchanged() -> None:
     assert VLMClient._strip_json_code_fences(plain) == plain
 
 
+def test_strip_json_code_fences_strips_json_fence() -> None:
+    fenced = '```json\n{"text":"hello"}\n```'
+
+    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_strip_json_code_fences_strips_plain_fence() -> None:
+    fenced = '```\n{"text":"hello"}\n```'
+
+    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_strip_json_code_fences_preserves_non_json_fence_language() -> None:
+    fenced = '```python\n{"text":"hello"}\n```'
+
+    assert VLMClient._strip_json_code_fences(fenced) == fenced
+
+
+def test_strip_json_code_fences_preserves_incomplete_opening_fence() -> None:
+    fenced = '```json\n{"text":"hello"}'
+
+    assert VLMClient._strip_json_code_fences(fenced) == fenced
+
+
+def test_strip_json_code_fences_preserves_incomplete_closing_fence() -> None:
+    fenced = '{"text":"hello"}\n```'
+
+    assert VLMClient._strip_json_code_fences(fenced) == fenced
+
+
+def test_strip_json_code_fences_preserves_single_line_fence() -> None:
+    fenced = '```json {"text":"hello"} ```'
+
+    assert VLMClient._strip_json_code_fences(fenced) == fenced
+
+
+def test_strip_json_code_fences_strips_fence_with_trailing_whitespace() -> None:
+    fenced = '  ```json\n{"text":"hello"}\n```  '
+
+    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
+
+
+def test_strip_json_code_fences_returns_empty_string_for_empty_input() -> None:
+    assert VLMClient._strip_json_code_fences("") == ""
+
+
+def test_strip_json_code_fences_strips_multiline_json_content() -> None:
+    fenced = '```json\n{\n  "text": "hello",\n  "value": 42\n}\n```'
+
+    assert VLMClient._strip_json_code_fences(fenced) == '{\n  "text": "hello",\n  "value": 42\n}'
+
+
 @pytest.mark.asyncio
 async def test_vlm_timeout_is_classified_explicitly() -> None:
     async def timeout_handler(request: httpx.Request) -> httpx.Response:


### PR DESCRIPTION
## Summary

Add fence-stripping characterization tests for both VLM clients and extract safely shareable Pydantic chat models into `backend/app/infrastructure/vlm/_models.py`. This is milestone 1 of VLM consolidation.

## Linked Issue

Closes #253

## Issue Alignment

This PR implements the issue by:

- Adding 10 characterization tests for `VLMClient._strip_json_code_fences`.
- Adding 9 characterization tests for `SolutionVLMClient._strip_json_code_fences` (inherited from `_BaseSolutionCoachingVLMClient`).
- Creating `_models.py` with shared Pydantic models: `_ChatMessageContentText`, `_ChatMessageContentImageUrl`, `_ChatMessage`, `_ChatCompletionRequest`.
- Updating imports in `client.py` and `solution_coaching_client.py` to use the shared models.
- Leaving `_ChatCompletionMessage`, `_ChatCompletionChoice`, and `_ChatCompletionResponse` local because the solution/coaching variant adds `reasoning_content` to `_ChatCompletionMessage`, which is a behavior-sensitive difference.

Scope covered:

- Fence-stripping characterization tests for both clients.
- Extraction of genuinely shareable chat message/completion request models.
- Import updates and verification that no behavior changed.

Out of scope / intentionally not included:

- Creating `BaseVLMClient`.
- Migrating client classes to inheritance.
- Unifying error classes.
- Unifying JSON parsing, fence-stripping, or chat message models beyond the safe subset.
- Changing VLM prompts or request payloads.

## Implementation Notes

- The shared models in `_models.py` are identical copies from both client files with no changes.
- `_ChatCompletionMessage` was intentionally **not** moved because `solution_coaching_client.py` adds `reasoning_content: str | None = None`, which the generic `client.py` does not use. Moving it would either break the coaching client or silently add an unused field to the generic client.
- The fence-stripping tests document the current behavior differences between the two clients:
  - `VLMClient` only strips fences when the first line is exactly ``` or ```json.
  - `_BaseSolutionCoachingVLMClient` strips any fence starting with ``` and accepts any language tag (e.g., ```python).

## Tests

Commands run:

- `cd backend && python -c "from app.infrastructure.vlm.client import VLMClient; from app.infrastructure.vlm.solution_coaching_client import SolutionVLMClient, CoachingVLMClient; print('OK')"` — passed
- `cd backend && uv run --frozen pytest tests/infrastructure/test_vlm.py -v` — **38 passed**
- `cd backend && uv run --frozen pytest tests/infrastructure/test_solution_coaching_client.py -v` — **31 passed**
- `cd backend && uv run --frozen pytest -x` — **457 passed, 1 skipped**

Automated tests added or updated:

- `test_vlm.py`: 9 new fence-stripping characterization tests for `VLMClient._strip_json_code_fences`.
- `test_solution_coaching_client.py`: 9 new fence-stripping characterization tests for `SolutionVLMClient._strip_json_code_fences`.

Manual verification:

- Confirmed both client modules import successfully after model extraction.
- Confirmed the shared models are byte-for-byte identical to their original definitions.
- Confirmed no production behavior was changed; this is a pure move + tests.

## Deviations From Issue Plan

None.

## Follow-Up Work

Followed by issue #254 (BaseVLMClient transport foundation) and then #255 (client migration).
