### PR TITLE
refactor(frontend): migrate IngestionWizard API helpers to shared API client

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { api } from "./client";
+
+describe("API Client postFormData", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends a POST request with the correct url, credentials, body, and no content-type header", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const formData = new FormData();
+    formData.append("key", "value");
+
+    const result = await api.postFormData("/test-path", formData);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/test-path", {
+      method: "POST",
+      credentials: "include",
+      body: formData,
+    });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("handles HTTP errors correctly by throwing enriched error", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: () => Promise.resolve({
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Invalid input provided",
+        },
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const formData = new FormData();
+    await expect(api.postFormData("/test-path", formData)).rejects.toThrow("Invalid input provided");
+
+    try {
+      await api.postFormData("/test-path", formData);
+    } catch (err) {
+      const error = err as Error & { code?: string; status?: number };
+      expect(error.code).toBe("VALIDATION_FAILED");
+      expect(error.status).toBe(400);
+    }
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -222,6 +222,18 @@ export const api = {
     });
     return handleResponse<T>(response);
   },
+
+  /**
+   * Generic POST request with FormData
+   */
+  async postFormData<T>(path: string, formData: FormData): Promise<T> {
+    const response = await fetch(`${API_BASE}${path}`, {
+      method: "POST",
+      credentials: "include",
+      body: formData,
+    });
+    return handleResponse<T>(response);
+  },
 };
 
 export default api;

--- a/frontend/src/components/IngestionWizard.test.tsx
+++ b/frontend/src/components/IngestionWizard.test.tsx
@@ -490,4 +490,56 @@ describe("IngestionWizard", () => {
       expect(subjectSelect.value).toBe("math");
     });
   });
+
+  describe("API Client migration contracts", () => {
+    it("sends FormData with image field and no Content-Type header on file upload", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            preview: {
+              id: "test-preview-id",
+              status: "extracting",
+              sourceImage: { bucket: "test", objectKey: "test-key" },
+              draft: {},
+              extraction: {},
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              expiresAt: new Date().toISOString(),
+            },
+          }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      render(<IngestionWizard />);
+
+      const file = new File(["test-content"], "test-image.png", { type: "image/png" });
+      const fileInput = screen.getByRole("button", {
+        name: "Choose Image File",
+      }).parentElement?.querySelector('input[type="file"]') as HTMLInputElement;
+
+      fireEvent.change(fileInput, { target: { files: [file] } });
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled();
+      });
+
+      const uploadCall = mockFetch.mock.calls.find(call => call[0] === "/api/v1/ingestion-previews");
+      expect(uploadCall).toBeDefined();
+      const [, options] = uploadCall!;
+      
+      expect(options.method).toBe("POST");
+      expect(options.credentials).toBe("include");
+      expect(options.body).toBeInstanceOf(FormData);
+      
+      const formData = options.body as FormData;
+      expect(formData.get("image")).toEqual(file);
+      
+      if (options.headers) {
+        const headers = options.headers as Record<string, string>;
+        expect(headers["Content-Type"]).toBeUndefined();
+        expect(headers["content-type"]).toBeUndefined();
+      }
+    });
+  });
 });

--- a/frontend/src/components/IngestionWizard.tsx
+++ b/frontend/src/components/IngestionWizard.tsx
@@ -121,18 +121,7 @@ async function createPreview(file: File): Promise<IngestionPreview> {
   const formData = new FormData();
   formData.append("image", file);
 
-  const response = await fetch("/api/v1/ingestion-previews", {
-    method: "POST",
-    credentials: "include",
-    body: formData,
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error?.message || `HTTP ${response.status}`);
-  }
-
-  const data = await response.json();
+  const data = await api.postFormData<PreviewResponse>("/ingestion-previews", formData);
   return normalizePreviewResponse(data);
 }
 
@@ -151,51 +140,20 @@ interface PreviewUpdateData {
 }
 
 async function updatePreview(id: string, data: PreviewUpdateData): Promise<IngestionPreview> {
-  const response = await fetch(`/api/v1/ingestion-previews/${id}`, {
-    method: "PATCH",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    credentials: "include",
-    body: JSON.stringify(data),
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error?.message || `HTTP ${response.status}`);
-  }
-
-  const result = await response.json();
+  const result = await api.patch<PreviewResponse>(`/ingestion-previews/${id}`, data);
   return normalizePreviewResponse(result);
 }
 
 async function retryPreview(id: string): Promise<IngestionPreview> {
-  const response = await fetch(`/api/v1/ingestion-previews/${id}/retry`, {
-    method: "POST",
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error?.message || `HTTP ${response.status}`);
-  }
-
-  const data = await response.json();
+  const data = await api.post<PreviewResponse>(`/ingestion-previews/${id}/retry`, undefined);
   return normalizePreviewResponse(data);
 }
 
 async function confirmPreview(id: string): Promise<{ problemId: string }> {
-  const response = await fetch(`/api/v1/ingestion-previews/${id}/confirm`, {
-    method: "POST",
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error?.message || `HTTP ${response.status}`);
-  }
-
-  const data = (await response.json()) as { problem: { id: string } };
+  const data = await api.post<{ problem: { id: string } }>(
+    `/ingestion-previews/${id}/confirm`,
+    undefined
+  );
   return { problemId: data.problem.id };
 }
 


### PR DESCRIPTION
## Summary

Migrate the remaining top-level `IngestionWizard` API helper functions from raw `fetch()` to the shared API client, including adding a generic `postFormData` method to the client.

## Linked Issue

Closes #257

## Issue Alignment

This PR implements the issue by:

- Adding `postFormData` to `frontend/src/api/client.ts`.
- Migrating `createPreview`, `updatePreview`, `retryPreview`, and `confirmPreview` helper functions to use the shared client `api` methods.
- Auditing catch blocks and verifying that error-shape expectations are preserved.

Scope covered:

- Extended `api` client with `postFormData`.
- Migrated all raw `fetch` calls in the wizard orchestrator.
- Added unit and contract tests verifying request parameters, `FormData` usage, correct field name, and lack of header overrides.

Out of scope / intentionally not included:

- Changing endpoint URLs or HTTP methods.
- Changing FormData field names.
- Changing ingestion step UI or state transitions.
- Changing backend ingestion behavior.

## Implementation Notes

- `postFormData` does not set `Content-Type` explicitly so the browser automatically handles boundary headers.
- Enriched error objects are caught and handled by the existing catch blocks in `IngestionWizard.tsx`, which display `err.message` in the UI seamlessly.

## Tests

Commands run:

- `cd frontend && npm test -- --run src/api/client.test.ts` — passed (2 tests)
- `cd frontend && npm test -- --run src/components/IngestionWizard.test.tsx` — passed (17 tests)
- `cd frontend && npm test -- --run` — passed (289 tests across 23 files)
- `cd frontend && npm run build` — passed

Automated tests added or updated:

- Unit tests in `frontend/src/api/client.test.ts` verifying `api.postFormData` request parameters (endpoint, POST method, credentials include, no override of content-type, correct body mapping, error mapping).
- Contract tests in `frontend/src/components/IngestionWizard.test.tsx` verifying that file upload uses `FormData` with field `image`, and that `Content-Type` header is not overridden.

Manual verification:

- Verified that TypeScript compile and production build complete successfully.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.