### PR TITLE
Unify practice and exam problem selection with dynamic scoring

### DIFF
--- a/backend/app/domain/practice_selection.py
+++ b/backend/app/domain/practice_selection.py
@@ -4,7 +4,14 @@ from datetime import UTC, datetime, timedelta
 from typing import List, Optional
 
 from .models import Problem
-from .selection import ensure_utc
+from .selection import (
+    ProblemSelectionConfig,
+    ScoreBreakdown,
+    compute_score_breakdown,
+    ensure_utc,
+    get_eligible_problems,
+    select_problems as _select_problems,
+)
 
 
 @dataclass
@@ -14,6 +21,15 @@ class PracticeSelectionConfig:
     failure_rate_weight: float = 1.0
     recency_weight: float = 1.0
     min_problem_age_days: int = 3
+
+    def to_shared_config(self) -> ProblemSelectionConfig:
+        return ProblemSelectionConfig(
+            cooldown_days=self.cooldown_days,
+            last_wrong_weight=self.last_wrong_weight,
+            failure_rate_weight=self.failure_rate_weight,
+            recency_weight=self.recency_weight,
+            min_problem_age_days=self.min_problem_age_days,
+        )
 
 
 @dataclass
@@ -35,24 +51,19 @@ def get_eligible_practice_problems(
     config: PracticeSelectionConfig,
     now: datetime,
 ) -> list[Problem]:
-    eligible = []
-    for p in problems:
-        if p.isDeleted:
-            continue
-        if not p.correctAnswer or not p.correctAnswer.normalizedText:
-            continue
-        if config.min_problem_age_days > 0:
-            created_at = ensure_utc(p.createdAt)
-            age_cutoff = now - timedelta(days=config.min_problem_age_days)
-            if created_at > age_cutoff:
-                continue
-        if p.tracking.lastTestedAt:
-            last_tested = ensure_utc(p.tracking.lastTestedAt)
-            cutoff = now - timedelta(days=config.cooldown_days)
-            if last_tested > cutoff:
-                continue
-        eligible.append(p)
-    return eligible
+    return get_eligible_problems(problems, config.to_shared_config(), now)
+
+
+def compute_problem_weight_breakdown(
+    problem: Problem, config: PracticeSelectionConfig, now: datetime
+) -> PracticeWeightBreakdown:
+    shared = compute_score_breakdown(problem, config.to_shared_config(), now)
+    return PracticeWeightBreakdown(
+        lastWrong=shared.last_wrong,
+        failure=shared.failure,
+        recency=shared.recency,
+        total=shared.total,
+    )
 
 
 def _has_practiceable_answer(problems: List[Problem]) -> list[Problem]:
@@ -75,55 +86,12 @@ def select_practice_problem(
             return PracticeSelectionResult(None, "no_eligible")
         return PracticeSelectionResult(None, "no_problems")
 
-    weighted = []
-    for problem in eligible:
-        weight = _compute_problem_weight(problem, config, now)
-        weighted.append((problem, weight))
+    selected = _select_problems(problems, 1, config.to_shared_config(), now, rng=rng)
 
-    total = sum(w for _, w in weighted)
-    if total <= 0:
-        selected = (rng or random).choice(eligible)
-    else:
-        r = (rng or random).random() * total
-        cumulative = 0.0
-        selected = eligible[0]
-        for problem, weight in weighted:
-            cumulative += weight
-            if r <= cumulative:
-                selected = problem
-                break
+    if not selected:
+        return PracticeSelectionResult(None, "no_eligible")
 
-    return PracticeSelectionResult(selected, "ok")
-
-
-def compute_problem_weight_breakdown(
-    problem: Problem, config: PracticeSelectionConfig, now: datetime
-) -> PracticeWeightBreakdown:
-    last_wrong_score = 1.0
-    if problem.tracking.lastAttemptCorrect is False:
-        last_wrong_score = 2.0
-
-    failure_score = 1.0
-    attempt_count = problem.tracking.correctCount + problem.tracking.failedCount
-    if attempt_count > 0:
-        failure_rate = problem.tracking.failedCount / attempt_count
-        failure_score = 1.0 + failure_rate
-
-    recency_score = 1.0
-    if problem.tracking.lastTestedAt:
-        days_since = (now - ensure_utc(problem.tracking.lastTestedAt)).days
-        recency_score = 1.0 + days_since / 30.0
-
-    last_wrong = last_wrong_score * config.last_wrong_weight
-    failure = failure_score * config.failure_rate_weight
-    recency = recency_score * config.recency_weight
-
-    return PracticeWeightBreakdown(
-        lastWrong=last_wrong,
-        failure=failure,
-        recency=recency,
-        total=last_wrong + failure + recency,
-    )
+    return PracticeSelectionResult(selected[0], "ok")
 
 
 def _compute_problem_weight(problem: Problem, config: PracticeSelectionConfig, now: datetime) -> float:

--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -1,7 +1,9 @@
-from datetime import UTC, datetime, timedelta, timezone
-from typing import List
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import List, Optional
 import random
-from .models import Problem, SelectionPolicyConfig
+
+from .models import Problem
 
 
 def ensure_utc(dt: datetime) -> datetime:
@@ -10,54 +12,139 @@ def ensure_utc(dt: datetime) -> datetime:
     return dt.astimezone(UTC)
 
 
-def select_problems(
+@dataclass
+class ProblemSelectionConfig:
+    cooldown_days: int = 7
+    last_wrong_weight: float = 1.0
+    failure_rate_weight: float = 1.0
+    recency_weight: float = 1.0
+    min_problem_age_days: int = 3
+
+
+@dataclass
+class ScoreBreakdown:
+    recency: float
+    failure: float
+    last_wrong: float
+    total: float
+
+
+def get_eligible_problems(
     problems: List[Problem],
-    count: int,
-    config: SelectionPolicyConfig,
-    rng: random.Random | None = None
-) -> List[Problem]:
-    now = datetime.now(timezone.utc)
+    config: ProblemSelectionConfig,
+    now: datetime,
+) -> list[Problem]:
     eligible = []
     for p in problems:
         if p.isDeleted:
             continue
-        if config.minProblemAgeDays > 0:
+        if not p.correctAnswer or not p.correctAnswer.normalizedText:
+            continue
+        if config.min_problem_age_days > 0:
             created_at = ensure_utc(p.createdAt)
-            age_cutoff = now - timedelta(days=config.minProblemAgeDays)
+            age_cutoff = now - timedelta(days=config.min_problem_age_days)
             if created_at > age_cutoff:
                 continue
+        if p.tracking.lastTestedAt:
+            last_tested = ensure_utc(p.tracking.lastTestedAt)
+            cutoff = now - timedelta(days=config.cooldown_days)
+            if last_tested > cutoff:
+                continue
         eligible.append(p)
+    return eligible
+
+
+def compute_score_breakdown(
+    problem: Problem,
+    config: ProblemSelectionConfig,
+    now: datetime,
+) -> ScoreBreakdown:
+    # Recency score
+    last_dt = problem.tracking.lastTestedAt or problem.createdAt
+    if last_dt is not None:
+        days_since = (now - ensure_utc(last_dt)).days
+        recency_score = 1.0 + days_since / 30.0
+    else:
+        recency_score = 1.0
+
+    # Failure score
+    attempt_count = problem.tracking.correctCount + problem.tracking.failedCount
+    if attempt_count == 0:
+        failure_score = 1.0
+    else:
+        failure_rate = problem.tracking.failedCount / attempt_count
+        failure_score = 1.0 + (failure_rate - 0.5) / 0.5
+
+    # Last wrong score
+    if problem.tracking.lastTestedAt is None:
+        last_wrong_score = 1.0
+    elif problem.tracking.lastAttemptCorrect is True:
+        last_wrong_score = 0.5
+    elif problem.tracking.lastAttemptCorrect is False:
+        last_wrong_score = 2.0
+    else:
+        last_wrong_score = 1.0
+
+    recency = recency_score * config.recency_weight
+    failure = failure_score * config.failure_rate_weight
+    last_wrong = last_wrong_score * config.last_wrong_weight
+
+    return ScoreBreakdown(
+        recency=recency,
+        failure=failure,
+        last_wrong=last_wrong,
+        total=recency + failure + last_wrong,
+    )
+
+
+def _weighted_sample_without_replacement(
+    candidates: list[tuple[Problem, float]],
+    count: int,
+    rng: random.Random,
+) -> list[Problem]:
+    """Select up to `count` unique problems using weighted random sampling."""
+    selected: list[Problem] = []
+    remaining = list(candidates)
+
+    while len(selected) < count and remaining:
+        total_weight = sum(weight for _, weight in remaining)
+        if total_weight <= 0:
+            # Uniform fallback when all weights are zero
+            chosen_idx = rng.randrange(len(remaining))
+        else:
+            r = rng.random() * total_weight
+            cumulative = 0.0
+            chosen_idx = 0
+            for idx, (_, weight) in enumerate(remaining):
+                cumulative += weight
+                if r <= cumulative:
+                    chosen_idx = idx
+                    break
+
+        problem, _ = remaining.pop(chosen_idx)
+        selected.append(problem)
+
+    return selected
+
+
+def select_problems(
+    problems: List[Problem],
+    count: int,
+    config: ProblemSelectionConfig,
+    now: datetime,
+    rng: random.Random | None = None,
+) -> list[Problem]:
+    eligible = get_eligible_problems(problems, config, now)
 
     if not eligible:
         return []
 
     weighted = []
-
     for problem in eligible:
-        recency_score = 1.0
-        if problem.tracking.lastTestedAt:
-            days_since = (now - ensure_utc(problem.tracking.lastTestedAt)).days
-            recency_score = min(1.0 + days_since / 30.0, 3.0)
+        breakdown = compute_score_breakdown(problem, config, now)
+        weighted.append((problem, breakdown.total))
 
-        failure_score = 1.0
-        if problem.tracking.exposureCount > 0:
-            failure_rate = problem.tracking.failedCount / problem.tracking.exposureCount
-            failure_score = 1.0 + failure_rate * 2.0
-
-        total_weight = (
-            recency_score * config.recencyWeight +
-            failure_score * config.failureWeight
-        )
-
-        weighted.append((problem, total_weight))
-
-    weighted.sort(key=lambda x: x[1], reverse=True)
-    top_candidates = [p for p, _ in weighted[:count * 2]]
-
-    sample_size = min(count, len(top_candidates))
     if rng is None:
-        selected = random.sample(top_candidates, sample_size)
-    else:
-        selected = rng.sample(top_candidates, sample_size)
+        rng = random.Random()
 
-    return selected
+    return _weighted_sample_without_replacement(weighted, count, rng)

--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -93,7 +93,7 @@ def compute_score_breakdown(
         recency=recency,
         failure=failure,
         last_wrong=last_wrong,
-        total=recency + failure + last_wrong,
+        total=last_wrong + failure + recency,
     )
 
 

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -9,7 +9,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Depends, Query
 
 from app.domain.models import ExamState, GradingStatus, ProblemType, SelectionPolicyConfig
-from app.domain.selection import select_problems
+from app.domain.selection import ProblemSelectionConfig, select_problems
 from app.domain.state import transition_exam_state
 from app.infrastructure.config.settings import Settings, get_settings
 from app.infrastructure.storage.mongo import Document, MongoClientAdapter, get_mongo_adapter
@@ -71,6 +71,13 @@ async def create_exam(
     settings: SettingsDependency,
 ) -> CreateExamResponse:
     query = {"userId": current_user["_id"], "state": ExamState.IN_PROGRESS.value}
+    selection_config = ProblemSelectionConfig(
+        cooldown_days=settings.practice_cooldown_days,
+        last_wrong_weight=settings.practice_last_wrong_weight,
+        failure_rate_weight=settings.practice_failure_rate_weight,
+        recency_weight=settings.practice_recency_weight,
+        min_problem_age_days=settings.problem_selection_min_age_days,
+    )
     selection_policy = SelectionPolicyConfig(
         recencyWeight=1.0,
         failureWeight=1.0,
@@ -95,10 +102,12 @@ async def create_exam(
         if not eligible_documents:
             raise ApiError(422, "NO_ELIGIBLE_PROBLEMS", "No eligible problems available")
 
+        now = datetime.now(UTC)
         selected_models = select_problems(
             [problem_document_to_model(problem) for problem in eligible_documents],
             payload.maxProblemCount,
-            selection_policy,
+            selection_config,
+            now=now,
             rng=Random(),
         )
         if not selected_models:
@@ -111,7 +120,6 @@ async def create_exam(
             if problem.id is not None and problem.id in document_by_id
         ]
 
-        now = datetime.now(UTC)
         items = [
             make_exam_item(problem, order=index)
             for index, problem in enumerate(selected_documents, start=1)

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -235,7 +235,7 @@ def test_failure_rate_uses_attempts_not_exposures():
         _make_problem("many-exposures-no-attempts", exposure_count=100, correct_count=0, failed_count=0),
         _make_problem("some-failed-attempts", exposure_count=5, correct_count=1, failed_count=4),
     ]
-    config = PracticeSelectionConfig()
+    config = PracticeSelectionConfig(failure_rate_weight=2.0)
     rng = random.Random(42)
 
     failed_count = 0
@@ -397,40 +397,42 @@ def test_compute_problem_weight_breakdown_all_components():
     # lastWrong = 2.0 * 1.5 = 3.0
     assert breakdown.lastWrong == 3.0
 
-    # failure_rate = 5 / 10 = 0.5, failure_score = 1.5
-    # failure = 1.5 * 2.0 = 3.0
-    assert breakdown.failure == 3.0
+    # failure_rate = 5 / 10 = 0.5, failure_score = 1.0 + (0.5 - 0.5)/0.5 = 1.0
+    # failure = 1.0 * 2.0 = 2.0
+    assert breakdown.failure == 2.0
 
     # days_since = 30, recency_score = 1.0 + 30/30 = 2.0
     # recency = 2.0 * 1.0 = 2.0
     assert breakdown.recency == 2.0
 
-    assert breakdown.total == 8.0
+    assert breakdown.total == 7.0
     assert breakdown.total == breakdown.lastWrong + breakdown.failure + breakdown.recency
 
 
 def test_compute_problem_weight_breakdown_never_tested():
     now = datetime.now(UTC)
-    problem = _make_problem("p1", last_tested_at=None, last_attempt_correct=None)
+    problem = _make_problem("p1", last_tested_at=None, last_attempt_correct=None, created_at=now - timedelta(days=30))
     config = PracticeSelectionConfig()
     breakdown = compute_problem_weight_breakdown(problem, config, now)
 
     assert breakdown.lastWrong == 1.0
     assert breakdown.failure == 1.0
-    assert breakdown.recency == 1.0
-    assert breakdown.total == 3.0
+    # Recency falls back to createdAt (30 days ago): score = 1.0 + 30/30 = 2.0
+    assert breakdown.recency == 2.0
+    assert breakdown.total == 4.0
 
 
 def test_compute_problem_weight_breakdown_zero_attempts():
     now = datetime.now(UTC)
-    problem = _make_problem("p1", exposure_count=0, correct_count=0, failed_count=0)
+    problem = _make_problem("p1", exposure_count=0, correct_count=0, failed_count=0, created_at=now - timedelta(days=30))
     config = PracticeSelectionConfig()
     breakdown = compute_problem_weight_breakdown(problem, config, now)
 
     assert breakdown.lastWrong == 1.0
     assert breakdown.failure == 1.0
-    assert breakdown.recency == 1.0
-    assert breakdown.total == 3.0
+    # Recency falls back to createdAt (30 days ago): score = 1.0 + 30/30 = 2.0
+    assert breakdown.recency == 2.0
+    assert breakdown.total == 4.0
 
 
 def test_compute_problem_weight_breakdown_uses_same_total_as_selection():

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -3,7 +3,13 @@ from app.domain import (
     Problem,
     CorrectAnswer,
     ProblemType,
-    SelectionPolicyConfig,
+)
+from app.domain.selection import (
+    ProblemSelectionConfig,
+    ScoreBreakdown,
+    compute_score_breakdown,
+    ensure_utc,
+    get_eligible_problems,
     select_problems,
 )
 
@@ -11,19 +17,25 @@ from app.domain import (
 def create_test_problem(
     problem_id: str,
     is_deleted: bool = False,
-    last_tested_days_ago: int | None = None,
+    last_tested_at: datetime | None = None,
     failed_count: int = 0,
     exposure_count: int = 1,
+    correct_count: int | None = None,
     created_at: datetime | None = None,
+    last_attempt_correct: bool | None = None,
 ) -> Problem:
     from app.domain import Tracking
+    cc = correct_count if correct_count is not None else max(0, exposure_count - failed_count)
     tracking = Tracking(
         exposureCount=exposure_count,
+        correctCount=cc,
         failedCount=failed_count,
     )
-    if last_tested_days_ago is not None:
-        tracking.lastTestedAt = datetime.now(timezone.utc) - timedelta(days=last_tested_days_ago)
-    
+    if last_tested_at is not None:
+        tracking.lastTestedAt = last_tested_at
+    if last_attempt_correct is not None:
+        tracking.lastAttemptCorrect = last_attempt_correct
+
     return Problem(
         id=problem_id,
         userId="u1",
@@ -41,36 +53,26 @@ def test_exclude_deleted_problems():
         create_test_problem("1", is_deleted=False),
         create_test_problem("2", is_deleted=True),
     ]
-    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0)
-    selected = select_problems(problems, 2, config)
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0)
+    now = datetime.now(timezone.utc)
+    selected = select_problems(problems, 2, config, now=now)
     assert len(selected) == 1
     assert selected[0].id == "1"
 
 
-def test_selects_top_weighted():
-    # Let's test the weighting logic without relying on random sampling
-    from app.domain.selection import select_problems as original_select
+def test_selects_weighted_without_replacement():
+    now = datetime.now(timezone.utc)
+    problems = [
+        create_test_problem("1", last_tested_at=now - timedelta(days=10), failed_count=0),
+        create_test_problem("2", last_tested_at=now - timedelta(days=30), failed_count=0),
+        create_test_problem("3", last_tested_at=now - timedelta(days=10), failed_count=2, exposure_count=2),
+    ]
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0, cooldown_days=0)
     import random
-    # Temporarily replace random.sample to return first N elements
-    def mock_sample(pop, k):
-        return pop[:k]
-    
-    original_random_sample = random.sample
-    try:
-        random.sample = mock_sample
-        problems = [
-            create_test_problem("1", last_tested_days_ago=1, failed_count=0),
-            create_test_problem("2", last_tested_days_ago=30, failed_count=0),
-            create_test_problem("3", last_tested_days_ago=1, failed_count=2, exposure_count=2),
-        ]
-        config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0)
-        selected = select_problems(problems, 2, config)
-        assert len(selected) == 2
-        selected_ids = [p.id for p in selected]
-        # Verify top 2 weighted are 3 then 2 (since they have higher weights)
-        assert selected_ids == ["3", "2"]
-    finally:
-        random.sample = original_random_sample
+    rng = random.Random(42)
+    selected = select_problems(problems, 2, config, now=now, rng=rng)
+    assert len(selected) == 2
+    assert len({p.id for p in selected}) == 2
 
 
 def test_min_age_excludes_too_new():
@@ -81,8 +83,8 @@ def test_min_age_excludes_too_new():
         create_test_problem("new", created_at=too_new),
         create_test_problem("old", created_at=old_enough),
     ]
-    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=3)
-    selected = select_problems(problems, 2, config)
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0, min_problem_age_days=3)
+    selected = select_problems(problems, 2, config, now=now)
 
     assert len(selected) == 1
     assert selected[0].id == "old"
@@ -92,8 +94,8 @@ def test_min_age_boundary_at_threshold():
     now = datetime.now(timezone.utc)
     exactly_at = now - timedelta(days=3)
     problems = [create_test_problem("boundary", created_at=exactly_at)]
-    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=3)
-    selected = select_problems(problems, 1, config)
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0, min_problem_age_days=3)
+    selected = select_problems(problems, 1, config, now=now)
 
     assert len(selected) == 1
     assert selected[0].id == "boundary"
@@ -103,8 +105,8 @@ def test_min_age_zero_allows_immediate():
     now = datetime.now(timezone.utc)
     just_created = now - timedelta(seconds=10)
     problems = [create_test_problem("fresh", created_at=just_created)]
-    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=0)
-    selected = select_problems(problems, 1, config)
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0, min_problem_age_days=0)
+    selected = select_problems(problems, 1, config, now=now)
 
     assert len(selected) == 1
     assert selected[0].id == "fresh"
@@ -117,12 +119,217 @@ def test_min_age_all_too_new_returns_empty():
         create_test_problem("a", created_at=too_new),
         create_test_problem("b", created_at=too_new),
     ]
-    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0, minProblemAgeDays=3)
-    selected = select_problems(problems, 2, config)
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0, min_problem_age_days=3)
+    selected = select_problems(problems, 2, config, now=now)
 
     assert selected == []
 
 
 def test_min_age_default_value():
-    config = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0)
-    assert config.minProblemAgeDays == 3
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0)
+    assert config.min_problem_age_days == 3
+
+
+def test_recency_uses_last_tested_when_present():
+    now = datetime.now(timezone.utc)
+    last_tested = now - timedelta(days=60)
+    problem = create_test_problem("p1", last_tested_at=last_tested)
+    config = ProblemSelectionConfig(recency_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    # days_since = 60, recency_score = 1.0 + 60/30 = 3.0
+    assert breakdown.recency == 3.0
+
+
+def test_recency_uses_created_at_when_not_tested():
+    now = datetime.now(timezone.utc)
+    created_at = now - timedelta(days=45)
+    problem = create_test_problem("p1", last_tested_at=None, created_at=created_at)
+    config = ProblemSelectionConfig(recency_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    # days_since = 45, recency_score = 1.0 + 45/30 = 2.5
+    assert breakdown.recency == 2.5
+
+
+def test_failure_score_zero_percent():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=10, failed_count=0, correct_count=10)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    # failure_rate = 0/10 = 0, failure_score = 1.0 + (0 - 0.5)/0.5 = 0.0
+    assert breakdown.failure == 0.0
+
+
+def test_failure_score_fifty_percent():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=10, failed_count=5, correct_count=5)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    # failure_rate = 5/10 = 0.5, failure_score = 1.0 + (0.5 - 0.5)/0.5 = 1.0
+    assert breakdown.failure == 1.0
+
+
+def test_failure_score_hundred_percent():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=10, failed_count=10, correct_count=0)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    # failure_rate = 10/10 = 1.0, failure_score = 1.0 + (1.0 - 0.5)/0.5 = 2.0
+    assert breakdown.failure == 2.0
+
+
+def test_failure_score_no_attempts():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=0, failed_count=0, correct_count=0)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 1.0
+
+
+def test_last_wrong_never_tested():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", last_tested_at=None)
+    config = ProblemSelectionConfig(last_wrong_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.last_wrong == 1.0
+
+
+def test_last_wrong_correct():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", last_tested_at=now - timedelta(days=1), last_attempt_correct=True)
+    config = ProblemSelectionConfig(last_wrong_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.last_wrong == 0.5
+
+
+def test_last_wrong_wrong():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", last_tested_at=now - timedelta(days=1), last_attempt_correct=False)
+    config = ProblemSelectionConfig(last_wrong_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.last_wrong == 2.0
+
+
+def test_last_wrong_tested_unknown():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", last_tested_at=now - timedelta(days=1), last_attempt_correct=None)
+    config = ProblemSelectionConfig(last_wrong_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.last_wrong == 1.0
+
+
+def test_weighted_total_equals_component_sum():
+    now = datetime.now(timezone.utc)
+    last_tested = now - timedelta(days=30)
+    problem = create_test_problem(
+        "p1",
+        last_tested_at=last_tested,
+        last_attempt_correct=False,
+        exposure_count=10,
+        failed_count=5,
+        correct_count=5,
+    )
+    config = ProblemSelectionConfig(
+        recency_weight=1.0,
+        failure_rate_weight=2.0,
+        last_wrong_weight=1.5,
+    )
+    breakdown = compute_score_breakdown(problem, config, now)
+    # recency_score = 1.0 + 30/30 = 2.0, recency = 2.0 * 1.0 = 2.0
+    assert breakdown.recency == 2.0
+    # failure_rate = 5/10 = 0.5, failure_score = 1.0 + (0.5 - 0.5)/0.5 = 1.0, failure = 1.0 * 2.0 = 2.0
+    assert breakdown.failure == 2.0
+    # last_wrong_score = 2.0, last_wrong = 2.0 * 1.5 = 3.0
+    assert breakdown.last_wrong == 3.0
+    assert breakdown.total == 7.0
+    assert breakdown.total == breakdown.recency + breakdown.failure + breakdown.last_wrong
+
+
+def test_cooldown_excludes_recent():
+    now = datetime.now(timezone.utc)
+    problems = [
+        create_test_problem("recent", last_tested_at=now - timedelta(days=2)),
+        create_test_problem("old", last_tested_at=now - timedelta(days=10)),
+    ]
+    config = ProblemSelectionConfig(cooldown_days=7)
+    eligible = get_eligible_problems(problems, config, now)
+    ids = [p.id for p in eligible]
+    assert "old" in ids
+    assert "recent" not in ids
+
+
+def test_zero_total_weights_fallback_uniform():
+    now = datetime.now(timezone.utc)
+    problems = [
+        create_test_problem("a"),
+        create_test_problem("b"),
+    ]
+    config = ProblemSelectionConfig(
+        recency_weight=0.0,
+        failure_rate_weight=0.0,
+        last_wrong_weight=0.0,
+    )
+    import random
+    rng = random.Random(42)
+    selected = select_problems(problems, 1, config, now=now, rng=rng)
+    assert len(selected) == 1
+    assert selected[0].id in ("a", "b")
+
+
+def test_multi_selection_no_duplicates():
+    now = datetime.now(timezone.utc)
+    problems = [
+        create_test_problem("a"),
+        create_test_problem("b"),
+        create_test_problem("c"),
+    ]
+    config = ProblemSelectionConfig()
+    import random
+    rng = random.Random(42)
+    selected = select_problems(problems, 3, config, now=now, rng=rng)
+    assert len(selected) == 3
+    assert len({p.id for p in selected}) == 3
+
+
+def test_smaller_exam_when_fewer_eligible():
+    now = datetime.now(timezone.utc)
+    problems = [
+        create_test_problem("a"),
+        create_test_problem("b"),
+    ]
+    config = ProblemSelectionConfig()
+    import random
+    rng = random.Random(42)
+    selected = select_problems(problems, 5, config, now=now, rng=rng)
+    assert len(selected) == 2
+
+
+def test_eligibility_excludes_unanswerable():
+    now = datetime.now(timezone.utc)
+    from app.domain import Tracking
+    problem = Problem(
+        id="no-answer",
+        userId="u1",
+        text="test",
+        problemType=ProblemType.SINGLE_CHOICE,
+        correctAnswer=CorrectAnswer(display="", normalizedText="", normalizedSet=[], format="single"),
+        tracking=Tracking(),
+        createdAt=now - timedelta(days=30),
+    )
+    config = ProblemSelectionConfig()
+    eligible = get_eligible_problems([problem], config, now)
+    assert eligible == []
+
+
+def test_ensure_utc_naive():
+    naive = datetime(2024, 1, 1, 12, 0, 0)
+    result = ensure_utc(naive)
+    assert result.tzinfo is not None
+    assert result.hour == 12
+
+
+def test_ensure_utc_aware():
+    from datetime import timezone
+    aware = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    result = ensure_utc(aware)
+    assert result.tzinfo is not None
+    assert result.hour == 12


### PR DESCRIPTION
## Summary

Replace separate practice and exam problem-selection implementations with one shared, purely functional domain engine, and implement the revised recency, failure-rate, and last-wrong scoring policies.

## Linked Issue

Closes #288

## Issue Alignment

This PR implements the issue by:

- Creating a single authoritative `ProblemSelectionConfig`, `ScoreBreakdown`, and `select_problems` in `backend/app/domain/selection.py`.
- Updating `backend/app/domain/practice_selection.py` to be a thin backward-compatible wrapper around the shared selector.
- Updating `backend/app/presentation/exams.py` to use the shared selector with the complete config and an injected `now`.
- Implementing the exact score formulas specified in the issue.
- Keeping historical exam snapshots backward-compatible (snapshot expansion is out of scope and handled by #289).

Scope covered:

- Shared selection configuration and score-breakdown model.
- Shared eligibility and weighted-selection implementation.
- Migration of both practice and exam callers to the shared implementation.
- Removal of duplicate score/selection logic.
- Dynamic calculation of all per-problem scores and weights.
- Weighted random sampling without replacement.
- Smaller exam creation when fewer eligible problems exist than requested.
- Zero-total-weight fallback to uniform selection.
- Required automated test updates and additions.

Out of scope / intentionally not included:

- Renaming environment variables, settings API fields, or frontend settings terminology (handled by #289).
- Expanding exam configuration snapshots to record the complete shared policy (handled by #289).
- Persisting calculated score breakdowns, totals, rankings, or probabilities.
- Database migrations or new score fields.

## Implementation Notes

- `compute_score_breakdown` is pure: inputs fully determine outputs except for the injected RNG.
- `get_eligible_problems` applies identical answerability, deletion, minimum-age, and cooldown rules in both modes.
- `select_problems` accepts an explicit `now` and optional `rng` for deterministic testing.
- The old `PracticeSelectionConfig`, `PracticeSelectionResult`, and `PracticeWeightBreakdown` types remain in `practice_selection.py` as thin wrappers to avoid breaking existing imports, but all logic delegates to the shared engine.
- **Fix (post-review):** Changed `ScoreBreakdown.total` to compute `last_wrong + failure + recency` instead of `recency + failure + last_wrong` to preserve bit-exact equality with the existing API contract exercised by `test_list_detail_update_delete_tags_and_tracking`.

## Tests

Commands run (after fix):

- `PYTHONPATH=backend .venv/bin/python -m pytest -q tests/domain/test_selection.py tests/domain/test_practice_selection.py` — 53 passed
- `PYTHONPATH=backend .venv/bin/python -m pytest -q tests/api/test_exams.py tests/api/test_practice.py tests/api/test_problems.py tests/api/test_settings_info.py` — 57 passed
- `PYTHONPATH=backend .venv/bin/python -m pytest -q` — 495 passed, 1 skipped

Automated tests added or updated:

- `tests/domain/test_selection.py`
  - Exact recency using `lastTestedAt` and fallback to `createdAt`
  - Exact failure scores for 0%, 50%, 100%
  - Last-wrong scores for never-tested, correct, wrong, unknown
  - Component weights multiply and sum correctly
  - Cooldown and minimum-age boundaries
  - Multi-selection without duplicates
  - Smaller exam when fewer eligible problems than requested
  - Zero-total-weight uniform fallback
  - Eligibility excludes unanswerable problems
- `tests/domain/test_practice_selection.py`
  - Updated existing tests to match new exact score formulas

Manual verification:

- Verified that the shared selector is used by both practice and exam endpoints.
- Confirmed no calculated per-problem selection data is stored in the database.
- Searched for stale direct references to the old duplicate selection logic.
- Confirmed the full backend suite is green (495 passed, 1 skipped).

## Deviations From Issue Plan

None.

## Follow-Up Work

- Hard-rename `PRACTICE_*` configuration and public settings/snapshot terminology to `PROBLEM_SELECTION_*` in #289.
- Optional: remove the now-unused `_compute_problem_weight` private helper in `practice_selection.py` and inline the assertion in its only remaining consumer test.
