### PR TITLE
refactor(backend): centralize shared VLM failure constants under base_client

### DIFF
--- a/backend/app/infrastructure/vlm/__init__.py
+++ b/backend/app/infrastructure/vlm/__init__.py
@@ -1,12 +1,14 @@
 """VLM infrastructure namespace."""
 
-from app.infrastructure.vlm.client import (
+from app.infrastructure.vlm.base_client import (
     FAILURE_CODE_INVALID_RESPONSE,
     FAILURE_CODE_NETWORK,
     FAILURE_CODE_PROVIDER,
     FAILURE_CODE_PROVIDER_REJECTED,
-    FAILURE_CODE_STALE_PREVIEW,
     FAILURE_CODE_TIMEOUT,
+)
+from app.infrastructure.vlm.client import (
+    FAILURE_CODE_STALE_PREVIEW,
     ExtractionResult,
     GradingResult,
     VLMClient,

--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -9,7 +9,14 @@ from typing import Any, Literal
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
-from app.infrastructure.vlm.base_client import BaseVLMClient
+from app.infrastructure.vlm.base_client import (
+    FAILURE_CODE_INVALID_RESPONSE,
+    FAILURE_CODE_NETWORK,
+    FAILURE_CODE_PROVIDER,
+    FAILURE_CODE_PROVIDER_REJECTED,
+    FAILURE_CODE_TIMEOUT,
+    BaseVLMClient,
+)
 from app.infrastructure.vlm._models import (
     _ChatCompletionRequest,
     _ChatMessage,
@@ -28,11 +35,6 @@ from app.infrastructure.vlm.prompts import (
 
 ProblemType = Literal["single-choice", "multi-choice", "fill-in-the-blank", "short-answer"]
 
-FAILURE_CODE_TIMEOUT = "vlm-timeout"
-FAILURE_CODE_NETWORK = "vlm-network-error"
-FAILURE_CODE_PROVIDER = "vlm-provider-error"
-FAILURE_CODE_PROVIDER_REJECTED = "vlm-provider-rejected"
-FAILURE_CODE_INVALID_RESPONSE = "vlm-invalid-response"
 FAILURE_CODE_STALE_PREVIEW = "vlm-stale-preview-timeout"
 
 

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -8,20 +8,21 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from app.infrastructure.config.settings import Settings, get_settings
-from app.infrastructure.vlm.base_client import BaseVLMClient
+from app.infrastructure.vlm.base_client import (
+    FAILURE_CODE_INVALID_RESPONSE,
+    FAILURE_CODE_NETWORK,
+    FAILURE_CODE_PROVIDER,
+    FAILURE_CODE_PROVIDER_REJECTED,
+    FAILURE_CODE_TIMEOUT,
+    BaseVLMClient,
+)
 from app.infrastructure.vlm._models import (
     _ChatCompletionRequest,
     _ChatMessage,
     _ChatMessageContentImageUrl,
     _ChatMessageContentText,
 )
-from app.infrastructure.vlm.client import (
-    FAILURE_CODE_INVALID_RESPONSE,
-    FAILURE_CODE_NETWORK,
-    FAILURE_CODE_PROVIDER,
-    FAILURE_CODE_PROVIDER_REJECTED,
-    FAILURE_CODE_TIMEOUT,
-)
+
 from app.infrastructure.vlm.solution_coaching_prompts import (
     ENGLISH_COACHING_SYSTEM_PROMPT,
     ENGLISH_SOLUTION_SYSTEM_PROMPT,


### PR DESCRIPTION
## Summary

- Move shared VLM failure constants from `client.py` to `base_client.py` imports.
- Update `solution_coaching_client.py` to import failure constants from `base_client.py` instead of `client.py`.
- Update `__init__.py` to re-export shared constants from `base_client.py`.

## Linked Issue

Closes #275

## Issue Alignment

This PR implements the issue by:

- Centralizing shared failure constants under the shared VLM infrastructure module (`base_client.py`).
- Removing the solution/coaching dependency on `client.py` for failure constants.
- Keeping ingestion/grading-specific `FAILURE_CODE_STALE_PREVIEW` in `client.py`.
- Preserving parser semantics and public error independence.

Scope covered:

- Move shared VLM failure constants to base_client.py.
- Update consumers to import from the shared module.
- Preserve public error class independence (`VLMError` vs `SolutionCoachingVLMError`).

Out of scope / intentionally not included:

- Merging `VLMError` and `SolutionCoachingVLMError`.
- Normalizing parser behavior between ingestion/grading and solution/coaching.
- Domain placement of factories.
- Broad VLM client rewrites.

## Implementation Notes

- Shared failure constants were already defined in `base_client.py` (lines 7-11). This PR removes the duplicate definitions from `client.py` and has both `client.py` and `solution_coaching_client.py` import from `base_client.py`.
- The `_ChatCompletionResponse` models differ between client.py (no reasoning_content) and solution_coaching_client.py (with reasoning_content), so they are NOT truly shared and remain separate.
- Parser behavior is preserved: each client retains its own parsing logic.

## Tests

Commands run:

- `cd backend && uv run pytest tests/infrastructure/test_vlm.py tests/infrastructure/test_base_vlm_client.py tests/infrastructure/test_vlm_error_independence.py tests/infrastructure/test_solution_coaching_client.py -v` — passed (84 tests)
- `cd backend && uv run pytest` — passed (472 passed, 1 skipped)

Automated tests added or updated:

- None needed; existing tests cover all affected behavior including error independence.

Manual verification:

- Verified `solution_coaching_client.py` no longer imports from `client.py`: `grep -rn "from app.infrastructure.vlm.client import" backend/app/` shows no solution/coaching imports from client.py.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.