### PR TITLE
VLM consolidation M2: introduce BaseVLMClient transport foundation

### DIFF
--- a/backend/app/infrastructure/vlm/base_client.py
+++ b/backend/app/infrastructure/vlm/base_client.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import httpx
+
+FAILURE_CODE_TIMEOUT = "vlm-timeout"
+FAILURE_CODE_NETWORK = "vlm-network-error"
+FAILURE_CODE_PROVIDER = "vlm-provider-error"
+FAILURE_CODE_PROVIDER_REJECTED = "vlm-provider-rejected"
+FAILURE_CODE_INVALID_RESPONSE = "vlm-invalid-response"
+
+
+class BaseVLMError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        retryable: bool,
+        status_code: int | None = None,
+        raw_provider_response: Any | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+        self.status_code = status_code
+        self.raw_provider_response = raw_provider_response
+
+
+class BaseVLMClient:
+    def __init__(
+        self,
+        *,
+        endpoint: str,
+        model: str,
+        api_key: str,
+        timeout_seconds: float,
+        http_client: httpx.AsyncClient | None = None,
+        error_factory: Callable[..., BaseException] | None = None,
+    ) -> None:
+        self._endpoint = endpoint
+        self._model = model
+        self._api_key = api_key
+        self._timeout_seconds = timeout_seconds
+        self._http_client = http_client
+        self._owns_client = http_client is None
+        self._error_factory = error_factory or BaseVLMError
+
+    @property
+    def http_client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(
+                base_url=self._endpoint,
+                timeout=self._timeout_seconds,
+                headers={
+                    "Authorization": f"Bearer {self._api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+        return self._http_client
+
+    async def aclose(self) -> None:
+        if self._owns_client and self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
+    async def _send_chat_completion(self, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            response = await self.http_client.post("/chat/completions", json=payload)
+        except httpx.TimeoutException as exc:
+            raise self._make_error(
+                "VLM request timed out",
+                code=FAILURE_CODE_TIMEOUT,
+                retryable=True,
+            ) from exc
+        except httpx.NetworkError as exc:
+            raise self._make_error(
+                "VLM network request failed",
+                code=FAILURE_CODE_NETWORK,
+                retryable=True,
+            ) from exc
+
+        raw_body = self._decode_raw_response(response)
+
+        if 500 <= response.status_code:
+            raise self._make_error(
+                f"VLM provider returned server error {response.status_code}",
+                code=FAILURE_CODE_PROVIDER,
+                retryable=True,
+                status_code=response.status_code,
+                raw_provider_response=raw_body,
+            )
+
+        if 400 <= response.status_code:
+            raise self._make_error(
+                f"VLM provider rejected request with status {response.status_code}",
+                code=FAILURE_CODE_PROVIDER_REJECTED,
+                retryable=False,
+                status_code=response.status_code,
+                raw_provider_response=raw_body,
+            )
+
+        if not isinstance(raw_body, dict):
+            raise self._make_error(
+                "VLM provider response must be a JSON object",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                status_code=response.status_code,
+                raw_provider_response=raw_body,
+            )
+
+        return raw_body
+
+    @staticmethod
+    def _decode_raw_response(response: httpx.Response) -> Any:
+        try:
+            return response.json()
+        except ValueError:
+            return response.text
+
+    def _make_error(
+        self,
+        message: str,
+        *,
+        code: str,
+        retryable: bool,
+        status_code: int | None = None,
+        raw_provider_response: Any | None = None,
+    ) -> BaseException:
+        return self._error_factory(
+            message,
+            code=code,
+            retryable=retryable,
+            status_code=status_code,
+            raw_provider_response=raw_provider_response,
+        )

--- a/backend/tests/infrastructure/test_base_vlm_client.py
+++ b/backend/tests/infrastructure/test_base_vlm_client.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.infrastructure.vlm.base_client import (
+    FAILURE_CODE_INVALID_RESPONSE,
+    FAILURE_CODE_NETWORK,
+    FAILURE_CODE_PROVIDER,
+    FAILURE_CODE_PROVIDER_REJECTED,
+    FAILURE_CODE_TIMEOUT,
+    BaseVLMClient,
+    BaseVLMError,
+)
+
+
+class _TestClient(BaseVLMClient):
+    pass
+
+
+class _CustomError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str,
+        retryable: bool,
+        status_code: int | None = None,
+        raw_provider_response: Any | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+        self.status_code = status_code
+        self.raw_provider_response = raw_provider_response
+
+
+def _build_client(
+    handler,
+    *,
+    error_factory: Any | None = None,
+) -> BaseVLMClient:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://vlm.example/api",
+        timeout=5,
+        headers={"Authorization": "Bearer demo", "Content-Type": "application/json"},
+    )
+    return _TestClient(
+        endpoint="https://vlm.example/api",
+        model="demo",
+        api_key="demo",
+        timeout_seconds=5,
+        http_client=http_client,
+        error_factory=error_factory,
+    )
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_timeout_maps_to_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timed out")
+
+    client = _build_client(handler)
+
+    with pytest.raises(BaseVLMError) as exc_info:
+        await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_TIMEOUT
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_network_error_maps_to_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    client = _build_client(handler)
+
+    with pytest.raises(BaseVLMError) as exc_info:
+        await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_NETWORK
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_5xx_maps_to_retryable_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": "overloaded"})
+
+    client = _build_client(handler)
+
+    with pytest.raises(BaseVLMError) as exc_info:
+        await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_PROVIDER
+    assert exc_info.value.retryable is True
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.raw_provider_response == {"detail": "overloaded"}
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_4xx_maps_to_non_retryable_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": "bad request"})
+
+    client = _build_client(handler)
+
+    with pytest.raises(BaseVLMError) as exc_info:
+        await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_PROVIDER_REJECTED
+    assert exc_info.value.retryable is False
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.raw_provider_response == {"detail": "bad request"}
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_non_dict_body_maps_to_invalid_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not json")
+
+    client = _build_client(handler)
+
+    with pytest.raises(BaseVLMError) as exc_info:
+        await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert exc_info.value.status_code == 200
+    assert exc_info.value.raw_provider_response == "not json"
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_returns_dict_on_success() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    client = _build_client(handler)
+
+    result = await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert result == {"choices": []}
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_custom_error_factory() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    client = _build_client(handler, error_factory=_CustomError)
+
+    with pytest.raises(_CustomError) as exc_info:
+        await client._send_chat_completion({"model": "demo"})
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_NETWORK
+    assert exc_info.value.retryable is True
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_close_owns_client() -> None:
+    client = _TestClient(
+        endpoint="https://vlm.example/api",
+        model="demo",
+        api_key="demo",
+        timeout_seconds=5,
+    )
+    _ = client.http_client
+    await client.aclose()
+    assert client._http_client is None
+
+
+@pytest.mark.asyncio
+async def test_base_vlm_close_does_not_close_injected_client() -> None:
+    injected = httpx.AsyncClient()
+    client = _TestClient(
+        endpoint="https://vlm.example/api",
+        model="demo",
+        api_key="demo",
+        timeout_seconds=5,
+        http_client=injected,
+    )
+    await client.aclose()
+    assert client._http_client is injected


### PR DESCRIPTION
## Summary

Introduces a shared `BaseVLMClient` transport foundation that consolidates duplicated HTTP client lifecycle, request sending, timeout/network/provider error mapping, and response body decoding. The base class is designed with a configurable error factory so callers can keep their own error classes independent.

## Linked Issue

Closes #254

## Issue Alignment

This PR implements the issue by:

- Creating `backend/app/infrastructure/vlm/base_client.py` with `BaseVLMClient`.
- Sharing constructor/lifecycle (`http_client` property, `aclose`), raw response decoding, and status-code-based error mapping.
- Using a configurable `error_factory` so subclasses can raise their own exception types (e.g. `VLMError` or `SolutionCoachingVLMError`).
- Adding focused tests for timeout, network error, 4xx, 5xx, invalid JSON/body decoding, close behavior, and custom error factories.
- Keeping production clients (`VLMClient` and `_BaseSolutionCoachingVLMClient`) on their current implementations.

Scope covered:

- `BaseVLMClient` and `BaseVLMError`.
- Transport-level tests in a new focused test file.

Out of scope / intentionally not included:

- Migrating existing VLM clients to inherit from the base.
- Unifying error classes.
- Moving fence-stripping, JSON parsing strategies, or chat message models into the base.
- Changing VLM request wire formats.

## Implementation Notes

- `_send_chat_completion` returns the raw decoded `dict` so subclasses retain control over parsing.
- `_decode_raw_response` mirrors the existing clients' behavior (try `response.json()`, fall back to `response.text`).
- Error codes are defined as module-level constants and reused inside the base.

## Tests

Commands run:

- `cd backend && uv run --frozen pytest tests/infrastructure/test_base_vlm_client.py` — passed (9 tests)
- `cd backend && uv run --frozen pytest tests/infrastructure/test_vlm.py` — passed (46 tests)
- `cd backend && uv run --frozen pytest tests/infrastructure/test_solution_coaching_client.py` — passed (23 tests)
- `cd backend && uv run --frozen pytest` — passed (466 tests, 1 skipped)

Automated tests added or updated:

- `backend/tests/infrastructure/test_base_vlm_client.py` covering:
  - Timeout maps to retryable error with correct code.
  - Network error maps to retryable error with correct code.
  - 5xx maps to retryable provider error with status code and raw response.
  - 4xx maps to non-retryable rejected error with status code and raw response.
  - Non-dict body maps to invalid-response error.
  - Successful 200 returns the raw dict.
  - Custom error factory is invoked correctly.
  - Owned client is closed and nulled on `aclose`.
  - Injected client is not closed on `aclose`.

Manual verification:

- Verified that existing VLM and solution-coaching tests pass unchanged, confirming no production behavior regression.
- Verified import of `BaseVLMClient` succeeds.

## Deviations From Issue Plan

None.

## Follow-Up Work

None within this PR. Production client migration is tracked in #255.