### PR TITLE
test(backend): add missing VLM parser/error characterization tests

### DIFF
--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -630,3 +630,94 @@ def test_solution_coaching_strip_json_code_fences_strips_multiline_json_content(
     fenced = '```json\n{\n  "text": "hello",\n  "value": 42\n}\n```'
 
     assert SolutionVLMClient._strip_json_code_fences(fenced) == '{\n  "text": "hello",\n  "value": 42\n}'
+
+
+@pytest.mark.asyncio
+async def test_solution_vlm_client_extracts_embedded_json_without_fences() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here is the solution:\n{\"steps_markdown\":\"Step 1\\nStep 2\",\"final_answer\":\"42\",\"level_classification\":\"primary\"}\nHope this helps!",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_solution_client(handler)
+    result = await client.generate_solution(
+        SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+    )
+    await client.aclose()
+
+    assert result.steps_markdown == "Step 1\nStep 2"
+    assert result.final_answer == "42"
+    assert result.level_classification == "primary"
+
+
+@pytest.mark.asyncio
+async def test_coaching_vlm_client_extracts_embedded_json_without_fences() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here is the reply:\n{\"text\":\"先想想已知条件。\"}\nDone",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingVLMRequest(
+            problem_text="题目",
+            correct_answer="答案",
+            canonical_steps_markdown="步骤",
+            canonical_final_answer="答案",
+            level_classification="primary",
+            new_message="请提示一下",
+        )
+    )
+    await client.aclose()
+
+    assert result.text == "先想想已知条件。"
+
+
+@pytest.mark.asyncio
+async def test_solution_vlm_client_preserves_reasoning_content_in_raw_response() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps({"steps_markdown":"步骤","final_answer":"42","level_classification":"primary"}),
+                            "reasoning_content": "推理过程",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_solution_client(handler)
+    result = await client.generate_solution(
+        SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+    )
+    await client.aclose()
+
+    assert result.raw_provider_response["reasoning_content"] == "推理过程"


### PR DESCRIPTION
## Summary

Audit existing VLM tests and add missing characterization coverage for solution/coaching embedded JSON extraction and solution reasoning_content behavior.

## Linked Issue

Closes #271

## Issue Alignment

This PR implements the issue by:

- Auditing existing VLM test coverage in `test_vlm.py`, `test_solution_coaching_client.py`, `test_vlm_error_independence.py`, and `test_base_vlm_client.py`.
- Adding missing characterization tests for solution/coaching embedded JSON extraction fallback.
- Adding a missing characterization test for SolutionVLMClient reasoning_content preservation.

Scope covered:

- Existing VLMClient fence stripping behavior is already comprehensively covered; no new tests needed.
- Existing solution/coaching fence stripping behavior is already comprehensively covered; no new tests needed.
- Existing public `VLMError` and `SolutionCoachingVLMError` independence is already comprehensively covered; no new tests needed.
- Existing optional coaching `reasoning_content` behavior (present and absent) is already covered; one additional solution test added for symmetry.
- Missing solution/coaching embedded JSON extraction fallback (JSON surrounded by text without fences) is now covered.

Out of scope / intentionally not included:

- Production VLM code changes.
- VLM primitive consolidation.
- Merging public error types.
- Normalizing parser behavior.

## Implementation Notes

- Added `test_solution_vlm_client_extracts_embedded_json_without_fences` to verify `_BaseSolutionCoachingVLMClient._load_json_content` falls back to extracting JSON between `{` and `}` when the content has surrounding text and no code fences.
- Added `test_coaching_vlm_client_extracts_embedded_json_without_fences` for the same fallback on the coaching path.
- Added `test_solution_vlm_client_preserves_reasoning_content_in_raw_response` to verify `reasoning_content` from the provider is preserved in `raw_provider_response` for solution generation.

## Tests

Commands run:

- `cd backend && uv run pytest tests/infrastructure/test_vlm.py tests/infrastructure/test_solution_coaching_client.py tests/infrastructure/test_vlm_error_independence.py tests/infrastructure/test_base_vlm_client.py -v` — passed (84 tests)
- `cd backend && uv run pytest` — passed (472 tests, 1 skipped)

Automated tests added or updated:

- `backend/tests/infrastructure/test_solution_coaching_client.py` — 3 new tests.

Manual verification:

- None required beyond automated test runs.

## Deviations From Issue Plan

None.

## Follow-Up Work

None. This issue enables the later VLM shared primitive consolidation (#275).
