### PR TITLE
refactor(#258): unify frontend problem-related types without a god type

### DIFF
--- a/frontend/src/pages/CoachingPage.test.tsx
+++ b/frontend/src/pages/CoachingPage.test.tsx
@@ -5,7 +5,8 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { api } from "@/api/client";
-import { CoachingPage, type PracticeHistoryResponse, type ExamResponse } from "./CoachingPage";
+import { CoachingPage, type ExamResponse } from "./CoachingPage";
+import type { PracticeHistoryResponse } from "@/types/practice";
 import type { CoachingConversation, CoachingMessage } from "@/types/coaching";
 
 // Mock GraphSandbox component to easily verify DSL and trigger errors
@@ -100,6 +101,15 @@ const mockPracticeHistory: PracticeHistoryResponse = {
   items: [
     {
       problemId: "prob-123",
+      problemText: "Given $x^2 = 4$, find $x$.",
+      problemType: "short-answer",
+      summary: {
+        totalAttempts: 1,
+        correctCount: 0,
+        wrongCount: 1,
+        lastPracticedAt: "2026-05-25T12:15:00Z",
+        lastResult: "incorrect",
+      },
       attempts: [
         {
           submittedAnswer: "3",

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -7,46 +7,8 @@ import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { MarkdownText } from "@/components/MarkdownText";
 import { LatexText } from "@/components/LatexText";
 import type { CoachingConversation } from "@/types/coaching";
-
-interface CorrectAnswer {
-  display: string;
-  normalizedText: string;
-  normalizedSet: string[];
-  format: string;
-}
-
-interface Problem {
-  id: string;
-  problemType: string;
-  text: string;
-  tags: string[];
-  graphDsl?: string;
-  imageUrl?: string;
-  correctAnswer?: CorrectAnswer;
-  isDeleted: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ProblemResponse {
-  problem: Problem;
-}
-
-interface PracticeAttemptDetail {
-  submittedAnswer: string;
-  gradingStatus: string;
-  gradingMethod: string;
-  createdAt: string;
-}
-
-interface PracticeHistoryItem {
-  problemId: string;
-  attempts: PracticeAttemptDetail[];
-}
-
-export interface PracticeHistoryResponse {
-  items: PracticeHistoryItem[];
-}
+import type { ProblemDetail, ProblemResponse } from "@/types/problem";
+import type { PracticeHistoryResponse } from "@/types/practice";
 
 interface ExamItem {
   problemId: string;

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -5,11 +5,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { formatDate } from "@/utils/format";
 import { LatexText } from "@/components/LatexText";
-import type { PracticeHistoryItem, PracticeNextResponse } from "@/types/practice";
-
-interface PracticeHistoryResponse {
-  items: PracticeHistoryItem[];
-}
+import type { PracticeHistoryItem, PracticeHistoryResponse, PracticeNextResponse } from "@/types/practice";
 
 interface PracticeStatsResponse {
   practiceableCount: number;

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -10,30 +10,7 @@ import { TagInput } from "@/components/TagInput";
 import { TagList } from "@/components/TagPill";
 import { TeacherPasswordModal } from "@/components/TeacherPasswordModal";
 import { useTagSuggestions } from "@/hooks/useTagSuggestions";
-
-interface CorrectAnswer {
-  display: string;
-  normalizedText: string;
-  normalizedSet: string[];
-  format: string;
-}
-
-interface Problem {
-  id: string;
-  problemType: string;
-  text: string;
-  tags: string[];
-  graphDsl?: string;
-  imageUrl?: string;
-  correctAnswer?: CorrectAnswer;
-  isDeleted: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ProblemResponse {
-  problem: Problem;
-}
+import type { ProblemDetail, ProblemResponse } from "@/types/problem";
 
 interface TrackingData {
   problemId: string;

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -6,24 +6,7 @@ import { formatProblemReference } from "@/utils/format";
 import { useTagSuggestions } from "@/hooks/useTagSuggestions";
 import Pagination from "@/components/Pagination";
 import { TagList } from "@/components/TagPill";
-
-interface Problem {
-  id: string;
-  problemType: string;
-  text: string;
-  tags: string[];
-  imageUrl?: string;
-  tracking: {
-    exposureCount: number;
-    correctCount: number;
-    failedCount: number;
-    lastTestedAt?: string;
-    lastAttemptCorrect?: boolean;
-  };
-  isDeleted: boolean;
-  createdAt: string;
-  updatedAt: string;
-}
+import type { ProblemListItem, ProblemsResponse } from "@/types/problem";
 
 interface FolderNode {
   id: string;
@@ -39,13 +22,6 @@ interface FolderTreeResponse {
   allProblemsCount: number;
   unfiledCount: number;
   items: FolderNode[];
-}
-
-interface ProblemsResponse {
-  items: Problem[];
-  total: number;
-  page: number;
-  pageSize: number;
 }
 
 const PROBLEM_TYPE_OPTIONS = [

--- a/frontend/src/types/practice.ts
+++ b/frontend/src/types/practice.ts
@@ -43,3 +43,7 @@ export interface PracticeNextResponse {
   status: PracticeNextStatus;
   problem?: PracticeProblem;
 }
+
+export interface PracticeHistoryResponse {
+  items: PracticeHistoryItem[];
+}

--- a/frontend/src/types/problem.ts
+++ b/frontend/src/types/problem.ts
@@ -1,0 +1,43 @@
+import type { CorrectAnswer } from "./exam";
+
+export interface ProblemDetail {
+  id: string;
+  problemType: string;
+  text: string;
+  tags: string[];
+  graphDsl?: string;
+  imageUrl?: string;
+  correctAnswer?: CorrectAnswer;
+  isDeleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProblemResponse {
+  problem: ProblemDetail;
+}
+
+export interface ProblemListItem {
+  id: string;
+  problemType: string;
+  text: string;
+  tags: string[];
+  imageUrl?: string;
+  tracking: {
+    exposureCount: number;
+    correctCount: number;
+    failedCount: number;
+    lastTestedAt?: string;
+    lastAttemptCorrect?: boolean;
+  };
+  isDeleted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProblemsResponse {
+  items: ProblemListItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+}


### PR DESCRIPTION
## Summary

Create focused shared TypeScript interfaces for problem detail and list use cases, then replace duplicated page-local interfaces across `ProblemDetailPage.tsx`, `CoachingPage.tsx`, and `ProblemsPage.tsx`. Move `PracticeHistoryResponse` to `types/practice.ts` to eliminate another local duplication.

## Linked Issue

Closes #258

## Issue Alignment

This PR implements the issue by:

- Creating `frontend/src/types/problem.ts` with `ProblemDetail` and `ProblemListItem`.
- Updating `ProblemDetailPage.tsx` and `CoachingPage.tsx` to import the shared `ProblemDetail` and `ProblemResponse` types.
- Updating `ProblemsPage.tsx` to import the shared `ProblemListItem` and `ProblemsResponse` types.
- Moving `PracticeHistoryResponse` to `frontend/src/types/practice.ts` and updating `CoachingPage.tsx` and `PracticePage.tsx` to import it.

Scope covered:

- Shared focused problem types exist.
- Duplicated inline problem interfaces are removed from the target pages.
- `PracticeHistoryResponse` is no longer locally declared in `CoachingPage.tsx`.

Out of scope / intentionally not included:

- `ExamItem` and `ExamResponse` local to `CoachingPage.tsx` (not problem-related).
- `TrackingData` and `UpdateProblemInput` local to `ProblemDetailPage.tsx` (not duplicated).
- Runtime validation, backend type generation, or API call changes.

## Implementation Notes

- `CorrectAnswer` is already exported from `types/exam.ts`; `types/problem.ts` imports it rather than duplicating it.
- `PracticeHistoryResponse` uses the existing rich `PracticeHistoryItem` from `types/practice.ts`. The `CoachingPage` only accesses a subset of fields, which is safe under TypeScript structural typing. The corresponding test mock was updated to include the required fields.
- No runtime behavior was changed; this is a pure type refactor.

## Tests

Commands run:

- `cd frontend && npm run build` — passed
- `cd frontend && npm test -- --run` — 286 tests passed

Automated tests added or updated:

- Updated `CoachingPage.test.tsx` mock data and imports to align with the shared `PracticeHistoryResponse` type.

Manual verification:

- Verified TypeScript build catches no regressions.
- Verified all existing page tests continue to pass.
- Confirmed no runtime code paths or API calls were changed.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
