### PR TITLE
feat: rename shared problem-selection configuration and snapshot contracts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,13 +47,9 @@ SESSION_COOKIE_NAME=ll_session
 SESSION_SECURE=false
 SESSION_SAMESITE=lax
 
-## Practice mode configuration
-PRACTICE_COOLDOWN_DAYS=7
-PRACTICE_LAST_WRONG_WEIGHT=1.0
-PRACTICE_FAILURE_RATE_WEIGHT=1.0
-PRACTICE_RECENCY_WEIGHT=1.0
-
-## Problem selection minimum age (days)
-## Problems newer than this threshold are excluded from practice and exam selection.
-## Set to 0 to allow newly created problems to appear immediately.
+## Problem selection configuration (shared by practice and exam)
+PROBLEM_SELECTION_COOLDOWN_DAYS=7
+PROBLEM_SELECTION_LAST_WRONG_WEIGHT=1.0
+PROBLEM_SELECTION_FAILURE_RATE_WEIGHT=1.0
+PROBLEM_SELECTION_RECENCY_WEIGHT=1.0
 PROBLEM_SELECTION_MIN_AGE_DAYS=3

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -237,10 +237,10 @@ The canonical template lives in `.env.example`.
 | `SESSION_COOKIE_NAME` | Session cookie name | `ll_session` |
 | `SESSION_SECURE` | HTTPS-only session cookie toggle | `false` |
 | `SESSION_SAMESITE` | Session cookie same-site policy | `lax` |
-| `PRACTICE_COOLDOWN_DAYS` | Days before revisiting a correctly answered problem | `7` |
-| `PRACTICE_LAST_WRONG_WEIGHT` | Weight for problems last answered incorrectly | `1.0` |
-| `PRACTICE_FAILURE_RATE_WEIGHT` | Weight for problems with high failure rates | `1.0` |
-| `PRACTICE_RECENCY_WEIGHT` | Weight for recently tested problems | `1.0` |
+| `PROBLEM_SELECTION_COOLDOWN_DAYS` | Days before revisiting a correctly answered problem | `7` |
+| `PROBLEM_SELECTION_LAST_WRONG_WEIGHT` | Weight for problems last answered incorrectly | `1.0` |
+| `PROBLEM_SELECTION_FAILURE_RATE_WEIGHT` | Weight for problems with high failure rates | `1.0` |
+| `PROBLEM_SELECTION_RECENCY_WEIGHT` | Weight for recently tested problems | `1.0` |
 | `PROBLEM_SELECTION_MIN_AGE_DAYS` | Minimum age (days) before a problem appears in practice or exams | `3` |
 
 ### AI tutoring VLM notes

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -118,8 +118,10 @@ class ClientMeta(BaseModel):
 
 
 class SelectionPolicyConfig(BaseModel):
+    cooldownDays: int = 7
+    lastWrongWeight: float = 1.0
+    failureRateWeight: float = 1.0
     recencyWeight: float
-    failureWeight: float
     minProblemAgeDays: int = 3
 
 

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -81,13 +81,11 @@ class Settings(BaseSettings):
     session_secure: bool = Field(default=False)
     session_samesite: Literal["lax", "strict", "none"] = Field(default="lax")
 
-    # Practice mode configuration
-    practice_cooldown_days: int = Field(default=7, ge=0)
-    practice_last_wrong_weight: float = Field(default=1.0, ge=0)
-    practice_failure_rate_weight: float = Field(default=1.0, ge=0)
-    practice_recency_weight: float = Field(default=1.0, ge=0)
-
-    # Problem selection minimum age
+    # Problem selection configuration (shared by practice and exam)
+    problem_selection_cooldown_days: int = Field(default=7, ge=0)
+    problem_selection_last_wrong_weight: float = Field(default=1.0, ge=0)
+    problem_selection_failure_rate_weight: float = Field(default=1.0, ge=0)
+    problem_selection_recency_weight: float = Field(default=1.0, ge=0)
     problem_selection_min_age_days: int = Field(default=3, ge=0)
 
     # Teacher password configuration

--- a/backend/app/presentation/exam_helpers.py
+++ b/backend/app/presentation/exam_helpers.py
@@ -14,7 +14,13 @@ from app.infrastructure.storage.mongo import Document
 from app.presentation.errors import ApiError
 from app.presentation.helpers import parse_object_id
 
-DEFAULT_SELECTION_POLICY = SelectionPolicyConfig(recencyWeight=1.0, failureWeight=1.0)
+DEFAULT_SELECTION_POLICY = SelectionPolicyConfig(
+    cooldownDays=7,
+    lastWrongWeight=1.0,
+    failureRateWeight=1.0,
+    recencyWeight=1.0,
+    minProblemAgeDays=3,
+)
 
 
 def problem_document_to_model(problem: Mapping[str, Any]) -> Problem:

--- a/backend/app/presentation/exam_helpers.py
+++ b/backend/app/presentation/exam_helpers.py
@@ -8,20 +8,11 @@ from bson import ObjectId
 from pydantic import ValidationError
 from pymongo.asynchronous.database import AsyncDatabase
 
-from app.domain.models import ExamItem, GradingStatus, Problem, SelectionPolicyConfig
+from app.domain.models import ExamItem, GradingStatus, Problem
 from app.domain.scoring import compute_summary
 from app.infrastructure.storage.mongo import Document
 from app.presentation.errors import ApiError
 from app.presentation.helpers import parse_object_id
-
-DEFAULT_SELECTION_POLICY = SelectionPolicyConfig(
-    cooldownDays=7,
-    lastWrongWeight=1.0,
-    failureRateWeight=1.0,
-    recencyWeight=1.0,
-    minProblemAgeDays=3,
-)
-
 
 def problem_document_to_model(problem: Mapping[str, Any]) -> Problem:
     try:

--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -61,9 +61,11 @@ class ExamItemPayload(BaseModel):
 
 
 class SelectionPolicyPayload(BaseModel):
+    cooldownDays: int
+    lastWrongWeight: float
+    failureRateWeight: float
     recencyWeight: float
-    failureWeight: float
-    minProblemAgeDays: int = 3
+    minProblemAgeDays: int
 
 
 class ExamConfigSnapshotPayload(BaseModel):
@@ -193,14 +195,20 @@ def serialize_exam(exam: Mapping[str, Any]) -> ExamPayload:
     include_correct_answer = str(exam.get("state")) == ExamState.SUBMITTED.value
     config_snapshot = dict(exam.get("configSnapshot", {}))
     selection_policy = dict(config_snapshot.get("selectionPolicy", {}))
+    # Backward compatibility: historical snapshots may use failureWeight instead of failureRateWeight
+    failure_rate_weight = float(
+        selection_policy.get("failureRateWeight", selection_policy.get("failureWeight", 1.0))
+    )
     return ExamPayload(
         id=str(exam["_id"]),
         state=ExamState(exam["state"]),
         configSnapshot=ExamConfigSnapshotPayload(
             maxProblemCount=int(config_snapshot.get("maxProblemCount", 0)),
             selectionPolicy=SelectionPolicyPayload(
+                cooldownDays=int(selection_policy.get("cooldownDays", 7)),
+                lastWrongWeight=float(selection_policy.get("lastWrongWeight", 1.0)),
+                failureRateWeight=failure_rate_weight,
                 recencyWeight=float(selection_policy.get("recencyWeight", 1.0)),
-                failureWeight=float(selection_policy.get("failureWeight", 1.0)),
                 minProblemAgeDays=int(selection_policy.get("minProblemAgeDays", 3)),
             ),
             generatedAt=config_snapshot["generatedAt"],

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -82,7 +82,7 @@ async def create_exam(
         cooldownDays=settings.problem_selection_cooldown_days,
         lastWrongWeight=settings.problem_selection_last_wrong_weight,
         failureRateWeight=settings.problem_selection_failure_rate_weight,
-        recencyWeight=1.0,
+        recencyWeight=settings.problem_selection_recency_weight,
         minProblemAgeDays=settings.problem_selection_min_age_days,
     )
 

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -72,15 +72,17 @@ async def create_exam(
 ) -> CreateExamResponse:
     query = {"userId": current_user["_id"], "state": ExamState.IN_PROGRESS.value}
     selection_config = ProblemSelectionConfig(
-        cooldown_days=settings.practice_cooldown_days,
-        last_wrong_weight=settings.practice_last_wrong_weight,
-        failure_rate_weight=settings.practice_failure_rate_weight,
-        recency_weight=settings.practice_recency_weight,
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
         min_problem_age_days=settings.problem_selection_min_age_days,
     )
     selection_policy = SelectionPolicyConfig(
+        cooldownDays=settings.problem_selection_cooldown_days,
+        lastWrongWeight=settings.problem_selection_last_wrong_weight,
+        failureRateWeight=settings.problem_selection_failure_rate_weight,
         recencyWeight=1.0,
-        failureWeight=1.0,
         minProblemAgeDays=settings.problem_selection_min_age_days,
     )
 

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -103,7 +103,7 @@ async def get_practice_stats(
 
     problem_models = [problem_document_to_model(p) for p in problem_documents]
     config = PracticeSelectionConfig(
-        cooldown_days=settings.practice_cooldown_days,
+        cooldown_days=settings.problem_selection_cooldown_days,
         min_problem_age_days=settings.problem_selection_min_age_days,
     )
     now = datetime.now(UTC)
@@ -133,10 +133,10 @@ async def get_next_practice_problem(
         return PracticeNextResponse(status="no_problems")
 
     config = PracticeSelectionConfig(
-        cooldown_days=settings.practice_cooldown_days,
-        last_wrong_weight=settings.practice_last_wrong_weight,
-        failure_rate_weight=settings.practice_failure_rate_weight,
-        recency_weight=settings.practice_recency_weight,
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
         min_problem_age_days=settings.problem_selection_min_age_days,
     )
 

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -432,10 +432,10 @@ async def get_problem_tracking(
     )
     problem_model = problem_document_to_model(problem_doc)
     config = PracticeSelectionConfig(
-        cooldown_days=settings.practice_cooldown_days,
-        last_wrong_weight=settings.practice_last_wrong_weight,
-        failure_rate_weight=settings.practice_failure_rate_weight,
-        recency_weight=settings.practice_recency_weight,
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
         min_problem_age_days=settings.problem_selection_min_age_days,
     )
     now = datetime.now(UTC)

--- a/backend/app/presentation/settings.py
+++ b/backend/app/presentation/settings.py
@@ -70,10 +70,11 @@ async def get_settings_info() -> dict:
             "secure": settings.session_secure,
             "samesite": settings.session_samesite,
         },
-        "practice": {
-            "cooldown_days": settings.practice_cooldown_days,
-            "last_wrong_weight": settings.practice_last_wrong_weight,
-            "failure_rate_weight": settings.practice_failure_rate_weight,
-            "recency_weight": settings.practice_recency_weight,
+        "problem_selection": {
+            "cooldown_days": settings.problem_selection_cooldown_days,
+            "last_wrong_weight": settings.problem_selection_last_wrong_weight,
+            "failure_rate_weight": settings.problem_selection_failure_rate_weight,
+            "recency_weight": settings.problem_selection_recency_weight,
+            "min_problem_age_days": settings.problem_selection_min_age_days,
         },
     }

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -695,3 +695,150 @@ async def test_create_exam_succeeds_with_old_problems_and_records_min_age(
     body = response.json()["exam"]
     assert body["configSnapshot"]["selectionPolicy"] == {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 3}
     assert len(body["items"]) == 1
+
+
+@pytest_asyncio.fixture
+async def exams_app_with_custom_policy() -> FastAPI:
+    application = create_app()
+    database = FakeDatabase()
+    adapter = FakeMongoAdapter()
+    storage = FakeStorage()
+    vlm = FakeVLMClient()
+    user = make_user()
+
+    settings = Settings(
+        problem_selection_cooldown_days=5,
+        problem_selection_last_wrong_weight=1.5,
+        problem_selection_failure_rate_weight=2.0,
+        problem_selection_recency_weight=2.5,
+        problem_selection_min_age_days=0,
+    )
+
+    application.state.fake_database = database
+    application.state.fake_adapter = adapter
+    application.state.fake_storage = storage
+    application.state.fake_grading_vlm = vlm
+    application.state.fake_vlm = vlm
+    application.state.primary_user = user
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
+    application.dependency_overrides[get_settings] = lambda: settings
+    application.dependency_overrides[get_exam_mongo_adapter] = lambda: adapter
+    application.dependency_overrides[get_exam_storage] = lambda: storage
+    application.dependency_overrides[get_exam_vlm_client] = lambda: vlm
+    return application
+
+
+@pytest_asyncio.fixture
+async def client_custom_policy(exams_app_with_custom_policy: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=exams_app_with_custom_policy)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+@pytest.mark.asyncio
+async def test_create_exam_snapshots_all_non_default_policy_values(
+    exams_app_with_custom_policy: FastAPI,
+    client_custom_policy: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app_with_custom_policy.state.fake_database
+    storage: FakeStorage = exams_app_with_custom_policy.state.fake_storage
+    user_id = exams_app_with_custom_policy.state.primary_user["_id"]
+    problem = make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    database["problems"].seed(problem)
+    storage.seed(problem["sourceImage"]["bucket"], problem["sourceImage"]["objectKey"], b"img")
+
+    response = await client_custom_policy.post("/api/v1/exams", json={"maxProblemCount": 1})
+
+    assert response.status_code == 201
+    body = response.json()["exam"]
+    assert body["configSnapshot"]["selectionPolicy"] == {
+        "cooldownDays": 5,
+        "lastWrongWeight": 1.5,
+        "failureRateWeight": 2.0,
+        "recencyWeight": 2.5,
+        "minProblemAgeDays": 0,
+    }
+    stored_exam = database["exams"]._documents[0]
+    assert stored_exam["configSnapshot"]["selectionPolicy"] == {
+        "cooldownDays": 5,
+        "lastWrongWeight": 1.5,
+        "failureRateWeight": 2.0,
+        "recencyWeight": 2.5,
+        "minProblemAgeDays": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_exam_deserializes_legacy_selection_policy(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+    exam_id = ObjectId()
+    database["exams"].seed(
+        {
+            "_id": exam_id,
+            "userId": user_id,
+            "state": "submitted",
+            "configSnapshot": {
+                "maxProblemCount": 1,
+                "selectionPolicy": {"recencyWeight": 1.5, "failureWeight": 1.7},
+                "generatedAt": datetime.now(UTC),
+            },
+            "items": [],
+            "summary": {"totalProblems": 0, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC),
+            "startedAt": None,
+            "submittedAt": None,
+            "updatedAt": datetime.now(UTC),
+        }
+    )
+
+    response = await client.get(f"/api/v1/exams/{exam_id}")
+
+    assert response.status_code == 200
+    body = response.json()["exam"]
+    assert body["configSnapshot"]["selectionPolicy"] == {
+        "cooldownDays": 7,
+        "lastWrongWeight": 1.0,
+        "failureRateWeight": 1.7,
+        "recencyWeight": 1.5,
+        "minProblemAgeDays": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_exam_prefers_failure_rate_weight_over_legacy_failure_weight(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+    exam_id = ObjectId()
+    database["exams"].seed(
+        {
+            "_id": exam_id,
+            "userId": user_id,
+            "state": "submitted",
+            "configSnapshot": {
+                "maxProblemCount": 1,
+                "selectionPolicy": {"recencyWeight": 1.2, "failureWeight": 1.7, "failureRateWeight": 2.3},
+                "generatedAt": datetime.now(UTC),
+            },
+            "items": [],
+            "summary": {"totalProblems": 0, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC),
+            "startedAt": None,
+            "submittedAt": None,
+            "updatedAt": datetime.now(UTC),
+        }
+    )
+
+    response = await client.get(f"/api/v1/exams/{exam_id}")
+
+    assert response.status_code == 200
+    body = response.json()["exam"]
+    assert body["configSnapshot"]["selectionPolicy"]["failureRateWeight"] == 2.3

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -305,7 +305,7 @@ async def test_create_exam_snapshots_selected_problems(exams_app: FastAPI, clien
     assert response.status_code == 201
     body = response.json()["exam"]
     assert body["state"] == "in-progress"
-    assert body["configSnapshot"]["selectionPolicy"] == {"recencyWeight": 1.0, "failureWeight": 1.0, "minProblemAgeDays": 0}
+    assert body["configSnapshot"]["selectionPolicy"] == {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 0}
     assert len(body["items"]) == 2
     assert body["items"][0]["problem"]["correctAnswer"] is None
     stored_exam = database["exams"]._documents[0]
@@ -322,7 +322,7 @@ async def test_create_exam_rejects_when_active_exam_exists(exams_app: FastAPI, c
             "_id": ObjectId(),
             "userId": user_id,
             "state": "in-progress",
-            "configSnapshot": {"maxProblemCount": 1, "selectionPolicy": {"recencyWeight": 1.0, "failureWeight": 1.0}, "generatedAt": datetime.now(UTC)},
+            "configSnapshot": {"maxProblemCount": 1, "selectionPolicy": {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 0}, "generatedAt": datetime.now(UTC)},
             "items": [],
             "summary": {"totalProblems": 0, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
             "createdAt": datetime.now(UTC),
@@ -693,5 +693,5 @@ async def test_create_exam_succeeds_with_old_problems_and_records_min_age(
 
     assert response.status_code == 201
     body = response.json()["exam"]
-    assert body["configSnapshot"]["selectionPolicy"]["minProblemAgeDays"] == 3
+    assert body["configSnapshot"]["selectionPolicy"] == {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 3}
     assert len(body["items"]) == 1

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -20,7 +20,7 @@ from tests.api.conftest import FakeDatabase, make_user, make_problem
 def practice_app() -> FastAPI:
     application = create_app()
     database = FakeDatabase()
-    settings = Settings(practice_cooldown_days=7, problem_selection_min_age_days=0)
+    settings = Settings(problem_selection_cooldown_days=7, problem_selection_min_age_days=0)
     user = make_user(ObjectId(), "student")
 
     application.state.fake_database = database
@@ -265,7 +265,7 @@ async def test_next_problem_without_graph_dsl(
 def practice_app_with_min_age() -> FastAPI:
     application = create_app()
     database = FakeDatabase()
-    settings = Settings(practice_cooldown_days=7, problem_selection_min_age_days=3)
+    settings = Settings(problem_selection_cooldown_days=7, problem_selection_min_age_days=3)
     user = make_user(ObjectId(), "student")
 
     application.state.fake_database = database

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -488,9 +488,9 @@ async def test_problem_tracking_includes_practice_weight_with_exact_values(
     from app.infrastructure.config.settings import Settings, get_settings
 
     explicit_settings = Settings(
-        practice_last_wrong_weight=1.5,
-        practice_failure_rate_weight=2.0,
-        practice_recency_weight=1.0,
+        problem_selection_last_wrong_weight=1.5,
+        problem_selection_failure_rate_weight=2.0,
+        problem_selection_recency_weight=1.0,
     )
     problems_app.dependency_overrides[get_settings] = lambda: explicit_settings
 

--- a/backend/tests/api/test_settings_info.py
+++ b/backend/tests/api/test_settings_info.py
@@ -97,3 +97,11 @@ async def test_settings_info_exposes_explicit_ai_profiles(client: AsyncClient) -
         "timeout_seconds": 79,
     }
     assert "vlm" not in payload
+    assert payload["problem_selection"] == {
+        "cooldown_days": 7,
+        "last_wrong_weight": 1.0,
+        "failure_rate_weight": 1.0,
+        "recency_weight": 1.0,
+        "min_problem_age_days": 3,
+    }
+    assert "practice" not in payload

--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -54,7 +54,7 @@ const baseExam = {
   state: "in-progress",
   configSnapshot: {
     maxProblemCount: 5,
-    selectionPolicy: { recencyWeight: 1.0, failureWeight: 1.0 },
+    selectionPolicy: { cooldownDays: 7, lastWrongWeight: 1.0, failureRateWeight: 1.0, recencyWeight: 1.0, minProblemAgeDays: 3 },
     generatedAt: "2024-01-01T00:00:00Z",
   },
   items: [baseExamItem],

--- a/frontend/src/pages/ExamDetailPage.test.tsx
+++ b/frontend/src/pages/ExamDetailPage.test.tsx
@@ -64,7 +64,7 @@ const baseExam = {
   state: "submitted",
   configSnapshot: {
     maxProblemCount: 5,
-    selectionPolicy: { recencyWeight: 1.0, failureWeight: 1.0 },
+    selectionPolicy: { cooldownDays: 7, lastWrongWeight: 1.0, failureRateWeight: 1.0, recencyWeight: 1.0, minProblemAgeDays: 3 },
     generatedAt: "2024-01-01T00:00:00Z",
   },
   items: [

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -74,7 +74,7 @@ const mockSettings = {
     timeout_seconds: 45,
   },
   session: { cookie_name: "ll_session", secure: false, samesite: "lax" },
-  practice: { cooldown_days: 7, last_wrong_weight: 1.0, failure_rate_weight: 1.0, recency_weight: 1.0 },
+  problem_selection: { cooldown_days: 7, last_wrong_weight: 1.0, failure_rate_weight: 1.0, recency_weight: 1.0, min_problem_age_days: 3 },
 };
 
 describe("SettingsPage", () => {
@@ -147,9 +147,9 @@ describe("SettingsPage", () => {
     expect(await screen.findByText("ll_session")).toBeInTheDocument();
   });
 
-  it("renders practice settings section", async () => {
+  it("renders problem selection settings section", async () => {
     renderWithProviders();
-    expect(await screen.findByText("Practice Mode")).toBeInTheDocument();
+    expect(await screen.findByText("Problem Selection")).toBeInTheDocument();
     expect(await screen.findByText("7")).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -66,11 +66,12 @@ interface SettingsResponse {
     secure: boolean;
     samesite: string;
   };
-  practice: {
+  problem_selection: {
     cooldown_days: number;
     last_wrong_weight: number;
     failure_rate_weight: number;
     recency_weight: number;
+    min_problem_age_days: number;
   };
 }
 
@@ -429,17 +430,18 @@ export function SettingsPage() {
         <SettingRow label="SameSite" value={data.session.samesite} />
       </SettingSection>
 
-      <SettingSection title="Practice Mode">
-        <SettingRow label="Cooldown Days" value={data.practice.cooldown_days} />
+      <SettingSection title="Problem Selection">
+        <SettingRow label="Cooldown Days" value={data.problem_selection.cooldown_days} />
         <SettingRow
           label="Last Wrong Weight"
-          value={data.practice.last_wrong_weight}
+          value={data.problem_selection.last_wrong_weight}
         />
         <SettingRow
           label="Failure Rate Weight"
-          value={data.practice.failure_rate_weight}
+          value={data.problem_selection.failure_rate_weight}
         />
-        <SettingRow label="Recency Weight" value={data.practice.recency_weight} />
+        <SettingRow label="Recency Weight" value={data.problem_selection.recency_weight} />
+        <SettingRow label="Min Problem Age Days" value={data.problem_selection.min_problem_age_days} />
       </SettingSection>
 
       <ChangeTeacherPasswordModal

--- a/frontend/src/types/exam.ts
+++ b/frontend/src/types/exam.ts
@@ -65,8 +65,11 @@ export interface ExamItem {
 }
 
 export interface SelectionPolicy {
+  cooldownDays: number;
+  lastWrongWeight: number;
+  failureRateWeight: number;
   recencyWeight: number;
-  failureWeight: number;
+  minProblemAgeDays: number;
 }
 
 export interface ExamConfigSnapshot {


### PR DESCRIPTION
## Summary

Hard-rename practice-specific problem-selection configuration and public settings terminology to shared `PROBLEM_SELECTION_*` names after practice and exam mode use the same selection engine.

## Linked Issue

Closes #289

## Issue Alignment

This PR implements the issue by:

- Renaming backend settings fields and environment variables from `practice_*` to `problem_selection_*`.
- Renaming the settings API response section from `practice` to `problem_selection` and including `min_problem_age_days`.
- Expanding `SelectionPolicyConfig` and exam snapshot serialization to the complete shared 5-field shape.
- Adding backward-compatible deserialization for historical exam snapshots (`failureWeight` maps to `failureRateWeight`).
- Updating frontend settings types, page rendering, labels, and fixtures.
- Updating `.env.example` and `DEVELOPMENT.md` documentation.

Scope covered:

- Backend configuration rename (settings, env vars).
- Settings API/frontend rename and expansion.
- Exam snapshot model and serialization changes with backward compatibility.
- Test updates for new names and snapshot shapes.
- Documentation updates.

Out of scope / intentionally not included:

- Merging `PracticeSelectionConfig` and `SelectionPolicyConfig` domain models (the internal dataclass wrapper is preserved to avoid broad refactor).
- Database migration of existing exam documents (handled by read-time fallback defaults).
- Legacy `PRACTICE_*` environment-variable aliases.

## Implementation Notes

- `SelectionPolicyConfig` now requires `recencyWeight` but defaults the other four fields to match current behavior.
- `serialize_exam` uses `selection_policy.get("failureRateWeight", selection_policy.get("failureWeight", 1.0))` so historical snapshots remain readable without a migration.
- The settings API now returns a single `problem_selection` object containing all five policy values.

## Tests

Commands run:

- `cd backend && .venv/bin/python -m pytest tests/api/test_exams.py tests/api/test_practice.py tests/api/test_problems.py tests/domain/test_selection.py -q` — **81 passed**
- `cd frontend && ./node_modules/.bin/vitest --run src/pages/SettingsPage.test.tsx` — **16 passed**

Automated tests added or updated:

- `backend/tests/api/test_exams.py` — updated snapshot assertions to expect the new 5-field `selectionPolicy` shape.
- `backend/tests/api/test_practice.py` — updated `Settings` fixtures to use new field names.
- `backend/tests/api/test_problems.py` — updated `Settings` fixtures to use new field names.
- `frontend/src/pages/SettingsPage.test.tsx` — updated mock settings to use `problem_selection` section and added `min_problem_age_days`.
- `frontend/src/pages/ExamDetailPage.test.tsx` and `ActiveExamPage.test.tsx` — updated exam fixtures to use the new `SelectionPolicy` shape.

Manual verification:

- Searched repository for stale `PRACTICE_*` env var references and `practice:` settings section — none found in supported runtime paths.
- Confirmed historical exam snapshot deserialization falls back correctly via test assertions and code inspection.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.