### PR TITLE
refactor(backend): migrate VLMClient and _BaseSolutionCoachingVLMClient to BaseVLMClient

### DIFF
--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from app.infrastructure.vlm.base_client import BaseVLMClient
 from app.infrastructure.vlm._models import (
     _ChatCompletionRequest,
     _ChatMessage,
@@ -166,7 +167,7 @@ class GradingResult(BaseModel):
     raw_provider_response: dict[str, Any]
 
 
-class VLMClient:
+class VLMClient(BaseVLMClient):
     def __init__(
         self,
         *,
@@ -177,35 +178,19 @@ class VLMClient:
         http_client: httpx.AsyncClient | None = None,
         extraction_system_prompt: str = MATH_EXTRACTION_SYSTEM_PROMPT,
     ) -> None:
-        self._endpoint = endpoint
-        self._model = model
-        self._api_key = api_key
-        self._timeout_seconds = timeout_seconds
-        self._http_client = http_client
-        self._owns_client = http_client is None
+        super().__init__(
+            endpoint=endpoint,
+            model=model,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+            http_client=http_client,
+            error_factory=VLMError,
+        )
         self._extraction_system_prompt = extraction_system_prompt
 
     @property
     def model(self) -> str:
         return self._model
-
-    @property
-    def http_client(self) -> httpx.AsyncClient:
-        if self._http_client is None:
-            self._http_client = httpx.AsyncClient(
-                base_url=self._endpoint,
-                timeout=self._timeout_seconds,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-        return self._http_client
-
-    async def aclose(self) -> None:
-        if self._owns_client and self._http_client is not None:
-            await self._http_client.aclose()
-            self._http_client = None
 
     async def extract(
         self,
@@ -317,58 +302,8 @@ class VLMClient:
 
     async def _send_request(self, request: _RequestBase) -> dict[str, Any]:
         payload = self._build_chat_completion_payload(request)
-        try:
-            response = await self.http_client.post("/chat/completions", json=payload)
-        except httpx.TimeoutException as exc:
-            raise VLMError(
-                "VLM request timed out",
-                code=FAILURE_CODE_TIMEOUT,
-                retryable=True,
-            ) from exc
-        except httpx.NetworkError as exc:
-            raise VLMError(
-                "VLM network request failed",
-                code=FAILURE_CODE_NETWORK,
-                retryable=True,
-            ) from exc
-
-        raw_body = self._decode_raw_response(response)
-
-        if 500 <= response.status_code:
-            raise VLMError(
-                f"VLM provider returned server error {response.status_code}",
-                code=FAILURE_CODE_PROVIDER,
-                retryable=True,
-                status_code=response.status_code,
-                raw_provider_response=raw_body,
-            )
-
-        if 400 <= response.status_code:
-            raise VLMError(
-                f"VLM provider rejected request with status {response.status_code}",
-                code=FAILURE_CODE_PROVIDER_REJECTED,
-                retryable=False,
-                status_code=response.status_code,
-                raw_provider_response=raw_body,
-            )
-
-        if not isinstance(raw_body, dict):
-            raise VLMError(
-                "VLM provider response must be a JSON object",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                status_code=response.status_code,
-                raw_provider_response=raw_body,
-            )
-
+        raw_body = await self._send_chat_completion(payload)
         return self._parse_chat_completion_response(raw_body)
-
-    @staticmethod
-    def _decode_raw_response(response: httpx.Response) -> Any:
-        try:
-            return response.json()
-        except ValueError:
-            return response.text
 
     @staticmethod
     def _strip_json_code_fences(content: str) -> str:

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -8,6 +8,7 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from app.infrastructure.config.settings import Settings, get_settings
+from app.infrastructure.vlm.base_client import BaseVLMClient
 from app.infrastructure.vlm._models import (
     _ChatCompletionRequest,
     _ChatMessage,
@@ -190,7 +191,7 @@ class _CoachingProviderPayload(BaseModel):
     reasoning_content: str | None = None
 
 
-class _BaseSolutionCoachingVLMClient:
+class _BaseSolutionCoachingVLMClient(BaseVLMClient):
     def __init__(
         self,
         *,
@@ -200,76 +201,17 @@ class _BaseSolutionCoachingVLMClient:
         timeout_seconds: float,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._endpoint = endpoint
-        self._model = model
-        self._api_key = api_key
-        self._timeout_seconds = timeout_seconds
-        self._http_client = http_client
-        self._owns_client = http_client is None
-
-    @property
-    def http_client(self) -> httpx.AsyncClient:
-        if self._http_client is None:
-            self._http_client = httpx.AsyncClient(
-                base_url=self._endpoint,
-                timeout=self._timeout_seconds,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                },
-            )
-        return self._http_client
-
-    async def aclose(self) -> None:
-        if self._owns_client and self._http_client is not None:
-            await self._http_client.aclose()
-            self._http_client = None
+        super().__init__(
+            endpoint=endpoint,
+            model=model,
+            api_key=api_key,
+            timeout_seconds=timeout_seconds,
+            http_client=http_client,
+            error_factory=SolutionCoachingVLMError,
+        )
 
     async def _send_chat_completion(self, payload: dict[str, Any]) -> dict[str, Any]:
-        try:
-            response = await self.http_client.post("/chat/completions", json=payload)
-        except httpx.TimeoutException as exc:
-            raise SolutionCoachingVLMError(
-                "VLM request timed out",
-                code=FAILURE_CODE_TIMEOUT,
-                retryable=True,
-            ) from exc
-        except httpx.NetworkError as exc:
-            raise SolutionCoachingVLMError(
-                "VLM network request failed",
-                code=FAILURE_CODE_NETWORK,
-                retryable=True,
-            ) from exc
-
-        raw_body = self._decode_raw_response(response)
-
-        if 500 <= response.status_code:
-            raise SolutionCoachingVLMError(
-                f"VLM provider returned server error {response.status_code}",
-                code=FAILURE_CODE_PROVIDER,
-                retryable=True,
-                status_code=response.status_code,
-                raw_provider_response=raw_body,
-            )
-
-        if 400 <= response.status_code:
-            raise SolutionCoachingVLMError(
-                f"VLM provider rejected request with status {response.status_code}",
-                code=FAILURE_CODE_PROVIDER_REJECTED,
-                retryable=False,
-                status_code=response.status_code,
-                raw_provider_response=raw_body,
-            )
-
-        if not isinstance(raw_body, dict):
-            raise SolutionCoachingVLMError(
-                "VLM provider response must be a JSON object",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                status_code=response.status_code,
-                raw_provider_response=raw_body,
-            )
-
+        raw_body = await super()._send_chat_completion(payload)
         return self._parse_chat_completion_response(raw_body)
 
     @staticmethod

--- a/backend/tests/infrastructure/test_vlm_error_independence.py
+++ b/backend/tests/infrastructure/test_vlm_error_independence.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.infrastructure.vlm.client import VLMClient, VLMError
+from app.infrastructure.vlm.solution_coaching_client import (
+    SolutionCoachingVLMError,
+    SolutionVLMClient,
+)
+
+
+def _build_vlm_client(handler) -> VLMClient:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://vlm.example/api",
+        timeout=5,
+        headers={"Authorization": "Bearer demo", "Content-Type": "application/json"},
+    )
+    return VLMClient(
+        endpoint="https://vlm.example/api",
+        model="demo",
+        api_key="demo",
+        timeout_seconds=5,
+        http_client=http_client,
+    )
+
+
+def _build_solution_client(handler) -> SolutionVLMClient:
+    from app.infrastructure.config.settings import Settings
+
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://solution.example/api",
+        timeout=5,
+        headers={"Authorization": "Bearer solution-key", "Content-Type": "application/json"},
+    )
+    settings = Settings(
+        math_solution_vlm_endpoint="https://solution.example/api",
+        math_solution_vlm_model="solution-model",
+        math_solution_vlm_api_key="solution-key",
+        math_solution_vlm_timeout_seconds=7,
+    )
+    return SolutionVLMClient(settings=settings, http_client=http_client)
+
+
+@pytest.mark.asyncio
+async def test_vlm_error_and_solution_coaching_error_are_independently_catchable() -> None:
+    async def vlm_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    async def solution_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    vlm_client = _build_vlm_client(vlm_handler)
+    solution_client = _build_solution_client(solution_handler)
+
+    with pytest.raises(VLMError) as vlm_exc:
+        await vlm_client.extract(image_url="https://example.com/img.png")
+    assert not isinstance(vlm_exc.value, SolutionCoachingVLMError)
+    await vlm_client.aclose()
+
+    from app.infrastructure.vlm.solution_coaching_client import SolutionVLMRequest
+
+    with pytest.raises(SolutionCoachingVLMError) as solution_exc:
+        await solution_client.generate_solution(
+            SolutionVLMRequest(problem_text="test", correct_answer="1")
+        )
+    assert not isinstance(solution_exc.value, VLMError)
+    await solution_client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_vlm_error_is_not_solution_coaching_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    client = _build_vlm_client(handler)
+    with pytest.raises(VLMError) as exc_info:
+        await client.extract(image_url="https://example.com/img.png")
+    await client.aclose()
+
+    assert not isinstance(exc_info.value, SolutionCoachingVLMError)
+
+
+@pytest.mark.asyncio
+async def test_solution_coaching_error_is_not_vlm_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom")
+
+    client = _build_solution_client(handler)
+    from app.infrastructure.vlm.solution_coaching_client import SolutionVLMRequest
+
+    with pytest.raises(SolutionCoachingVLMError) as exc_info:
+        await client.generate_solution(
+            SolutionVLMRequest(problem_text="test", correct_answer="1")
+        )
+    await client.aclose()
+
+    assert not isinstance(exc_info.value, VLMError)


### PR DESCRIPTION
## Summary

Migrate `VLMClient` and `_BaseSolutionCoachingVLMClient` to use `BaseVLMClient` for transport while preserving all current wire formats, errors, parsing, and fence-stripping behavior.

## Linked Issue

Closes #255

## Issue Alignment

This PR implements the issue by:

- Making `VLMClient` inherit from `BaseVLMClient` and passing `error_factory=VLMError`.
- Making `_BaseSolutionCoachingVLMClient` inherit from `BaseVLMClient` and passing `error_factory=SolutionCoachingVLMError`.
- Removing duplicated `http_client` property, `aclose`, and `_decode_raw_response` from both clients.
- Keeping client-specific fence-stripping, JSON loading/parsing, chat message models, and error classes separate.

Scope covered:

- `VLMClient` uses `BaseVLMClient._send_chat_completion` for transport.
- `_BaseSolutionCoachingVLMClient` uses `BaseVLMClient._send_chat_completion` for transport, then applies its own `_parse_chat_completion_response`.
- Error independence test added.

Out of scope / intentionally not included:

- Unifying error classes or introducing shared parent exceptions.
- Unifying fence-stripping behavior.
- Unifying JSON parsing strategies.
- Changing prompts, retry logic, public method signatures, or request payloads.

## Implementation Notes

- `VLMClient._send_request` now delegates transport to `BaseVLMClient._send_chat_completion` and then applies its own `_parse_chat_completion_response`.
- `_BaseSolutionCoachingVLMClient._send_chat_completion` overrides the base method to call `super()._send_chat_completion(payload)` and then parse the response with its own parser.
- Both clients retain their distinct `_strip_json_code_fences` implementations.

## Tests

Commands run:

- `cd backend && uv run --frozen pytest tests/infrastructure/test_vlm.py tests/infrastructure/test_solution_coaching_client.py tests/infrastructure/test_vlm_error_independence.py -v` -- passed (72 tests)
- `cd backend && uv run --frozen pytest tests/ -v` -- passed (469 tests, 1 skipped)
- `cd backend && python -c "from app.infrastructure.vlm.client import VLMClient; from app.infrastructure.vlm.solution_coaching_client import _BaseSolutionCoachingVLMClient; print('OK')"` -- OK

Automated tests added or updated:

- `backend/tests/infrastructure/test_vlm_error_independence.py` -- new tests proving `VLMError` and `SolutionCoachingVLMError` remain independently catchable.
- Existing characterization tests in `test_vlm.py` and `test_solution_coaching_client.py` continue to pass without modification.

Manual verification:

- Verified imports load correctly with no cycles.
- Verified full backend test suite passes.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
