### PR TITLE
refactor(frontend): extract shared folder DTO types and problem type options

### DIFF
--- a/frontend/src/components/ingestion/EditingStep.tsx
+++ b/frontend/src/components/ingestion/EditingStep.tsx
@@ -2,6 +2,7 @@ import { GraphSandbox } from "../GraphSandbox";
 import { TagInput } from "../TagInput";
 import { parseOptions } from "../AnswerInput";
 import type { IngestionPreview, WizardFormData, WizardStep } from "../IngestionWizard";
+import { PROBLEM_TYPE_OPTIONS } from "@/constants/problemTypes";
 
 export interface EditingStepProps {
   previewId: string;
@@ -158,10 +159,9 @@ export function EditingStep({
           data-testid="problem-type-input"
         >
           <option value="">Select a problem type…</option>
-          <option value="single-choice">Single Choice</option>
-          <option value="multi-choice">Multi Choice</option>
-          <option value="fill-in-the-blank">Fill in the Blank</option>
-          <option value="short-answer">Short Answer</option>
+          {PROBLEM_TYPE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>{option.label}</option>
+          ))}
         </select>
       </div>
 

--- a/frontend/src/constants/problemTypes.ts
+++ b/frontend/src/constants/problemTypes.ts
@@ -1,0 +1,11 @@
+export const PROBLEM_TYPE_OPTIONS = [
+  { value: "single-choice", label: "Single Choice" },
+  { value: "multi-choice", label: "Multi Choice" },
+  { value: "fill-in-the-blank", label: "Fill in the Blank" },
+  { value: "short-answer", label: "Short Answer" },
+];
+
+export const PROBLEM_TYPE_FILTER_OPTIONS = [
+  { value: "", label: "All Types" },
+  ...PROBLEM_TYPE_OPTIONS,
+];

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -11,6 +11,7 @@ import { TagList } from "@/components/TagPill";
 import { TeacherPasswordModal } from "@/components/TeacherPasswordModal";
 import { useTagSuggestions } from "@/hooks/useTagSuggestions";
 import type { ProblemDetail, ProblemResponse } from "@/types/problem";
+import { PROBLEM_TYPE_OPTIONS } from "@/constants/problemTypes";
 
 interface TrackingData {
   problemId: string;
@@ -299,10 +300,9 @@ export function ProblemDetailPage() {
                 data-testid="problem-type-input"
               >
                 <option value="">Select a problem type…</option>
-                <option value="single-choice">Single Choice</option>
-                <option value="multi-choice">Multi Choice</option>
-                <option value="fill-in-the-blank">Fill in the Blank</option>
-                <option value="short-answer">Short Answer</option>
+                {PROBLEM_TYPE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
               </select>
               <div style={{ marginTop: "0.25rem", fontSize: "0.75rem", color: "var(--color-text-muted)" }}>
                 The existing correct answer will be interpreted using the selected type.

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -7,30 +7,8 @@ import { useTagSuggestions } from "@/hooks/useTagSuggestions";
 import Pagination from "@/components/Pagination";
 import { TagList } from "@/components/TagPill";
 import type { ProblemListItem, ProblemsResponse } from "@/types/problem";
-
-interface FolderNode {
-  id: string;
-  name: string;
-  parentId: string | null;
-  problemCount: number;
-  children: FolderNode[];
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface FolderTreeResponse {
-  allProblemsCount: number;
-  unfiledCount: number;
-  items: FolderNode[];
-}
-
-const PROBLEM_TYPE_OPTIONS = [
-  { value: "", label: "All Types" },
-  { value: "single-choice", label: "Single Choice" },
-  { value: "multi-choice", label: "Multi Choice" },
-  { value: "fill-in-the-blank", label: "Fill in the Blank" },
-  { value: "short-answer", label: "Short Answer" },
-];
+import type { FolderNode, FolderTreeResponse } from "@/types/folder";
+import { PROBLEM_TYPE_FILTER_OPTIONS } from "@/constants/problemTypes";
 
 const SIDEBAR_COLLAPSED_KEY = "problems.folderSidebarCollapsed";
 const UNFILED_FOLDER_ID = "unfiled";
@@ -561,7 +539,7 @@ export function ProblemsPage() {
                 exitSelectionMode();
               }}
             >
-              {PROBLEM_TYPE_OPTIONS.map((option) => (
+              {PROBLEM_TYPE_FILTER_OPTIONS.map((option) => (
                 <option key={option.value || "all"} value={option.value}>
                   {option.label}
                 </option>

--- a/frontend/src/types/folder.ts
+++ b/frontend/src/types/folder.ts
@@ -1,0 +1,15 @@
+export interface FolderNode {
+  id: string;
+  name: string;
+  parentId: string | null;
+  problemCount: number;
+  children: FolderNode[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FolderTreeResponse {
+  allProblemsCount: number;
+  unfiledCount: number;
+  items: FolderNode[];
+}


### PR DESCRIPTION
## Summary

- Add `frontend/src/types/folder.ts` for shared `FolderNode` and `FolderTreeResponse` DTOs.
- Add `frontend/src/constants/problemTypes.ts` for shared problem type UI options.
- Replace duplicated definitions in `ProblemsPage.tsx`, `ProblemDetailPage.tsx`, and `EditingStep.tsx`.

## Linked Issue

Closes #273

## Issue Alignment

This PR implements the issue by:

- Adding `frontend/src/types/folder.ts` with shared `FolderNode` and `FolderTreeResponse` interfaces.
- Adding `frontend/src/constants/problemTypes.ts` with `PROBLEM_TYPE_OPTIONS` (for edit forms) and `PROBLEM_TYPE_FILTER_OPTIONS` (for filter dropdowns with "All Types").
- Replacing page-local `FolderNode`/`FolderTreeResponse` definitions in `ProblemsPage.tsx` with shared imports.
- Replacing hardcoded problem type dropdown options in `ProblemDetailPage.tsx` and `EditingStep.tsx` with shared constants.

Scope covered:

- Add `frontend/src/types/folder.ts` for folder tree DTOs shared by folder-aware frontend pages/components.
- Add `frontend/src/constants/problemTypes.ts` for problem type UI options.
- Replace duplicated problem type dropdown option values.
- Replace page-local folder DTO definitions.

Out of scope / intentionally not included:

- Backend API contract changes.
- Renaming `PracticeProblem.type`.
- Moving `CorrectAnswer`.
- Creating a catch-all `types/index.ts` barrel.
- Broad frontend page/component decomposition.

## Implementation Notes

- Split problem type constants into `PROBLEM_TYPE_OPTIONS` (base options for edit forms) and `PROBLEM_TYPE_FILTER_OPTIONS` (extends with "All Types" for filter dropdowns) to avoid forcing edit forms to include the filter-only entry.
- Net change: +37 lines, -33 lines (includes 2 new files).

## Tests

Commands run:

- `cd frontend && npx tsc -b --noEmit` — passed
- `cd frontend && npm test -- --run` — passed (297 tests, 24 test files)

Automated tests added or updated:

- None needed; existing tests cover all affected behavior.

Manual verification:

- None required beyond automated test runs.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.