### PR TITLE
refactor(frontend): introduce typed ApiError and remove API default export

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { api } from "./client";
+import { api, ApiError } from "./client";
 
 describe("API Client postFormData", () => {
   beforeEach(() => {
@@ -31,7 +31,7 @@ describe("API Client postFormData", () => {
     expect(result).toEqual({ success: true });
   });
 
-  it("handles HTTP errors correctly by throwing enriched error", async () => {
+  it("handles HTTP errors correctly by throwing ApiError", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: false,
       status: 400,
@@ -51,9 +51,32 @@ describe("API Client postFormData", () => {
     try {
       await api.postFormData("/test-path", formData);
     } catch (err) {
-      const error = err as Error & { code?: string; status?: number };
+      expect(err).toBeInstanceOf(ApiError);
+      const error = err as ApiError;
       expect(error.code).toBe("VALIDATION_FAILED");
       expect(error.status).toBe(400);
+      expect(error.name).toBe("ApiError");
+    }
+  });
+
+  it("falls back to HTTP status text when error body is missing", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.reject(new Error("no json")),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const formData = new FormData();
+    try {
+      await api.postFormData("/test-path", formData);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const error = err as ApiError;
+      expect(error.message).toBe("HTTP 500: Internal Server Error");
+      expect(error.status).toBe(500);
+      expect(error.code).toBeUndefined();
     }
   });
 });

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -79,4 +79,25 @@ describe("API Client postFormData", () => {
       expect(error.code).toBeUndefined();
     }
   });
+
+  it("falls back to HTTP status text when json resolves to null", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve(null),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const formData = new FormData();
+    try {
+      await api.postFormData("/test-path", formData);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const error = err as ApiError;
+      expect(error.message).toBe("HTTP 500: Internal Server Error");
+      expect(error.status).toBe(500);
+      expect(error.code).toBeUndefined();
+    }
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -33,7 +33,8 @@ export interface MeResponse {
 
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
+    const rawData = await response.json().catch(() => ({}));
+    const errorData = rawData && typeof rawData === "object" ? rawData : {};
     throw new ApiError(
       errorData.error?.message || `HTTP ${response.status}: ${response.statusText}`,
       response.status,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5,6 +5,18 @@ import type { CoachingConversation } from "@/types/coaching";
 
 const API_BASE = "/api/v1";
 
+export class ApiError extends Error {
+  code?: string;
+  status: number;
+
+  constructor(message: string, status: number, code?: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
 export interface User {
   id: string;
   username: string;
@@ -22,12 +34,11 @@ export interface MeResponse {
 async function handleResponse<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));
-    const error = new Error(
+    throw new ApiError(
       errorData.error?.message || `HTTP ${response.status}: ${response.statusText}`,
+      response.status,
+      errorData.error?.code,
     );
-    (error as Error & { code?: string; status?: number }).code = errorData.error?.code;
-    (error as Error & { code?: string; status?: number }).status = response.status;
-    throw error;
   }
   if (response.status === 204) {
     return undefined as unknown as T;
@@ -235,5 +246,3 @@ export const api = {
     return handleResponse<T>(response);
   },
 };
-
-export default api;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 
-import api, { type User } from "@/api/client";
+import { api, type User } from "@/api/client";
 
 interface AuthState {
   user: User | null;

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/api/client";
+import { api, ApiError } from "@/api/client";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { LatexText } from "@/components/LatexText";
@@ -188,7 +188,7 @@ export function ActiveExamPage() {
     );
   }
 
-  const isNotFoundError = examError instanceof Error && examError.message.includes("404");
+  const isNotFoundError = examError instanceof ApiError && examError.status === 404;
   if (isNotFoundError || !exam) {
     return (
       <main style={pageCanvasStyle}>


### PR DESCRIPTION
## Summary

- Add exported `ApiError` class with `.message`, `.code`, and `.status` to `frontend/src/api/client.ts`.
- Update `handleResponse` to throw `ApiError` instead of enriched plain `Error`.
- Replace ActiveExamPage 404 string matching with `ApiError` status check.
- Convert AuthContext to named `api` import.
- Remove the API client default export.

## Linked Issue

Closes #274

## Issue Alignment

This PR implements the issue by:

- Adding a typed `ApiError` class that preserves `.message`, `.code`, and `.status` behavior.
- Updating `handleResponse` to throw `ApiError`.
- Replacing ActiveExamPage fragile 404 string matching with `instanceof ApiError && status === 404`.
- Converting AuthContext to named `api` import.
- Removing `export default api`.

Scope covered:

- Typed `ApiError` export.
- `handleResponse` throws `ApiError`.
- ActiveExamPage uses `status === 404`.
- AuthContext named import conversion.
- Default export removal.

Out of scope / intentionally not included:

- Feature API module splitting.
- IngestionWizard raw-fetch migration.
- User-visible behavior changes.
- Backend API changes.

## Implementation Notes

- `ApiError` extends `Error` so `instanceof Error` checks still work, preserving existing catch blocks.
- Added fallback test for missing/malformed error body case.

## Tests

Commands run:

- `cd frontend && npx tsc -b --noEmit` — passed
- `cd frontend && npm test -- --run src/api/client.test.ts src/pages/ActiveExamPage.test.tsx` — passed (11 tests)
- `cd frontend && npm test -- --run` — passed (298 tests, 24 test files)

Automated tests added or updated:

- Updated `client.test.ts` to verify `ApiError` instance, `.name`, `.code`, `.status`.
- Added test for fallback HTTP status text when error body is missing.

Manual verification:

- Default import grep returns no matches: `rg "^import\\s+[A-Za-z_$][\\w$]*\\s*(,\\s*\\{[^}]*\\})?\\s+from\\s+[\"'](@/api/client|\\.\\.?/.*api/client)[\"']" src`

## Deviations From Issue Plan

None.

## Follow-Up Work

None.