### PR TITLE
Add Playwright E2E tests to CI pipeline

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -109,6 +109,8 @@ jobs:
           docker compose --profile bootstrap run --rm rustfs-bootstrap
         env:
           DOCKER_BUILDKIT: 1
+          S3_ACCESS_KEY: minioadmin
+          S3_SECRET_KEY: minioadmin
 
       - name: Wait for MongoDB replica set
         run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,6 +57,49 @@ jobs:
         working-directory: frontend
         run: npm test -- --run
 
+  playwright-tests:
+    name: Playwright E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          python-version: "3.11"
+          enable-cache: true
+          cache-dependency-glob: |
+            backend/pyproject.toml
+            backend/uv.lock
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright E2E tests
+        working-directory: frontend
+        run: npm run test:ui
+
   docker-smoke-test:
     name: Docker Compose Smoke Test
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,6 +61,7 @@ jobs:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    continue-on-error: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v5

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -61,7 +61,6 @@ jobs:
     name: Playwright E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    continue-on-error: true
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
@@ -129,7 +128,7 @@ jobs:
 
       - name: Run Playwright E2E tests
         working-directory: frontend
-        run: npm run test:ui
+        run: npm run test:ui -- tests/graph-sandbox-security.spec.ts
         env:
           MONGODB_URI: mongodb://localhost:27017/learnloop?replicaSet=rs0&directConnection=true
           S3_ENDPOINT: http://localhost:9000

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -96,9 +96,46 @@ jobs:
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create .env file and start infrastructure services
+        run: |
+          mkdir -p backend
+          echo "VLM_API_KEY=ci-placeholder" >> backend/.env
+          echo "S3_ACCESS_KEY=minioadmin" >> backend/.env
+          echo "S3_SECRET_KEY=minioadmin" >> backend/.env
+          docker compose up -d mongodb rustfs
+          docker compose --profile bootstrap run --rm rustfs-bootstrap
+        env:
+          DOCKER_BUILDKIT: 1
+
+      - name: Wait for MongoDB replica set
+        run: |
+          for i in {1..30}; do
+            if docker compose exec -T mongodb mongosh --quiet --host 127.0.0.1 --port 27017 --eval 'try { rs.status().ok === 1 ? quit(0) : quit(1) } catch (error) { quit(1) }'; then
+              echo "MongoDB replica set is ready"
+              exit 0
+            fi
+            echo "Waiting for MongoDB... ($i)"
+            sleep 2
+          done
+          echo "MongoDB did not become ready in time"
+          docker compose logs mongodb
+          exit 1
+
       - name: Run Playwright E2E tests
         working-directory: frontend
         run: npm run test:ui
+        env:
+          MONGODB_URI: mongodb://localhost:27017/learnloop?replicaSet=rs0&directConnection=true
+          S3_ENDPOINT: http://localhost:9000
+          S3_ACCESS_KEY: minioadmin
+          S3_SECRET_KEY: minioadmin
+
+      - name: Tear down infrastructure
+        if: always()
+        run: docker compose down --volumes
 
   docker-smoke-test:
     name: Docker Compose Smoke Test

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Wait for MongoDB replica set
         run: |
           for i in {1..30}; do
-            if docker compose exec -T mongodb mongosh --quiet --host 127.0.0.1 --port 27017 --eval 'try { rs.status().ok === 1 ? quit(0) : quit(1) } catch (error) { quit(1) }'; then
+            if docker compose exec -T mongodb mongo --quiet --host 127.0.0.1 --port 27017 --eval 'try { rs.status().ok === 1 ? quit(0) : quit(1) } catch (error) { quit(1) }'; then
               echo "MongoDB replica set is ready"
               exit 0
             fi

--- a/frontend/src/components/GraphSandbox.iframe.ts
+++ b/frontend/src/components/GraphSandbox.iframe.ts
@@ -26,7 +26,7 @@ export function generateIframeHtml(): string {
     script-src 'unsafe-eval' 'unsafe-inline' ${JSXGRAPH_CDN_URL};
     style-src 'unsafe-inline';
     img-src data:;
-    connect-src 'none';
+    connect-src *;
     font-src 'none';
     frame-src 'none';
     object-src 'none';

--- a/frontend/src/components/GraphSandbox.iframe.ts
+++ b/frontend/src/components/GraphSandbox.iframe.ts
@@ -26,7 +26,7 @@ export function generateIframeHtml(): string {
     script-src 'unsafe-eval' 'unsafe-inline' ${JSXGRAPH_CDN_URL};
     style-src 'unsafe-inline';
     img-src data:;
-    connect-src *;
+    connect-src 'none';
     font-src 'none';
     frame-src 'none';
     object-src 'none';


### PR DESCRIPTION
## Summary

- Add `playwright-tests` job to `.github/workflows/pr-checks.yml`
- Set up Node.js (v20) and uv (Python 3.11) using the same actions as existing jobs
- Install frontend dependencies and Playwright browsers with caching
- Start MongoDB and S3 (RustFS) infrastructure via Docker Compose before tests
- Run Playwright security specs (`tests/graph-sandbox-security.spec.ts`) on every PR

## Linked Issue

Closes #296

## Issue Alignment

This PR implements the issue by:
- Adding a CI job that runs Playwright E2E tests
- Ensuring the job uses the same Node.js/npm setup as the existing frontend test job
- Caching Playwright browser binaries between runs
- Setting up required backend infrastructure (MongoDB replica set + S3) so the backend server can start

Scope covered:
- CI job for Playwright tests
- Browser binary caching
- Docker Compose infrastructure setup (MongoDB + RustFS)
- S3 bucket bootstrapping

Out of scope / intentionally not included:
- Not adding new Playwright tests (existing tests are sufficient)
- Not modifying Playwright configuration files
- Not changing existing vitest or Docker smoke jobs
- Not adding `test:smoke:compose` to CI
- Not fixing pre-existing failing tests in practice.spec.ts and theme.spec.ts (scoped to security specs only; see Follow-Up Work)

## Implementation Notes

The new `playwright-tests` job:
1. Checks out the repo
2. Sets up Node.js v20 with npm cache
3. Sets up uv with Python 3.11 (needed for the backend server that Playwright tests spin up)
4. Installs frontend dependencies via `npm ci`
5. Caches Playwright browsers at `~/.cache/ms-playwright`
6. Installs Chromium browser with system deps via `npx playwright install --with-deps chromium`
7. Sets up Docker Buildx
8. Creates `backend/.env` with placeholder credentials and exports S3 credentials for Docker Compose
9. Starts MongoDB and RustFS via `docker compose up -d mongodb rustfs`
10. Bootstraps the S3 bucket via `docker compose --profile bootstrap run --rm rustfs-bootstrap`
11. Waits for MongoDB replica set to be ready
12. Runs `npm run test:ui -- tests/graph-sandbox-security.spec.ts`
13. Tears down infrastructure after tests complete

## Tests

Commands run:
- Workflow syntax validated via GitHub Actions schema

Automated tests added or updated:
- The new CI job itself serves as the test

Manual verification:
1. **Confirm the Playwright job appears and passes** — ✅ Verified. CI run shows all 4 checks green (Backend ✅, Frontend ✅, Playwright E2E Tests ✅, Docker Compose Smoke Test ✅).
2. **Negative test: confirm breaking a CSP directive causes the security test to fail** — ✅ Verified:
   - Commit `4d2571f` temporarily changed `connect-src 'none'` to `connect-src *`
   - CI run [27805988299](https://github.com/brianlan/LearnLoop/actions/runs/27805988299) shows Playwright E2E Tests **FAILED** (1 failed — security spec caught the CSP regression: `expect(routeHit).toBe(false)` failed because the route was hit)
   - Reverted in commit `e460c1d`; subsequent CI run [27806067922](https://github.com/brianlan/LearnLoop/actions/runs/27806067922) shows Playwright E2E Tests **PASSED**

## Deviations From Issue Plan

- Added infrastructure setup steps because the Playwright tests spin up a backend server that requires a MongoDB replica set and S3-compatible storage.
- Scoped the CI job to `tests/graph-sandbox-security.spec.ts` only (instead of the full suite) because the remaining E2E specs (practice.spec.ts, theme.spec.ts) have 7 pre-existing failures unrelated to this issue. Per reviewer feedback, scoping ensures a green job.

## Follow-Up Work

- Issue #298: Bring the full E2E suite (practice.spec.ts, theme.spec.ts, teacher-password.spec.ts) into CI by fixing the pre-existing test failures.