### PR TITLE
Harden GraphSandbox iframe with restrictive CSP and pinned JSXGraph version

### DIFF
--- a/frontend/src/components/GraphSandbox.iframe.ts
+++ b/frontend/src/components/GraphSandbox.iframe.ts
@@ -1,0 +1,145 @@
+// Pinned JSXGraph version for security and stability
+export const JSXGRAPH_VERSION = "1.10.0";
+export const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
+
+/**
+ * Generates the iframe HTML content with JSXGraph loader.
+ * This is loaded into the sandboxed iframe.
+ * Exported for testing only.
+ */
+export function generateIframeHtml(): string {
+  // CSP justification:
+  // - default-src 'none': block everything by default
+  // - script-src:
+  //   - 'unsafe-eval': required for new Function('board', dsl) to execute the DSL
+  //   - 'unsafe-inline': required for the inline <script> tag that sets up the sandbox
+  //   - ${JSXGRAPH_CDN_URL}: only allow JSXGraph from our pinned CDN version
+  // - style-src 'unsafe-inline': required for inline JSXGraph styles
+  // - img-src data:: allow data URIs for JSXGraph images
+  // - All other directives set to 'none' to block unnecessary capabilities
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    script-src 'unsafe-eval' 'unsafe-inline' ${JSXGRAPH_CDN_URL};
+    style-src 'unsafe-inline';
+    img-src data:;
+    connect-src 'none';
+    font-src 'none';
+    frame-src 'none';
+    object-src 'none';
+    media-src 'none';
+    base-uri 'none';
+    form-action 'none';
+  ">
+  <title>JSXGraph Sandbox</title>
+  <script src="${JSXGRAPH_CDN_URL}"></script>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      font-family: sans-serif;
+    }
+    #jxgbox {
+      width: 100%;
+      height: 100%;
+    }
+    .error {
+      color: #dc2626;
+      padding: 16px;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div id="jxgbox"></div>
+  <script>
+    (function() {
+      // Track board instance for cleanup
+      let board = null;
+
+      // Message handler for postMessage protocol
+      function handleMessage(event) {
+        const data = event.data;
+        
+        if (!data || typeof data !== 'object') {
+          return;
+        }
+
+        switch (data.type) {
+          case 'render':
+            handleRender(data.payload);
+            break;
+          case 'clear':
+            handleClear();
+            break;
+          default:
+            console.warn('Unknown message type:', data.type);
+        }
+      }
+
+      function handleRender(dsl) {
+        try {
+          // Clear any existing board
+          if (board) {
+            JXG.JSXGraph.freeBoard(board);
+            board = null;
+          }
+
+          // Create new board
+          board = JXG.JSXGraph.initBoard('jxgbox', {
+            boundingbox: [-5, 5, 5, -5],
+            axis: false,
+            grid: false,
+            showCopyright: false,
+            showNavigation: true,
+            keepaspectratio: true
+          });
+
+          // Execute the DSL in a controlled way
+          // The DSL is expected to be a function that takes the board as parameter
+          const dslFunction = new Function('board', dsl);
+          dslFunction(board);
+
+          // Notify parent of success
+          parent.postMessage({ type: 'rendered' }, '*');
+        } catch (error) {
+          // Notify parent of error
+          parent.postMessage({ 
+            type: 'error', 
+            payload: error instanceof Error ? error.message : String(error)
+          }, '*');
+        }
+      }
+
+      function handleClear() {
+        if (board) {
+          JXG.JSXGraph.freeBoard(board);
+          board = null;
+        }
+        // Notify parent of clear completion
+        parent.postMessage({ type: 'cleared' }, '*');
+      }
+
+      // Listen for messages from parent
+      window.addEventListener('message', handleMessage);
+
+      // Notify parent that sandbox is ready
+      parent.postMessage({ type: 'ready' }, '*');
+
+      // Cleanup on page unload
+      window.addEventListener('beforeunload', function() {
+        if (board) {
+          JXG.JSXGraph.freeBoard(board);
+        }
+      });
+    })();
+  </script>
+</body>
+</html>`;
+}

--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { GraphSandbox, validateDsl } from "./GraphSandbox";
+import { GraphSandbox, validateDsl, generateIframeHtml } from "./GraphSandbox";
+
+// Pinned JSXGraph version - keep in sync with GraphSandbox.tsx
+const JSXGRAPH_VERSION = "1.10.0";
+const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
 
 describe("GraphSandbox", () => {
   beforeEach(() => {
@@ -24,6 +28,27 @@ describe("GraphSandbox", () => {
     const iframe = screen.getByTestId("jsxgraph-iframe");
     expect(iframe).toBeInTheDocument();
     expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+  });
+
+  it("generates iframe HTML with restrictive Content Security Policy", () => {
+    const html = generateIframeHtml();
+
+    // Verify CSP meta tag exists with restrictive directives
+    expect(html).toContain("<meta http-equiv=\"Content-Security-Policy\"");
+    expect(html).toContain("default-src 'none'");
+    expect(html).toContain("connect-src 'none'");
+    expect(html).toContain("frame-src 'none'");
+    expect(html).toContain("object-src 'none'");
+    expect(html).toContain("base-uri 'none'");
+    expect(html).toContain("form-action 'none'");
+  });
+
+  it("generates iframe HTML with pinned JSXGraph version", () => {
+    const html = generateIframeHtml();
+
+    // Verify pinned JSXGraph URL is used
+    expect(html).toContain(JSXGRAPH_CDN_URL);
+    expect(html).not.toContain("https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js");
   });
 
   it("accepts custom width and height", () => {

--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -2,11 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { GraphSandbox, validateDsl, generateIframeHtml } from "./GraphSandbox";
-
-// Pinned JSXGraph version - keep in sync with GraphSandbox.tsx
-const JSXGRAPH_VERSION = "1.10.0";
-const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
+import { GraphSandbox, validateDsl, generateIframeHtml, JSXGRAPH_VERSION, JSXGRAPH_CDN_URL } from "./GraphSandbox";
 
 describe("GraphSandbox", () => {
   beforeEach(() => {

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -66,9 +66,9 @@ const BLOCKED_TOKENS = [
 // Timeout for rendering operations (30 seconds)
 const RENDER_TIMEOUT_MS = 30000;
 
-// Pinned JSXGraph version for security and stability
-export const JSXGRAPH_VERSION = "1.10.0";
-export const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
+import { JSXGRAPH_VERSION, JSXGRAPH_CDN_URL, generateIframeHtml } from "./GraphSandbox.iframe";
+
+export { JSXGRAPH_VERSION, JSXGRAPH_CDN_URL, generateIframeHtml };
 
 export interface GraphSandboxProps {
   /** The JSXGraph DSL code to render */
@@ -329,148 +329,6 @@ export function validateDsl(dsl: string): string | null {
   }
 
   return null;
-}
-
-/**
- * Generates the iframe HTML content with JSXGraph loader.
- * This is loaded into the sandboxed iframe.
- * Exported for testing only.
- */
-export function generateIframeHtml(): string {
-  // CSP justification:
-  // - default-src 'none': block everything by default
-  // - script-src:
-  //   - 'unsafe-eval': required for new Function('board', dsl) to execute the DSL
-  //   - 'unsafe-inline': required for the inline <script> tag that sets up the sandbox
-  //   - ${JSXGRAPH_CDN_URL}: only allow JSXGraph from our pinned CDN version
-  // - style-src 'unsafe-inline': required for inline JSXGraph styles
-  // - img-src data:: allow data URIs for JSXGraph images
-  // - All other directives set to 'none' to block unnecessary capabilities
-  return `<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="
-    default-src 'none';
-    script-src 'unsafe-eval' 'unsafe-inline' ${JSXGRAPH_CDN_URL};
-    style-src 'unsafe-inline';
-    img-src data:;
-    connect-src 'none';
-    font-src 'none';
-    frame-src 'none';
-    object-src 'none';
-    media-src 'none';
-    base-uri 'none';
-    form-action 'none';
-  ">
-  <title>JSXGraph Sandbox</title>
-  <script src="${JSXGRAPH_CDN_URL}"></script>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      font-family: sans-serif;
-    }
-    #jxgbox {
-      width: 100%;
-      height: 100%;
-    }
-    .error {
-      color: #dc2626;
-      padding: 16px;
-      font-size: 14px;
-    }
-  </style>
-</head>
-<body>
-  <div id="jxgbox"></div>
-  <script>
-    (function() {
-      // Track board instance for cleanup
-      let board = null;
-
-      // Message handler for postMessage protocol
-      function handleMessage(event) {
-        const data = event.data;
-        
-        if (!data || typeof data !== 'object') {
-          return;
-        }
-
-        switch (data.type) {
-          case 'render':
-            handleRender(data.payload);
-            break;
-          case 'clear':
-            handleClear();
-            break;
-          default:
-            console.warn('Unknown message type:', data.type);
-        }
-      }
-
-      function handleRender(dsl) {
-        try {
-          // Clear any existing board
-          if (board) {
-            JXG.JSXGraph.freeBoard(board);
-            board = null;
-          }
-
-          // Create new board
-          board = JXG.JSXGraph.initBoard('jxgbox', {
-            boundingbox: [-5, 5, 5, -5],
-            axis: false,
-            grid: false,
-            showCopyright: false,
-            showNavigation: true,
-            keepaspectratio: true
-          });
-
-          // Execute the DSL in a controlled way
-          // The DSL is expected to be a function that takes the board as parameter
-          const dslFunction = new Function('board', dsl);
-          dslFunction(board);
-
-          // Notify parent of success
-          parent.postMessage({ type: 'rendered' }, '*');
-        } catch (error) {
-          // Notify parent of error
-          parent.postMessage({ 
-            type: 'error', 
-            payload: error instanceof Error ? error.message : String(error)
-          }, '*');
-        }
-      }
-
-      function handleClear() {
-        if (board) {
-          JXG.JSXGraph.freeBoard(board);
-          board = null;
-        }
-        // Notify parent of clear completion
-        parent.postMessage({ type: 'cleared' }, '*');
-      }
-
-      // Listen for messages from parent
-      window.addEventListener('message', handleMessage);
-
-      // Notify parent that sandbox is ready
-      parent.postMessage({ type: 'ready' }, '*');
-
-      // Cleanup on page unload
-      window.addEventListener('beforeunload', function() {
-        if (board) {
-          JXG.JSXGraph.freeBoard(board);
-        }
-      });
-    })();
-  </script>
-</body>
-</html>`;
 }
 
 interface MessagePayload {

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -66,6 +66,10 @@ const BLOCKED_TOKENS = [
 // Timeout for rendering operations (30 seconds)
 const RENDER_TIMEOUT_MS = 30000;
 
+// Pinned JSXGraph version for security and stability
+const JSXGRAPH_VERSION = "1.10.0";
+const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
+
 export interface GraphSandboxProps {
   /** The JSXGraph DSL code to render */
   dsl: string;
@@ -330,14 +334,28 @@ export function validateDsl(dsl: string): string | null {
 /**
  * Generates the iframe HTML content with JSXGraph loader.
  * This is loaded into the sandboxed iframe.
+ * Exported for testing only.
  */
-function generateIframeHtml(): string {
+export function generateIframeHtml(): string {
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    script-src 'unsafe-eval' 'unsafe-inline' ${JSXGRAPH_CDN_URL};
+    style-src 'unsafe-inline';
+    img-src data:;
+    connect-src 'none';
+    font-src 'none';
+    frame-src 'none';
+    object-src 'none';
+    media-src 'none';
+    base-uri 'none';
+    form-action 'none';
+  ">
   <title>JSXGraph Sandbox</title>
-  <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
+  <script src="${JSXGRAPH_CDN_URL}"></script>
   <style>
     html, body {
       margin: 0;
@@ -453,11 +471,13 @@ interface MessagePayload {
 
 /**
  * GraphSandbox Component
- * 
+ *
  * Renders JSXGraph DSL in a sandboxed iframe with strict postMessage protocol.
- * 
+ *
  * Security features:
  * - iframe with sandbox="allow-scripts" (no allow-same-origin, no allow-forms)
+ * - Restrictive Content Security Policy (CSP) blocking all network requests and unsafe operations
+ * - Pinned JSXGraph version from trusted CDN
  * - DSL validation against denylist patterns
  * - Timeout handling with iframe recreation
  * - No external API access from iframe

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -67,8 +67,8 @@ const BLOCKED_TOKENS = [
 const RENDER_TIMEOUT_MS = 30000;
 
 // Pinned JSXGraph version for security and stability
-const JSXGRAPH_VERSION = "1.10.0";
-const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
+export const JSXGRAPH_VERSION = "1.10.0";
+export const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
 
 export interface GraphSandboxProps {
   /** The JSXGraph DSL code to render */
@@ -337,6 +337,15 @@ export function validateDsl(dsl: string): string | null {
  * Exported for testing only.
  */
 export function generateIframeHtml(): string {
+  // CSP justification:
+  // - default-src 'none': block everything by default
+  // - script-src:
+  //   - 'unsafe-eval': required for new Function('board', dsl) to execute the DSL
+  //   - 'unsafe-inline': required for the inline <script> tag that sets up the sandbox
+  //   - ${JSXGRAPH_CDN_URL}: only allow JSXGraph from our pinned CDN version
+  // - style-src 'unsafe-inline': required for inline JSXGraph styles
+  // - img-src data:: allow data URIs for JSXGraph images
+  // - All other directives set to 'none' to block unnecessary capabilities
   return `<!DOCTYPE html>
 <html>
 <head>

--- a/frontend/tests/graph-sandbox-security.spec.ts
+++ b/frontend/tests/graph-sandbox-security.spec.ts
@@ -1,0 +1,156 @@
+import { expect, test, type Page } from "@playwright/test";
+import { APP_BASE } from "./helpers";
+
+test.use({ baseURL: APP_BASE });
+
+test.describe("GraphSandbox Security", () => {
+  let testPage: Page;
+
+  test.beforeEach(async ({ page }) => {
+    testPage = page;
+  });
+
+  test("should block outbound fetch requests from within the iframe", async ({ page }) => {
+    // Track all network requests
+    const requestedUrls: string[] = [];
+    page.on("request", (request) => {
+      requestedUrls.push(request.url());
+    });
+
+    // Navigate to the app
+    await page.goto("/");
+
+    // Inject a test iframe with the same CSP and sandbox as GraphSandbox
+    await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const iframe = document.createElement("iframe");
+        iframe.id = "test-graph-sandbox-iframe";
+        iframe.sandbox = "allow-scripts";
+        iframe.style.position = "absolute";
+        iframe.style.left = "-9999px";
+        iframe.style.top = "-9999px";
+
+        // Same CSP as GraphSandbox
+        const iframeHtml = `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <meta http-equiv="Content-Security-Policy" content="
+              default-src 'none';
+              script-src 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net/npm/jsxgraph@1.10.0/distrib/jsxgraphcore.js;
+              style-src 'unsafe-inline';
+              img-src data:;
+              connect-src 'none';
+              font-src 'none';
+              frame-src 'none';
+              object-src 'none';
+              media-src 'none';
+              base-uri 'none';
+              form-action 'none';
+            ">
+            <script src="https://cdn.jsdelivr.net/npm/jsxgraph@1.10.0/distrib/jsxgraphcore.js"></script>
+            <script>
+              // Try to make a fetch request
+              fetch('https://example.com/malicious-test-request')
+                .catch(() => {});
+
+              // Also try XMLHttpRequest
+              try {
+                const xhr = new XMLHttpRequest();
+                xhr.open('GET', 'https://example.com/malicious-xhr-request', true);
+                xhr.send();
+              } catch (e) {}
+
+              // Notify parent that we've attempted the requests
+              parent.postMessage({ type: 'test-done' }, '*');
+            </script>
+          </head>
+          <body>
+            <div id="jxgbox"></div>
+          </body>
+          </html>
+        `;
+
+        const blob = new Blob([iframeHtml], { type: "text/html" });
+        const blobUrl = URL.createObjectURL(blob);
+        iframe.src = blobUrl;
+
+        // Wait for the iframe to send the test-done message
+        window.addEventListener("message", function handler(event) {
+          if (event.data?.type === "test-done") {
+            window.removeEventListener("message", handler);
+            resolve(undefined);
+          }
+        });
+
+        document.body.appendChild(iframe);
+      });
+    });
+
+    // Wait a bit for any requests to go through
+    await page.waitForTimeout(1000);
+
+    // Verify no requests to example.com were made
+    const hasExampleComRequest = requestedUrls.some(url =>
+      url.includes("example.com")
+    );
+    expect(hasExampleComRequest).toBe(false);
+  });
+
+  test("should block access to parent document from within the iframe", async ({ page }) => {
+    // Navigate to the app
+    await page.goto("/");
+
+    // Inject a test iframe to check parent access
+    const result = await page.evaluate(() => {
+      return new Promise((resolve) => {
+        const iframe = document.createElement("iframe");
+        iframe.id = "test-parent-access-iframe";
+        iframe.sandbox = "allow-scripts";
+        iframe.style.position = "absolute";
+        iframe.style.left = "-9999px";
+        iframe.style.top = "-9999px";
+
+        const iframeHtml = `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <script>
+              let parentAccessResult: { blocked: boolean; message?: string } = { blocked: false };
+              try {
+                // Try to access parent.document
+                const _ = window.parent.document;
+                parentAccessResult = { blocked: false };
+              } catch (e) {
+                parentAccessResult = { blocked: true, message: e instanceof Error ? e.message : String(e) };
+              }
+
+              // Notify parent of the result
+              parent.postMessage({ type: 'parent-access-result', result: parentAccessResult }, '*');
+            </script>
+          </head>
+          <body></body>
+          </html>
+        `;
+
+        const blob = new Blob([iframeHtml], { type: "text/html" });
+        const blobUrl = URL.createObjectURL(blob);
+        iframe.src = blobUrl;
+
+        window.addEventListener("message", function handler(event) {
+          if (event.data?.type === "parent-access-result") {
+            window.removeEventListener("message", handler);
+            resolve(event.data.result);
+          }
+        });
+
+        document.body.appendChild(iframe);
+      });
+    });
+
+    // Verify parent access was blocked
+    expect((result as any).blocked).toBe(true);
+  });
+});

--- a/frontend/tests/graph-sandbox-security.spec.ts
+++ b/frontend/tests/graph-sandbox-security.spec.ts
@@ -1,28 +1,23 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { APP_BASE } from "./helpers";
+import { generateIframeHtml } from "../src/components/GraphSandbox.iframe";
 
 test.use({ baseURL: APP_BASE });
 
 test.describe("GraphSandbox Security", () => {
-  let testPage: Page;
-
-  test.beforeEach(async ({ page }) => {
-    testPage = page;
-  });
-
   test("should block outbound fetch requests from within the iframe", async ({ page }) => {
-    // Track all network requests
-    const requestedUrls: string[] = [];
-    page.on("request", (request) => {
-      requestedUrls.push(request.url());
+    // Use page.route for deterministic assertion that no request reaches example.com
+    let routeHit = false;
+    await page.route("**/example.com/**", (route) => {
+      routeHit = true;
+      route.abort();
     });
 
-    // Navigate to the app
     await page.goto("/");
 
-    // Inject a test iframe with the same CSP and sandbox as GraphSandbox
-    await page.evaluate(() => {
-      return new Promise((resolve) => {
+    // Inject iframe using real generateIframeHtml() and the postMessage protocol
+    await page.evaluate((html) => {
+      return new Promise<void>((resolve) => {
         const iframe = document.createElement("iframe");
         iframe.id = "test-graph-sandbox-iframe";
         iframe.sandbox = "allow-scripts";
@@ -30,80 +25,49 @@ test.describe("GraphSandbox Security", () => {
         iframe.style.left = "-9999px";
         iframe.style.top = "-9999px";
 
-        // Same CSP as GraphSandbox
-        const iframeHtml = `
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta charset="UTF-8">
-            <meta http-equiv="Content-Security-Policy" content="
-              default-src 'none';
-              script-src 'unsafe-eval' 'unsafe-inline' https://cdn.jsdelivr.net/npm/jsxgraph@1.10.0/distrib/jsxgraphcore.js;
-              style-src 'unsafe-inline';
-              img-src data:;
-              connect-src 'none';
-              font-src 'none';
-              frame-src 'none';
-              object-src 'none';
-              media-src 'none';
-              base-uri 'none';
-              form-action 'none';
-            ">
-            <script src="https://cdn.jsdelivr.net/npm/jsxgraph@1.10.0/distrib/jsxgraphcore.js"></script>
-            <script>
-              // Try to make a fetch request
-              fetch('https://example.com/malicious-test-request')
-                .catch(() => {});
+        const blob = new Blob([html], { type: "text/html" });
+        iframe.src = URL.createObjectURL(blob);
 
-              // Also try XMLHttpRequest
-              try {
-                const xhr = new XMLHttpRequest();
-                xhr.open('GET', 'https://example.com/malicious-xhr-request', true);
-                xhr.send();
-              } catch (e) {}
-
-              // Notify parent that we've attempted the requests
-              parent.postMessage({ type: 'test-done' }, '*');
-            </script>
-          </head>
-          <body>
-            <div id="jxgbox"></div>
-          </body>
-          </html>
-        `;
-
-        const blob = new Blob([iframeHtml], { type: "text/html" });
-        const blobUrl = URL.createObjectURL(blob);
-        iframe.src = blobUrl;
-
-        // Wait for the iframe to send the test-done message
         window.addEventListener("message", function handler(event) {
-          if (event.data?.type === "test-done") {
+          if (event.data?.type === "ready") {
             window.removeEventListener("message", handler);
-            resolve(undefined);
+            // Send malicious DSL via postMessage (same protocol as GraphSandbox)
+            iframe.contentWindow?.postMessage(
+              {
+                type: "render",
+                payload: `
+                  fetch('https://example.com/malicious-test-request').catch(() => {});
+                  try {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('GET', 'https://example.com/malicious-xhr-request', true);
+                    xhr.send();
+                  } catch (e) {}
+                `,
+              },
+              "*"
+            );
+
+            // Wait for any requests to be attempted, then signal completion
+            setTimeout(() => resolve(undefined), 1500);
           }
         });
 
         document.body.appendChild(iframe);
       });
-    });
+    }, generateIframeHtml());
 
-    // Wait a bit for any requests to go through
-    await page.waitForTimeout(1000);
+    // Wait for the iframe test to complete
+    await page.waitForTimeout(2000);
 
     // Verify no requests to example.com were made
-    const hasExampleComRequest = requestedUrls.some(url =>
-      url.includes("example.com")
-    );
-    expect(hasExampleComRequest).toBe(false);
+    expect(routeHit).toBe(false);
   });
 
   test("should block access to parent document from within the iframe", async ({ page }) => {
-    // Navigate to the app
     await page.goto("/");
 
-    // Inject a test iframe to check parent access
-    const result = await page.evaluate(() => {
+    // Inject iframe using real generateIframeHtml() with an appended parent-access probe
+    const result = await page.evaluate((html) => {
       return new Promise((resolve) => {
         const iframe = document.createElement("iframe");
         iframe.id = "test-parent-access-iframe";
@@ -112,32 +76,24 @@ test.describe("GraphSandbox Security", () => {
         iframe.style.left = "-9999px";
         iframe.style.top = "-9999px";
 
-        const iframeHtml = `
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta charset="UTF-8">
-            <script>
-              let parentAccessResult: { blocked: boolean; message?: string } = { blocked: false };
+        // Append a script that probes parent access before </body>
+        const probeScript = `
+          <script>
+            (function() {
+              let parentAccessResult = { blocked: false };
               try {
-                // Try to access parent.document
                 const _ = window.parent.document;
-                parentAccessResult = { blocked: false };
               } catch (e) {
                 parentAccessResult = { blocked: true, message: e instanceof Error ? e.message : String(e) };
               }
-
-              // Notify parent of the result
               parent.postMessage({ type: 'parent-access-result', result: parentAccessResult }, '*');
-            </script>
-          </head>
-          <body></body>
-          </html>
+            })();
+          </script>
         `;
+        const modifiedHtml = html.replace("</body>", `${probeScript}</body>`);
 
-        const blob = new Blob([iframeHtml], { type: "text/html" });
-        const blobUrl = URL.createObjectURL(blob);
-        iframe.src = blobUrl;
+        const blob = new Blob([modifiedHtml], { type: "text/html" });
+        iframe.src = URL.createObjectURL(blob);
 
         window.addEventListener("message", function handler(event) {
           if (event.data?.type === "parent-access-result") {
@@ -148,7 +104,7 @@ test.describe("GraphSandbox Security", () => {
 
         document.body.appendChild(iframe);
       });
-    });
+    }, generateIframeHtml());
 
     // Verify parent access was blocked
     expect((result as any).blocked).toBe(true);


### PR DESCRIPTION
## Summary

- Add restrictive Content Security Policy that blocks network requests, frames, objects, etc.
- Pin JSXGraph to version 1.10.0 from jsDelivr CDN
- Update component documentation to reflect security features
- Add tests for CSP and pinned JSXGraph version
- Export generateIframeHtml for testing purposes
- Add comments justifying CSP directives (unsafe-eval, unsafe-inline)
- Export JSXGRAPH_VERSION and JSXGRAPH_CDN_URL constants
- Add Playwright browser tests to verify blocked network requests and parent access
- Extract iframe generation into GraphSandbox.iframe.ts so Playwright tests consume the real production CSP/sandbox without duplicating it

## Linked Issue

Closes #292

## Issue Alignment

This PR implements the issue by:
- Adding a restrictive CSP that blocks network requests
- Pinning JSXGraph to a specific version instead of using latest
- Keeping the sandbox attribute as allow-scripts only

Scope covered:
- All GraphSandbox usage now has hardened security

Out of scope / intentionally not included:
- Not modifying the frontend DSL validator yet (that will be in #293)
- Not changing backend validation

## Implementation Notes

The CSP directives:
- default-src 'none': block everything by default
- script-src:
  - 'unsafe-eval': required for new Function('board', dsl) to execute the DSL
  - 'unsafe-inline': required for the inline <script> tag that sets up the sandbox
  - ${JSXGRAPH_CDN_URL}: only allow JSXGraph from our pinned CDN version
- style-src 'unsafe-inline': allow inline styles for JSXGraph rendering
- img-src data:: allow data URIs for JSXGraph images
- All other directives set to 'none' to block unnecessary capabilities

## Tests

Commands run:
- `npm run build` — passed
- `npm test -- --run src/components/GraphSandbox.test.tsx` — 20 tests passed
- `npm test -- --run` — 304 tests passed
- `npm run test:ui -- tests/graph-sandbox-security.spec.ts` — 2 tests passed
- `npm run test:smoke:compose` — 3 tests passed

Automated tests added or updated:
- Added test that verifies CSP is present with restrictive directives
- Added test that verifies pinned JSXGraph version is used
- Added Playwright tests in `graph-sandbox-security.spec.ts` that verify:
  - Blocked outbound fetch/XMLHttpRequest from within iframe (uses real `generateIframeHtml()` output and `page.route()` for deterministic assertion)
  - Blocked access to parent document from within iframe (uses real `generateIframeHtml()` output with `sandbox="allow-scripts"`)

Manual verification:
- Verified via Playwright browser tests that malicious DSL (`fetch`, `XMLHttpRequest`) inside the real iframe does not reach the network
- Verified via Playwright browser tests that `window.parent.document` access is blocked from within the sandboxed iframe

## Deviations From Issue Plan

- Extracted `generateIframeHtml()`, `JSXGRAPH_VERSION`, and `JSXGRAPH_CDN_URL` into `GraphSandbox.iframe.ts` so the Playwright security spec can import and test the real production HTML without duplicating the CSP string. This is a small structural change that improves regression-test integrity.

## Follow-Up Work

#293 will remove the frontend semantic DSL validator now that the iframe is hardened
