### PR TITLE
Restore legacy JSXGraph rendering by removing the frontend semantic DSL allowlist

### DIFF
--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -2,7 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
-import { GraphSandbox, validateDsl } from "./GraphSandbox";
+import { GraphSandbox, validateDsl, generateIframeHtml } from "./GraphSandbox";
+
+// Pinned JSXGraph version - keep in sync with GraphSandbox.tsx
+const JSXGRAPH_VERSION = "1.10.0";
+const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
 
 describe("GraphSandbox", () => {
   beforeEach(() => {
@@ -24,6 +28,27 @@ describe("GraphSandbox", () => {
     const iframe = screen.getByTestId("jsxgraph-iframe");
     expect(iframe).toBeInTheDocument();
     expect(iframe).toHaveAttribute("sandbox", "allow-scripts");
+  });
+
+  it("generates iframe HTML with restrictive Content Security Policy", () => {
+    const html = generateIframeHtml();
+
+    // Verify CSP meta tag exists with restrictive directives
+    expect(html).toContain("<meta http-equiv=\"Content-Security-Policy\"");
+    expect(html).toContain("default-src 'none'");
+    expect(html).toContain("connect-src 'none'");
+    expect(html).toContain("frame-src 'none'");
+    expect(html).toContain("object-src 'none'");
+    expect(html).toContain("base-uri 'none'");
+    expect(html).toContain("form-action 'none'");
+  });
+
+  it("generates iframe HTML with pinned JSXGraph version", () => {
+    const html = generateIframeHtml();
+
+    // Verify pinned JSXGraph URL is used
+    expect(html).toContain(JSXGRAPH_CDN_URL);
+    expect(html).not.toContain("https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js");
   });
 
   it("accepts custom width and height", () => {

--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -53,14 +53,14 @@ describe("GraphSandbox", () => {
 
   it("accepts custom width and height", () => {
     const { container } = render(<GraphSandbox dsl="" width={500} height={300} />);
-    const sandbox = container.querySelector('[data-testid="graph-sandbox"]') as HTMLElement;
+    const sandbox = container.querySelector('[data-testid="graph-sandbox"]');
     expect(sandbox.style.width).toBe("500px");
     expect(sandbox.style.height).toBe("300px");
   });
 
   it("accepts string width values", () => {
     const { container } = render(<GraphSandbox dsl="" width="80%" height={300} />);
-    const sandbox = container.querySelector('[data-testid="graph-sandbox"]') as HTMLElement;
+    const sandbox = container.querySelector('[data-testid="graph-sandbox"]');
     expect(sandbox.style.width).toBe("80%");
   });
 
@@ -74,28 +74,25 @@ describe("GraphSandbox", () => {
     expect(screen.getByTestId("jsxgraph-iframe")).toBeInTheDocument();
   });
 
-  it("allows the supported graph DSL subset", () => {
-    const dsl = [
-      "board.setBoundingBox([-1, 2, 6, -2])",
-      "var A = board.create('point', [0, 0], {name:'A'})",
-      "var B = board.create('point', [5, 0], {name:'B'})",
-      "board.create('segment', [A, B], {strokeWidth:2})",
-      "board.create('text', [2.5, 0.3, '490米'], {anchorX:'middle', fontSize:12})",
-    ].join(";");
-
+  it("allows setBoundingBox with multiple arguments", () => {
+    const dsl = "board.setBoundingBox([-2, 2, 4, -3], true);";
     expect(validateDsl(dsl)).toBeNull();
   });
 
-  it.each([
-    "fetch('/api/private'); board.create('point', [0, 0]);",
-    "while (true) { board.create('point', [0, 0]); }",
-    "window.location = 'https://example.com';",
-    "new Function('return document.cookie')();",
-    "board.constructor.constructor('return window')();",
-    "board.create('functiongraph', [function(x) { return x; }, -1, 1]);",
-    "board.create('point', [1 + 2, 0]);",
-  ])("rejects unsafe graph DSL: %s", (dsl) => {
-    expect(validateDsl(dsl)).not.toBeNull();
+  it("allows complex historical DSL", () => {
+    const dsl = `
+      board.setBoundingBox([-2, 2, 4, -3], true);
+      var a = board.create('point', [0, 0]);
+      var b = board.create('point', [1, 1]);
+      var c = board.create('segment', [a, b]);
+      var d = Math.sqrt(2);
+    `;
+    expect(validateDsl(dsl)).toBeNull();
+  });
+
+  it("rejects DSL that is too long", () => {
+    const dsl = "x".repeat(5001);
+    expect(validateDsl(dsl)).toBe("DSL is too long");
   });
 
   describe("prop change lifecycle", () => {

--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -77,13 +77,29 @@ describe("GraphSandbox", () => {
     expect(validateDsl(dsl)).toBeNull();
   });
 
-  it("allows complex historical DSL", () => {
+  it("allows complex historical DSL with arithmetic and coordinate methods", () => {
     const dsl = `
       board.setBoundingBox([-2, 2, 4, -3], true);
       var a = board.create('point', [0, 0]);
       var b = board.create('point', [1, 1]);
       var c = board.create('segment', [a, b]);
       var d = Math.sqrt(2);
+      var e = board.create('point', [a.X() + 1, a.Y() - 1]);
+      var f = (a.X() + b.X()) / 2;
+    `;
+    expect(validateDsl(dsl)).toBeNull();
+  });
+
+  it("allows second stored problem DSL shape with multi-var declarations", () => {
+    const dsl = `
+      board.setBoundingBox([-3, 3, 3, -3], true);
+      var p1 = board.create('point', [-1, 1]),
+          p2 = board.create('point', [2, -1]),
+          p3 = board.create('point', [0, 2]);
+      var poly = board.create('polygon', [p1, p2, p3]);
+      var area = Math.abs(p1.X() * (p2.Y() - p3.Y()) +
+                          p2.X() * (p3.Y() - p1.Y()) +
+                          p3.X() * (p1.Y() - p2.Y())) / 2;
     `;
     expect(validateDsl(dsl)).toBeNull();
   });
@@ -232,6 +248,49 @@ describe("GraphSandbox", () => {
       // Wait a bit and verify no additional render messages
       await new Promise(resolve => setTimeout(resolve, 100));
       expect(postMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it("surfaces invalid JavaScript syntax errors through iframe error protocol", async () => {
+      const invalidDsl = "var = = board.create('point', [0, 0]);";
+      const postMessageSpy = vi.fn();
+      const mockContentWindow = { postMessage: postMessageSpy };
+
+      render(<GraphSandbox dsl={invalidDsl} />);
+
+      const iframe = screen.getByTestId("jsxgraph-iframe") as HTMLIFrameElement;
+
+      Object.defineProperty(iframe, "contentWindow", {
+        value: mockContentWindow,
+        writable: true,
+      });
+
+      // Simulate iframe sending "ready" message
+      const readyEvent = new MessageEvent("message", {
+        source: mockContentWindow as unknown as Window,
+        data: { type: "ready" },
+      });
+      window.dispatchEvent(readyEvent);
+
+      // Wait for render message to be sent
+      await waitFor(() => {
+        expect(postMessageSpy).toHaveBeenCalledWith(
+          { type: "render", payload: invalidDsl },
+          "*"
+        );
+      });
+
+      // Simulate iframe reporting a syntax error (as it would from new Function())
+      const syntaxErrorEvent = new MessageEvent("message", {
+        source: mockContentWindow as unknown as Window,
+        data: { type: "error", payload: "SyntaxError: Unexpected token '='" },
+      });
+      window.dispatchEvent(syntaxErrorEvent);
+
+      // Error UI should appear with the syntax error message
+      await waitFor(() => {
+        expect(screen.getByText("Rendering Error")).toBeInTheDocument();
+      });
+      expect(screen.getByText("SyntaxError: Unexpected token '='")).toBeInTheDocument();
     });
 
     it("clears lastSentDslRef when iframe is reset", async () => {

--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -49,14 +49,16 @@ describe("GraphSandbox", () => {
 
   it("accepts custom width and height", () => {
     const { container } = render(<GraphSandbox dsl="" width={500} height={300} />);
-    const sandbox = container.querySelector('[data-testid="graph-sandbox"]');
+    const sandbox = container.querySelector('[data-testid="graph-sandbox"]') as HTMLElement;
+    expect(sandbox).toBeTruthy();
     expect(sandbox.style.width).toBe("500px");
     expect(sandbox.style.height).toBe("300px");
   });
 
   it("accepts string width values", () => {
     const { container } = render(<GraphSandbox dsl="" width="80%" height={300} />);
-    const sandbox = container.querySelector('[data-testid="graph-sandbox"]');
+    const sandbox = container.querySelector('[data-testid="graph-sandbox"]') as HTMLElement;
+    expect(sandbox).toBeTruthy();
     expect(sandbox.style.width).toBe("80%");
   });
 

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -1,68 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-const ALLOWED_ELEMENT_TYPES = new Set([
-  "point",
-  "segment",
-  "line",
-  "arrow",
-  "circle",
-  "angle",
-  "polygon",
-  "text",
-  "glider",
-  "intersection",
-  "midpoint",
-  "perpendicular",
-]);
-
-const ALLOWED_OPTION_KEYS = new Set([
-  "anchorX",
-  "anchorY",
-  "color",
-  "dash",
-  "face",
-  "fillColor",
-  "fillOpacity",
-  "fixed",
-  "fontSize",
-  "highlight",
-  "label",
-  "name",
-  "opacity",
-  "radius",
-  "showInfobox",
-  "size",
-  "strokeColor",
-  "strokeOpacity",
-  "strokeWidth",
-  "visible",
-  "withLabel",
-]);
-
-const BLOCKED_TOKENS = [
-  "constructor",
-  "document",
-  "eval",
-  "fetch",
-  "for",
-  "function",
-  "globalThis",
-  "if",
-  "import",
-  "localStorage",
-  "new",
-  "prototype",
-  "return",
-  "sessionStorage",
-  "setInterval",
-  "setTimeout",
-  "this",
-  "while",
-  "window",
-  "XMLHttpRequest",
-  "__proto__",
-];
-
 // Timeout for rendering operations (30 seconds)
 const RENDER_TIMEOUT_MS = 30000;
 
@@ -83,216 +20,8 @@ export interface GraphSandboxProps {
   onRender?: () => void;
 }
 
-function stripQuotedStrings(value: string): string {
-  return value.replace(/'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*"/g, "");
-}
-
-function splitTopLevel(value: string, delimiter: string): string[] | null {
-  const parts: string[] = [];
-  let start = 0;
-  let depth = 0;
-  let quote: string | null = null;
-  let escaped = false;
-
-  for (let i = 0; i < value.length; i += 1) {
-    const char = value[i];
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = null;
-      }
-      continue;
-    }
-
-    if (char === "'" || char === '"') {
-      quote = char;
-    } else if (char === "[" || char === "{" || char === "(") {
-      depth += 1;
-    } else if (char === "]" || char === "}" || char === ")") {
-      depth -= 1;
-      if (depth < 0) {
-        return null;
-      }
-    } else if (char === delimiter && depth === 0) {
-      parts.push(value.slice(start, i).trim());
-      start = i + 1;
-    }
-  }
-
-  if (quote || depth !== 0) {
-    return null;
-  }
-
-  const last = value.slice(start).trim();
-  if (last) {
-    parts.push(last);
-  }
-  return parts;
-}
-
-function splitStatements(dsl: string): string[] | null {
-  const statements = splitTopLevel(dsl, ";");
-  if (!statements) {
-    return null;
-  }
-  return statements.filter(Boolean);
-}
-
-function isStringLiteral(value: string): boolean {
-  return /^'(?:\\.|[^'\\])*'$|^"(?:\\.|[^"\\])*"$/.test(value);
-}
-
-function unquote(value: string): string {
-  return value.slice(1, -1);
-}
-
-function validateObjectLiteral(
-  value: string,
-  declaredNames: Set<string>,
-): string | null {
-  if (!value.startsWith("{") || !value.endsWith("}")) {
-    return "Expected an object literal";
-  }
-
-  const inner = value.slice(1, -1).trim();
-  if (!inner) {
-    return null;
-  }
-
-  const entries = splitTopLevel(inner, ",");
-  if (!entries) {
-    return "Object literal has unbalanced syntax";
-  }
-
-  for (const entry of entries) {
-    const keyValue = splitTopLevel(entry, ":");
-    if (!keyValue || keyValue.length !== 2) {
-      return "Object literal entries must be key-value pairs";
-    }
-    const key = keyValue[0].trim().replace(/^['"]|['"]$/g, "");
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key) || !ALLOWED_OPTION_KEYS.has(key)) {
-      return `Unsupported option key: ${key}`;
-    }
-    const valueError = validateDslValue(keyValue[1], declaredNames);
-    if (valueError) {
-      return valueError;
-    }
-  }
-
-  return null;
-}
-
-function validateDslValue(value: string, declaredNames: Set<string>): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return "Empty DSL value";
-  }
-  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
-    return null;
-  }
-  if (isStringLiteral(trimmed)) {
-    return null;
-  }
-  if (trimmed === "true" || trimmed === "false" || trimmed === "null") {
-    return null;
-  }
-  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmed)) {
-    return declaredNames.has(trimmed) ? null : `Unknown identifier: ${trimmed}`;
-  }
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-    const inner = trimmed.slice(1, -1).trim();
-    if (!inner) {
-      return null;
-    }
-    const items = splitTopLevel(inner, ",");
-    if (!items) {
-      return "Array literal has unbalanced syntax";
-    }
-    for (const item of items) {
-      const itemError = validateDslValue(item, declaredNames);
-      if (itemError) {
-        return itemError;
-      }
-    }
-    return null;
-  }
-  if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
-    return validateObjectLiteral(trimmed, declaredNames);
-  }
-  return `Unsupported DSL value: ${trimmed}`;
-}
-
-function validateCreateCall(call: string, declaredNames: Set<string>): string | null {
-  if (!call.startsWith("board.create(") || !call.endsWith(")")) {
-    return "Only board.create(...) calls are allowed";
-  }
-
-  const args = splitTopLevel(call.slice("board.create(".length, -1), ",");
-  if (!args || args.length < 2 || args.length > 3) {
-    return "board.create requires two or three arguments";
-  }
-
-  const typeArg = args[0].trim();
-  if (!isStringLiteral(typeArg)) {
-    return "board.create element type must be a string literal";
-  }
-  const elementType = unquote(typeArg);
-  if (!ALLOWED_ELEMENT_TYPES.has(elementType)) {
-    return `Unsupported JSXGraph element type: ${elementType}`;
-  }
-
-  const parentsError = validateDslValue(args[1], declaredNames);
-  if (parentsError) {
-    return parentsError;
-  }
-
-  if (args[2]) {
-    return validateObjectLiteral(args[2].trim(), declaredNames);
-  }
-
-  return null;
-}
-
-function validateStatement(statement: string, declaredNames: Set<string>): string | null {
-  const trimmed = statement.trim();
-  const boundingBoxMatch = trimmed.match(/^board\.setBoundingBox\((.*)\)$/);
-  if (boundingBoxMatch) {
-    const value = boundingBoxMatch[1].trim();
-    const parts = value.startsWith("[") && value.endsWith("]")
-      ? splitTopLevel(value.slice(1, -1), ",")
-      : null;
-    if (!parts || parts.length !== 4 || parts.some((part) => !/^-?\d+(?:\.\d+)?$/.test(part.trim()))) {
-      return "board.setBoundingBox must use four numeric literals";
-    }
-    return null;
-  }
-
-  const declarationMatch = trimmed.match(/^var\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(board\.create\(.*\))$/);
-  if (declarationMatch) {
-    const [, name, call] = declarationMatch;
-    if (declaredNames.has(name)) {
-      return `Duplicate DSL variable: ${name}`;
-    }
-    const callError = validateCreateCall(call, declaredNames);
-    if (callError) {
-      return callError;
-    }
-    declaredNames.add(name);
-    return null;
-  }
-
-  if (trimmed.startsWith("board.create(")) {
-    return validateCreateCall(trimmed, declaredNames);
-  }
-
-  return "Only var declarations, board.setBoundingBox, and board.create calls are allowed";
-}
-
 /**
- * Validates model-generated JSXGraph DSL against a strict allowlist.
+ * Validates JSXGraph DSL with lightweight checks.
  * Returns null if valid, error message if invalid.
  */
 export function validateDsl(dsl: string): string | null {
@@ -303,31 +32,6 @@ export function validateDsl(dsl: string): string | null {
   if (stripped.length > 5000) {
     return "DSL is too long";
   }
-
-  const unquoted = stripQuotedStrings(stripped);
-  if (/=>|`|\/\/|\/\*|\*\/|\+\+|--/.test(unquoted)) {
-    return "DSL contains unsupported JavaScript syntax";
-  }
-  for (const token of BLOCKED_TOKENS) {
-    const pattern = new RegExp(`\\b${token}\\b`, "i");
-    if (pattern.test(unquoted)) {
-      return `DSL contains forbidden token: ${token}`;
-    }
-  }
-
-  const statements = splitStatements(stripped);
-  if (!statements) {
-    return "DSL has unbalanced statement syntax";
-  }
-
-  const declaredNames = new Set<string>();
-  for (const statement of statements) {
-    const statementError = validateStatement(statement, declaredNames);
-    if (statementError) {
-      return statementError;
-    }
-  }
-
   return null;
 }
 
@@ -386,7 +90,7 @@ export function generateIframeHtml(): string {
       // Message handler for postMessage protocol
       function handleMessage(event) {
         const data = event.data;
-        
+
         if (!data || typeof data !== 'object') {
           return;
         }
@@ -430,8 +134,8 @@ export function generateIframeHtml(): string {
           parent.postMessage({ type: 'rendered' }, '*');
         } catch (error) {
           // Notify parent of error
-          parent.postMessage({ 
-            type: 'error', 
+          parent.postMessage({
+            type: 'error',
             payload: error instanceof Error ? error.message : String(error)
           }, '*');
         }
@@ -478,7 +182,7 @@ interface MessagePayload {
  * - iframe with sandbox="allow-scripts" (no allow-same-origin, no allow-forms)
  * - Restrictive Content Security Policy (CSP) blocking all network requests and unsafe operations
  * - Pinned JSXGraph version from trusted CDN
- * - DSL validation against denylist patterns
+ * - Lightweight DSL size validation
  * - Timeout handling with iframe recreation
  * - No external API access from iframe
  */
@@ -570,7 +274,7 @@ export function GraphSandbox({
       return;
     }
 
-    // Validate DSL against denylist
+    // Validate DSL
     const validationError = validateDsl(dsl);
     if (validationError) {
       setStatus("error");

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -66,6 +66,10 @@ const BLOCKED_TOKENS = [
 // Timeout for rendering operations (30 seconds)
 const RENDER_TIMEOUT_MS = 30000;
 
+// Pinned JSXGraph version for security and stability
+const JSXGRAPH_VERSION = "1.10.0";
+const JSXGRAPH_CDN_URL = `https://cdn.jsdelivr.net/npm/jsxgraph@${JSXGRAPH_VERSION}/distrib/jsxgraphcore.js`;
+
 export interface GraphSandboxProps {
   /** The JSXGraph DSL code to render */
   dsl: string;
@@ -330,14 +334,28 @@ export function validateDsl(dsl: string): string | null {
 /**
  * Generates the iframe HTML content with JSXGraph loader.
  * This is loaded into the sandboxed iframe.
+ * Exported for testing only.
  */
-function generateIframeHtml(): string {
+export function generateIframeHtml(): string {
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="
+    default-src 'none';
+    script-src 'unsafe-eval' 'unsafe-inline' ${JSXGRAPH_CDN_URL};
+    style-src 'unsafe-inline';
+    img-src data:;
+    connect-src 'none';
+    font-src 'none';
+    frame-src 'none';
+    object-src 'none';
+    media-src 'none';
+    base-uri 'none';
+    form-action 'none';
+  ">
   <title>JSXGraph Sandbox</title>
-  <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
+  <script src="${JSXGRAPH_CDN_URL}"></script>
   <style>
     html, body {
       margin: 0;
@@ -453,11 +471,13 @@ interface MessagePayload {
 
 /**
  * GraphSandbox Component
- * 
+ *
  * Renders JSXGraph DSL in a sandboxed iframe with strict postMessage protocol.
- * 
+ *
  * Security features:
  * - iframe with sandbox="allow-scripts" (no allow-same-origin, no allow-forms)
+ * - Restrictive Content Security Policy (CSP) blocking all network requests and unsafe operations
+ * - Pinned JSXGraph version from trusted CDN
  * - DSL validation against denylist patterns
  * - Timeout handling with iframe recreation
  * - No external API access from iframe


### PR DESCRIPTION
## Summary

- Remove all semantic validation from GraphSandbox.validateDsl
- Keep only the size check (max 5000 chars)
- Update tests to reflect the change
- Add tests for complex historical DSL and setBoundingBox with multiple args
- Adopt GraphSandbox.iframe.ts module (from merged #294) for generateIframeHtml and constants

## Linked Issue

Closes #293

## Issue Alignment

This PR implements the issue by:
- Removing the frontend semantic allowlists for element types, option keys, statement forms, and blocked JavaScript tokens
- Replacing validateDsl with just a size check
- Updating stale comments that claimed the frontend was enforcing a strict DSL allowlist

Scope covered:
- All GraphSandbox usage now allows full JSXGraph DSL

Out of scope / intentionally not included:
- Not weakening iframe sandbox flags or CSP
- Not modifying stored MongoDB graph data
- Not building or maintaining a fuller JavaScript parser
- Not changing the backend _is_allowed_graph_dsl sanitizer used for VLM-generated coaching whiteboards

## Implementation Notes

The historical problem DSL (like board.setBoundingBox([-2, 2, 4, -3], true)) now works as-is.

## Tests

Commands run:
- `npm test -- --run src/components/GraphSandbox.test.tsx` — 17 tests passed
- `npm test -- --run` — 299 tests passed
- `npm run build` — passed
- `npm run test:smoke:compose` — 3 tests passed

Automated tests added or updated:
- Added test that allows setBoundingBox with multiple arguments
- Added test that allows complex historical DSL (first problem shape, with arithmetic and X()/Y())
- Added test that allows second stored problem DSL shape (multi-variable declarations, polygon construction)
- Added test that surfaces invalid JavaScript syntax errors through iframe error protocol
- Updated test that verifies the size limit
- Removed tests that checked for semantic validation

Manual verification:
1. **Open `http://localhost:8080/problems/6a17020044f95e79a52c15ca` authenticated and confirm graph renders** — ⏸️ Infeasible in headless agent environment. No authenticated browser session available. Substituted by:
   - Regression fixture representing this problem's DSL shape passes unit test (reaches iframe, no validation error)
   - `npm run build` passes (no TypeScript errors in rendering path)
2. **Verify second active graph problem renders** — ⏸️ Infeasible in headless agent environment. No authenticated browser session available. Substituted by:
   - Second regression fixture representing the other problem shape (`6a25846d7fc2a674734411f5`) passes unit test
3. **Verify a practice/exam graph renders** — ⏸️ Infeasible in headless agent environment. No authenticated browser session available. Substituted by:
   - Existing lifecycle tests prove the render → ready → rendered flow works with any valid DSL
4. **Confirm browser security tests still pass** — ✅ Verified:
   ```bash
   cd frontend && npx playwright test tests/graph-sandbox-security.spec.ts
   ```
   Results: 2 passed (18.0s)
   - `should block outbound fetch requests from within the iframe` (8.5s)
   - `should block access to parent document from within the iframe` (5.2s)

## Deviations From Issue Plan

- Adopted `GraphSandbox.iframe.ts` module from merged #294 instead of keeping inline `generateIframeHtml` — this is a structural alignment with master, not a functional change.

## Follow-Up Work

None
