### PR TITLE
feat(frontend): add Docker Compose Playwright smoke validation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -162,6 +162,24 @@ Frontend browser tests:
 cd frontend && npm run test:ui
 ```
 
+Docker Compose smoke validation tests (requires running Compose stack):
+
+```bash
+# Start the full stack in Docker Compose
+docker compose up -d mongodb rustfs app frontend
+docker compose --profile bootstrap run --rm rustfs-bootstrap
+
+# Wait for health checks to pass
+curl -fsS http://127.0.0.1:8000/api/health
+curl -fsS http://127.0.0.1:8080/healthz
+
+# Run the Compose smoke browser test suite
+cd frontend && npm run test:smoke:compose
+
+# Tear down the stack when finished
+docker compose down
+```
+
 ## Environment variable reference
 
 The canonical template lives in `.env.example`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "test": "vitest",
     "test:ui": "playwright test",
+    "test:smoke:compose": "playwright test --config=playwright.compose.config.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/frontend/playwright.compose.config.ts
+++ b/frontend/playwright.compose.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+// Target the Compose-served API gateway on port 8000
+process.env.PLAYWRIGHT_API_ORIGIN = "http://127.0.0.1:8000";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "compose-smoke.spec.ts",
+  use: {
+    baseURL: "http://127.0.0.1:8080",
+    headless: true,
+  },
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -4,6 +4,7 @@ process.env.PLAYWRIGHT_API_ORIGIN ??= "http://127.0.0.1:18000";
 
 export default defineConfig({
   testDir: "./tests",
+  testIgnore: ["**/compose-smoke.spec.ts"],
   use: {
     baseURL: "http://127.0.0.1:5173",
     headless: true,

--- a/frontend/tests/compose-smoke.spec.ts
+++ b/frontend/tests/compose-smoke.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Docker Compose Smoke Validation", () => {
+  test("backend health check responds with 200 OK and status ok", async ({ request }) => {
+    const apiOrigin = process.env.PLAYWRIGHT_API_ORIGIN || "http://127.0.0.1:8000";
+    
+    // Check both standard health check paths for robustness
+    let response = await request.get(`${apiOrigin}/api/v1/health`);
+    if (!response.ok()) {
+      response = await request.get(`${apiOrigin}/api/health`);
+    }
+    
+    expect(response.status()).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+  });
+
+  test("frontend healthz endpoint responds with 200 OK", async ({ request }) => {
+    // The frontend healthz route should respond with 200 OK.
+    // In playwright.compose.config.ts, baseURL is set to http://127.0.0.1:8080
+    const response = await request.get("/healthz");
+    expect(response.status()).toBe(200);
+  });
+
+  test("minimal browser smoke flow: loading the login page and navigating to register", async ({ page }) => {
+    // Navigate to the root URL of the running frontend
+    await page.goto("/");
+
+    // We should be redirected to the login page (or it should be loaded directly)
+    // Check for the Login heading
+    const loginHeading = page.getByRole("heading", { name: "Login" });
+    await expect(loginHeading).toBeVisible();
+
+    // Verify the presence of unauthenticated login fields
+    const usernameInput = page.locator("#username");
+    const passwordInput = page.locator("#password");
+    await expect(usernameInput).toBeVisible();
+    await expect(passwordInput).toBeVisible();
+
+    // Confirm that navigating to the registration page works
+    const registerLink = page.getByRole("link", { name: "Register" });
+    await expect(registerLink).toBeVisible();
+    await registerLink.click();
+
+    // Ensure we reach the registration page and it displays the Register heading
+    const registerHeading = page.getByRole("heading", { name: "Register" });
+    await expect(registerHeading).toBeVisible();
+    await expect(page).toHaveURL(/\/register/);
+  });
+});


### PR DESCRIPTION
## Summary

- Add an opt-in Playwright browser smoke validation configuration and test suite targeting the running Docker Compose stack.
- Document startup, bootstrapping, health validation, smoke test execution, and shutdown commands in `DEVELOPMENT.md`.

## Linked Issue

Closes #276

## Issue Alignment

This PR implements the issue by:

- Adding `frontend/playwright.compose.config.ts` configured for the Compose-served frontend at `http://127.0.0.1:8080` and backend at `http://127.0.0.1:8000`.
- Adding `frontend/tests/compose-smoke.spec.ts` to verify backend health, frontend `/healthz` health, and a minimal unauthenticated browser login-to-register navigation flow.
- Introducing the `test:smoke:compose` npm script in `frontend/package.json`.
- Adding runbook instructions for Docker Compose smoke validation in `DEVELOPMENT.md`.

Scope covered:

- Compose smoke config and test spec.
- Script definition and documentation.
- Independence of existing Playwright tests from Docker.

Out of scope / intentionally not included:

- Replacing `npm run test:ui`.
- Requiring Docker for normal local dev frontend tests.
- Comprehensive E2E expansion.

## Implementation Notes

- `playwright.compose.config.ts` omits the `webServer` block so it depends entirely on the pre-running Compose services on ports `8080` and `8000`.
- `compose-smoke.spec.ts` only runs when using the compose smoke configuration (`testMatch` is set to `compose-smoke.spec.ts`).

## Tests

Commands run:

- `cd frontend && npm run test:smoke:compose` — passed (3 passed)
- `cd frontend && npm run test:ui` — 41 passed, 7 failed (note: theme.spec.ts and practice.spec.ts failures are pre-existing on master and unrelated to this PR)

Automated tests added or updated:

- `frontend/tests/compose-smoke.spec.ts` (3 tests covering backend health, frontend health, and minimal browser flow).

Manual verification:

- Bootstrapped and started Compose stack:
  ```bash
  docker compose up -d mongodb rustfs
  docker compose --profile bootstrap run --rm rustfs-bootstrap
  docker compose up -d app frontend
  ```
- Validated health endpoints:
  ```bash
  curl -fsS http://127.0.0.1:8000/api/health
  # Responded with {"status":"ok"}
  curl -fsS http://127.0.0.1:8080/healthz
  # Responded with ok
  ```
- Executed Playwright Compose smoke tests:
  ```bash
  cd frontend && npm run test:smoke:compose
  # 3 passed
  ```
- Stopped Compose:
  ```bash
  docker compose down
  ```

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
