### PR TITLE
Enable full Playwright E2E suite in CI

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Run Playwright E2E tests
         working-directory: frontend
-        run: npm run test:ui -- tests/graph-sandbox-security.spec.ts
+        run: npm run test:ui
         env:
           MONGODB_URI: mongodb://localhost:27017/learnloop?replicaSet=rs0&directConnection=true
           S3_ENDPOINT: http://localhost:9000

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   },
   webServer: [
     {
-      command: "MATH_INGESTION_VLM_ENDPOINT=http://127.0.0.1:9 MATH_INGESTION_VLM_TIMEOUT_SECONDS=1 ENGLISH_INGESTION_VLM_ENDPOINT=http://127.0.0.1:9 ENGLISH_INGESTION_VLM_TIMEOUT_SECONDS=1 uv run --directory ../backend uvicorn app.main:app --host 127.0.0.1 --port 18000",
+      command: "MATH_INGESTION_VLM_ENDPOINT=http://127.0.0.1:9 MATH_INGESTION_VLM_TIMEOUT_SECONDS=1 ENGLISH_INGESTION_VLM_ENDPOINT=http://127.0.0.1:9 ENGLISH_INGESTION_VLM_TIMEOUT_SECONDS=1 PROBLEM_SELECTION_MIN_AGE_DAYS=0 uv run --directory ../backend uvicorn app.main:app --host 127.0.0.1 --port 18000",
       url: "http://127.0.0.1:18000/api/health",
       name: "Backend",
       reuseExistingServer: false,

--- a/frontend/tests/theme.spec.ts
+++ b/frontend/tests/theme.spec.ts
@@ -178,8 +178,8 @@ test.describe("Theme E2E", () => {
     await expect(header).toBeVisible();
 
     // Verify nav items are visible
-    await expect(page.getByRole("button", { name: "Problems" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Primary" }).getByRole("button", { name: "Problems" })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Primary" }).getByRole("button", { name: "Settings" })).toBeVisible();
 
     // Toggle to dark
     await page.getByRole("button", { name: "Toggle theme" }).click();
@@ -189,8 +189,8 @@ test.describe("Theme E2E", () => {
     await expect(header).toBeVisible();
 
     // Verify nav items remain visible
-    await expect(page.getByRole("button", { name: "Problems" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Primary" }).getByRole("button", { name: "Problems" })).toBeVisible();
+    await expect(page.getByRole("navigation", { name: "Primary" }).getByRole("button", { name: "Settings" })).toBeVisible();
   });
 });
 
@@ -356,7 +356,7 @@ test.describe("Tags Page Theme", () => {
     await expect(page.getByRole("heading", { name: "Tags" })).toBeVisible();
 
     // Verify create tag button is visible
-    await expect(page.getByRole("button", { name: "Create Tag" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Tag" })).toBeVisible();
   });
 
   test("tags page renders in dark theme", async ({ page, request }) => {
@@ -374,7 +374,7 @@ test.describe("Tags Page Theme", () => {
     await expect(page.getByRole("heading", { name: "Tags" })).toBeVisible();
 
     // Verify create tag button is visible
-    await expect(page.getByRole("button", { name: "Create Tag" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Tag" })).toBeVisible();
   });
 
   test("tags page dark theme paints a full-page themed background", async ({ page, request }) => {


### PR DESCRIPTION
## Summary

- Fix stale Playwright assertions in the theme E2E tests.
- Configure Playwright's backend web server with `PROBLEM_SELECTION_MIN_AGE_DAYS=0` so freshly seeded E2E problems are immediately practiceable.
- Expand the Playwright CI job from the graph sandbox security spec to the full `npm run test:ui` suite.

## Linked Issue

Closes #298

## Issue Alignment

This PR implements the issue by:

- Reproducing the 7 pre-existing full-suite Playwright failures.
- Fixing the practice failures caused by freshly seeded problems being excluded by the production min-age selection rule in the E2E environment.
- Updating stale theme assertions for the current app shell/tag page UI.
- Removing the CI spec filter so the Playwright job runs the full suite.

Scope covered:

- Full Playwright suite passes locally.
- CI Playwright command now runs `npm run test:ui` without spec scoping.

Out of scope / intentionally not included:

- No production practice-selection behavior changes.
- No new E2E scenarios beyond fixing existing failing assertions/config.

## Implementation Notes

- `frontend/playwright.config.ts` now starts the backend with `PROBLEM_SELECTION_MIN_AGE_DAYS=0`, keeping the production default unchanged while making seeded E2E problems eligible immediately.
- Theme tests now scope the app-shell navigation lookup to `navigation[name=Primary]` to avoid matching the `Show All Problems` control.
- Tags page theme tests now assert the actual visible `Add Tag` button.

## Tests

Commands run:

- `docker compose up -d mongodb rustfs && docker compose --profile bootstrap run --rm rustfs-bootstrap` — passed
- `cd frontend && npm ci` — passed
- `cd frontend && npm run test:ui` before fixes — failed with 7 expected pre-existing failures / 40 passed
- `cd frontend && npm run test:ui` after fixes — passed, 47 passed

Automated tests added or updated:

- Updated `frontend/tests/theme.spec.ts` assertions to match current UI.
- Updated Playwright backend test environment config for practice eligibility.

Manual verification:

- Confirmed the full local Playwright suite now passes with all 47 tests.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
