### PR TITLE
refactor(backend): extract shared folder ownership and descendant helpers

### DIFF
--- a/backend/app/presentation/folders.py
+++ b/backend/app/presentation/folders.py
@@ -10,7 +10,11 @@ from pydantic import BaseModel, Field
 
 from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
-from app.presentation.helpers import parse_object_id
+from app.presentation.helpers import (
+    get_all_descendant_folder_ids,
+    get_owned_folder,
+    parse_object_id,
+)
 
 router = APIRouter(prefix="/folders", tags=["folders"])
 
@@ -71,21 +75,6 @@ def _normalize_folder_name(name: str) -> str:
     return trimmed
 
 
-async def _get_owned_folder(
-    database: DatabaseDependency,
-    folder_id: str,
-    user_id: ObjectId,
-) -> dict[str, Any]:
-    """Get a folder by ID, verifying ownership."""
-    object_id = parse_object_id(folder_id, resource_name="Folder")
-    folder = await database["folders"].find_one({"_id": object_id})
-    if folder is None:
-        raise ApiError(404, "NOT_FOUND", "Folder not found")
-    if folder.get("userId") != user_id:
-        raise ApiError(403, "FORBIDDEN", "Forbidden")
-    return folder
-
-
 async def _check_sibling_name_conflict(
     database: DatabaseDependency,
     user_id: ObjectId,
@@ -110,33 +99,6 @@ async def _check_sibling_name_conflict(
         raise ApiError(409, "DUPLICATE_FOLDER_NAME", "A folder with this name already exists in this location")
 
 
-async def _get_all_descendant_ids(
-    database: DatabaseDependency,
-    folder_id: ObjectId,
-) -> set[ObjectId]:
-    """Get all descendant folder IDs recursively."""
-    descendants: set[ObjectId] = set()
-    to_check = [folder_id]
-
-    while to_check:
-        current_batch = to_check
-        to_check = []
-
-        cursor = database["folders"].find(
-            {"parentId": {"$in": current_batch}},
-            {"_id": 1},
-        )
-        children = await cursor.to_list(length=None)
-
-        for child in children:
-            child_id = child["_id"]
-            if child_id not in descendants:
-                descendants.add(child_id)
-                to_check.append(child_id)
-
-    return descendants
-
-
 async def _count_problems_in_folder(
     database: DatabaseDependency,
     user_id: ObjectId,
@@ -158,7 +120,7 @@ async def _count_problems_in_folder_tree(
 ) -> int:
     """Count non-deleted problems in a folder and all its descendants."""
     # Get all descendants
-    descendant_ids = await _get_all_descendant_ids(database, folder_id)
+    descendant_ids = await get_all_descendant_folder_ids(database, folder_id)
     all_folder_ids = {folder_id} | descendant_ids
 
     # Count problems in all these folders
@@ -288,7 +250,7 @@ async def get_folder(
 ) -> FolderResponse:
     """Get a single folder by ID."""
     user_id = current_user["_id"]
-    folder = await _get_owned_folder(database, folder_id, user_id)
+    folder = await get_owned_folder(database, folder_id, user_id)
     return FolderResponse(folder=_serialize_folder(folder))
 
 
@@ -301,7 +263,7 @@ async def update_folder(
 ) -> FolderResponse:
     """Rename or move a folder."""
     user_id = current_user["_id"]
-    folder = await _get_owned_folder(database, folder_id, user_id)
+    folder = await get_owned_folder(database, folder_id, user_id)
     folder_oid = folder["_id"]
 
     updates: dict[str, Any] = {"updatedAt": datetime.now(UTC)}
@@ -334,7 +296,7 @@ async def update_folder(
             if new_parent_id == folder_oid:
                 raise ApiError(400, "INVALID_MOVE", "Cannot move folder under itself")
 
-            descendants = await _get_all_descendant_ids(database, folder_oid)
+            descendants = await get_all_descendant_folder_ids(database, folder_oid)
             if new_parent_id in descendants:
                 raise ApiError(400, "INVALID_MOVE", "Cannot move folder under its descendant")
 
@@ -360,7 +322,7 @@ async def delete_folder(
 ) -> DeleteFolderResponse:
     """Delete an empty folder."""
     user_id = current_user["_id"]
-    folder = await _get_owned_folder(database, folder_id, user_id)
+    folder = await get_owned_folder(database, folder_id, user_id)
     folder_oid = folder["_id"]
 
     # Check for child folders

--- a/backend/app/presentation/helpers.py
+++ b/backend/app/presentation/helpers.py
@@ -51,3 +51,45 @@ async def get_owned_problem(
     return problem
 
 
+async def get_owned_folder(
+    database: AsyncDatabase[Document],
+    folder_id: str,
+    user_id: ObjectId,
+) -> dict[str, Any]:
+    """Get a folder by ID, verifying ownership."""
+    object_id = parse_object_id(folder_id, resource_name="Folder")
+    folder = await database["folders"].find_one({"_id": object_id})
+    if folder is None:
+        raise ApiError(404, "NOT_FOUND", "Folder not found")
+    if folder.get("userId") != user_id:
+        raise ApiError(403, "FORBIDDEN", "Forbidden")
+    return folder
+
+
+async def get_all_descendant_folder_ids(
+    database: AsyncDatabase[Document],
+    folder_id: ObjectId,
+) -> set[ObjectId]:
+    """Get all descendant folder IDs recursively."""
+    descendants: set[ObjectId] = set()
+    to_check = [folder_id]
+
+    while to_check:
+        current_batch = to_check
+        to_check = []
+
+        cursor = database["folders"].find(
+            {"parentId": {"$in": current_batch}},
+            {"_id": 1},
+        )
+        children = await cursor.to_list(length=None)
+
+        for child in children:
+            child_id = child["_id"]
+            if child_id not in descendants:
+                descendants.add(child_id)
+                to_check.append(child_id)
+
+    return descendants
+
+

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -14,7 +14,7 @@ from app.domain.models import ProblemType
 from app.domain.normalization import normalize_answer
 from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
-from app.presentation.helpers import build_problem_image_url, get_owned_problem, normalize_tags, parse_object_id
+from app.presentation.helpers import build_problem_image_url, get_all_descendant_folder_ids, get_owned_folder, get_owned_problem, normalize_tags, parse_object_id
 from app.presentation.schemas import CorrectAnswerPayload
 from app.presentation.tags import _register_tags
 
@@ -173,49 +173,6 @@ def _serialize_problem_detail(problem: dict[str, Any]) -> ProblemDetailPayload:
     )
 
 
-async def _get_owned_folder(
-    database: DatabaseDependency,
-    folder_id: str,
-    user_id: ObjectId,
-) -> dict[str, Any]:
-    """Get a folder by ID, verifying ownership."""
-    object_id = parse_object_id(folder_id, resource_name="Folder")
-    folder = await database["folders"].find_one({"_id": object_id})
-    if folder is None:
-        raise ApiError(404, "NOT_FOUND", "Folder not found")
-    if folder.get("userId") != user_id:
-        raise ApiError(403, "FORBIDDEN", "Forbidden")
-    return folder
-
-
-async def _get_all_descendant_folder_ids(
-    database: DatabaseDependency,
-    folder_id: ObjectId,
-) -> set[ObjectId]:
-    """Get all descendant folder IDs recursively."""
-    descendants: set[ObjectId] = set()
-    to_check = [folder_id]
-
-    while to_check:
-        current_batch = to_check
-        to_check = []
-
-        cursor = database["folders"].find(
-            {"parentId": {"$in": current_batch}},
-            {"_id": 1},
-        )
-        children = await cursor.to_list(length=None)
-
-        for child in children:
-            child_id = child["_id"]
-            if child_id not in descendants:
-                descendants.add(child_id)
-                to_check.append(child_id)
-
-    return descendants
-
-
-
 @router.get("/tags", response_model=ProblemTagsResponse)
 async def list_problem_tags(
     database: DatabaseDependency,
@@ -261,9 +218,9 @@ async def list_problems(
             query["folderId"] = None
         else:
             # Real folder: validate ownership and include descendants
-            folder = await _get_owned_folder(database, folder_id, user_id)
+            folder = await get_owned_folder(database, folder_id, user_id)
             folder_oid = folder["_id"]
-            descendant_ids = await _get_all_descendant_folder_ids(database, folder_oid)
+            descendant_ids = await get_all_descendant_folder_ids(database, folder_oid)
             all_folder_ids = {folder_oid} | descendant_ids
             query["folderId"] = {"$in": [str(fid) for fid in all_folder_ids]}
 
@@ -291,7 +248,7 @@ async def bulk_set_problem_folder(
     # Validate target folder if provided
     target_folder_id: str | None = None
     if payload.folderId is not None:
-        folder = await _get_owned_folder(database, payload.folderId, user_id)
+        folder = await get_owned_folder(database, payload.folderId, user_id)
         target_folder_id = str(folder["_id"])
 
     # Validate all problem IDs and ownership
@@ -387,7 +344,7 @@ async def set_problem_folder(
     # Validate target folder if provided
     target_folder_id: str | None = None
     if payload.folderId is not None:
-        folder = await _get_owned_folder(database, payload.folderId, user_id)
+        folder = await get_owned_folder(database, payload.folderId, user_id)
         target_folder_id = str(folder["_id"])
 
     # Update the problem


### PR DESCRIPTION
## Summary

- Extract duplicated `_get_owned_folder` and `_get_all_descendant_folder_ids` from `folders.py` and `problems.py` into `presentation/helpers.py` as shared route-neutral helpers.

## Linked Issue

Closes #272

## Issue Alignment

This PR implements the issue by:

- Moving `_get_owned_folder` logic into `helpers.py` as `get_owned_folder`.
- Moving descendant-folder traversal logic into `helpers.py` as `get_all_descendant_folder_ids`.
- Updating `folders.py` and `problems.py` to import the shared helpers.
- Removing the duplicated local implementations.

Scope covered:

- Extract duplicated `_get_owned_folder` logic.
- Extract duplicated descendant-folder traversal logic.
- Update `presentation/folders.py` and `presentation/problems.py` to use shared route-neutral helper code.

Out of scope / intentionally not included:

- Router-to-router imports.
- A new service/repository layer.
- Authorization behavior changes.
- API response shape changes.
- Unrelated cleanup in folders or problems routes.

## Implementation Notes

- Added `get_owned_folder` and `get_all_descendant_folder_ids` to `backend/app/presentation/helpers.py`.
- Updated `folders.py` to import from helpers instead of defining locally.
- Updated `problems.py` to import from helpers instead of defining locally.
- Net reduction of ~39 lines (96 removed, 57 added).

## Tests

Commands run:

- `cd backend && uv run pytest tests/api/test_folders.py tests/api/test_problems.py -v` — passed (50 tests)
- `cd backend && uv run pytest` — passed (469 tests, 1 skipped)

Automated tests added or updated:

- None needed; existing tests cover all affected behavior.

Manual verification:

- None required beyond automated test runs.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.