### PR TITLE
Add sortable Problems Page

### DIFF
--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from datetime import UTC, datetime
 import re
 
-from typing import Any, Annotated
+from typing import Any, Annotated, Literal
 
 from bson import ObjectId
 from fastapi import APIRouter, Depends, Query
@@ -119,6 +119,10 @@ class BulkSetFolderResponse(BaseModel):
 
 
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
+ProblemSortBy = Literal["selectionScore", "addDate", "lastTestDate"]
+ProblemSortOrder = Literal["asc", "desc"]
+
+
 
 
 def _serialize_tracking(problem: dict[str, Any]) -> TrackingPayload:
@@ -184,6 +188,56 @@ def _serialize_problem_detail(problem: dict[str, Any]) -> ProblemDetailPayload:
     )
 
 
+def _practice_selection_config(settings: Settings) -> PracticeSelectionConfig:
+    return PracticeSelectionConfig(
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
+        min_problem_age_days=settings.problem_selection_min_age_days,
+    )
+
+
+def _problem_id_sort_value(problem: dict[str, Any]) -> str:
+    return str(problem["_id"])
+
+
+def _sort_by_last_test_date(
+    problems: list[dict[str, Any]],
+    *,
+    reverse: bool,
+) -> list[dict[str, Any]]:
+    tested = [problem for problem in problems if problem.get("tracking", {}).get("lastTestedAt") is not None]
+    never_tested = [problem for problem in problems if problem.get("tracking", {}).get("lastTestedAt") is None]
+    tested.sort(key=_problem_id_sort_value)
+    tested.sort(
+        key=lambda problem: problem.get("tracking", {})["lastTestedAt"],
+        reverse=reverse,
+    )
+    never_tested.sort(key=_problem_id_sort_value)
+    return tested + never_tested
+
+
+def _sort_by_selection_score(
+    problems: list[dict[str, Any]],
+    *,
+    reverse: bool,
+    settings: Settings,
+) -> list[dict[str, Any]]:
+    config = _practice_selection_config(settings)
+    now = datetime.now(UTC)
+    scored = [
+        (
+            compute_problem_weight_breakdown(problem_document_to_model(problem), config, now).total,
+            problem,
+        )
+        for problem in problems
+    ]
+    scored.sort(key=lambda item: _problem_id_sort_value(item[1]))
+    scored.sort(key=lambda item: item[0], reverse=reverse)
+    return [problem for _, problem in scored]
+
+
 @router.get("/tags", response_model=ProblemTagsResponse)
 async def list_problem_tags(
     database: DatabaseDependency,
@@ -200,10 +254,13 @@ async def list_problem_tags(
 async def list_problems(
     database: DatabaseDependency,
     current_user: CurrentUserDependency,
+    settings: Annotated[Settings, Depends(get_settings)],
     tag: str | None = Query(default=None),
     problem_type: ProblemType | None = Query(default=None, alias="type"),
     q: str | None = Query(default=None),
     folder_id: str | None = Query(default=None, alias="folderId"),
+    sort_by: ProblemSortBy | None = Query(default=None, alias="sortBy"),
+    sort_order: ProblemSortOrder | None = Query(default=None, alias="sortOrder"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
 ) -> ProblemListResponse:
@@ -236,9 +293,24 @@ async def list_problems(
             query["folderId"] = {"$in": [str(fid) for fid in all_folder_ids]}
 
     total = await database["problems"].count_documents(query)
-    cursor = database["problems"].find(query).sort("updatedAt", -1)
-    cursor = cursor.skip((page - 1) * page_size).limit(page_size)
-    items = await cursor.to_list(length=page_size)
+    skip = (page - 1) * page_size
+    effective_sort_order = sort_order or "desc"
+    if sort_by is None:
+        cursor = database["problems"].find(query).sort("updatedAt", -1)
+        items = await cursor.skip(skip).limit(page_size).to_list(length=page_size)
+    elif sort_by == "addDate":
+        direction = 1 if effective_sort_order == "asc" else -1
+        cursor = database["problems"].find(query).sort([("createdAt", direction), ("_id", 1)])
+        items = await cursor.skip(skip).limit(page_size).to_list(length=page_size)
+    else:
+        all_items = await database["problems"].find(query).to_list(length=None)
+        reverse = effective_sort_order == "desc"
+        if sort_by == "lastTestDate":
+            sorted_items = _sort_by_last_test_date(all_items, reverse=reverse)
+        else:
+            sorted_items = _sort_by_selection_score(all_items, reverse=reverse, settings=settings)
+        items = sorted_items[skip : skip + page_size]
+
     return ProblemListResponse(
         items=[_serialize_problem_summary(problem) for problem in items],
         page=page,
@@ -431,13 +503,7 @@ async def get_problem_tracking(
         allow_deleted=False,
     )
     problem_model = problem_document_to_model(problem_doc)
-    config = PracticeSelectionConfig(
-        cooldown_days=settings.problem_selection_cooldown_days,
-        last_wrong_weight=settings.problem_selection_last_wrong_weight,
-        failure_rate_weight=settings.problem_selection_failure_rate_weight,
-        recency_weight=settings.problem_selection_recency_weight,
-        min_problem_age_days=settings.problem_selection_min_age_days,
-    )
+    config = _practice_selection_config(settings)
     now = datetime.now(UTC)
     breakdown = compute_problem_weight_breakdown(problem_model, config, now)
     return ProblemTrackingResponse(

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -34,12 +34,14 @@ class FakeCursor:
         self._skip = 0
         self._limit: int | None = None
 
-    def sort(self, field: str, direction: int) -> FakeCursor:
-        reverse = direction < 0
-        self._documents.sort(
-            key=lambda document: cast(Any, document.get(field)),
-            reverse=reverse,
-        )
+    def sort(self, field: str | list[tuple[str, int]], direction: int | None = None) -> FakeCursor:
+        sort_fields = field if isinstance(field, list) else [(field, direction or 1)]
+        for sort_field, sort_direction in reversed(sort_fields):
+            reverse = sort_direction < 0
+            self._documents.sort(
+                key=lambda document: cast(Any, document.get(sort_field)),
+                reverse=reverse,
+            )
         return self
 
     def skip(self, amount: int) -> FakeCursor:
@@ -237,17 +239,23 @@ def make_preview(user_id: ObjectId, *, status: str = "ready") -> dict[str, Any]:
     }
 
 
+DEFAULT_LAST_TESTED = object()
+
+
 def make_problem(
     user_id: ObjectId,
     *,
     text: str = "What is 2+2?",
     problem_type: str = "short-answer",
     updated_at: datetime | None = None,
+    created_at: datetime | None = None,
+    last_tested_at: Any = DEFAULT_LAST_TESTED,
     tags: list[str] | None = None,
     is_deleted: bool = False,
     folder_id: str | None = None,
 ) -> dict[str, Any]:
     now = updated_at or datetime.now(UTC)
+    created = created_at or now
     return {
         "_id": ObjectId(),
         "userId": user_id,
@@ -280,13 +288,13 @@ def make_problem(
             "exposureCount": 3,
             "correctCount": 2,
             "failedCount": 1,
-            "lastTestedAt": now,
+            "lastTestedAt": now if last_tested_at is DEFAULT_LAST_TESTED else last_tested_at,
             "lastAttemptCorrect": True,
         },
         "isDeleted": is_deleted,
         "deletedAt": now if is_deleted else None,
         "folderId": folder_id,
-        "createdAt": now,
+        "createdAt": created,
         "updatedAt": now,
     }
 
@@ -827,6 +835,148 @@ async def test_search_pagination_total_reflects_filtered(
     data = response.json()
     assert data["total"] == 5
     assert len(data["items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_problems_sorts_by_add_date_before_pagination(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    newest = make_problem(user_id, text="Newest", created_at=base + timedelta(days=2))
+    oldest = make_problem(user_id, text="Oldest", created_at=base)
+    middle = make_problem(user_id, text="Middle", created_at=base + timedelta(days=1))
+    database["problems"].seed(newest, oldest, middle)
+
+    asc_response = await client.get("/api/v1/problems?sortBy=addDate&sortOrder=asc&pageSize=2&page=2")
+    desc_response = await client.get("/api/v1/problems?sortBy=addDate&sortOrder=desc")
+
+    assert asc_response.status_code == 200
+    assert [item["text"] for item in asc_response.json()["items"]] == ["Newest"]
+    assert desc_response.status_code == 200
+    assert [item["text"] for item in desc_response.json()["items"]] == ["Newest", "Middle", "Oldest"]
+
+
+@pytest.mark.asyncio
+async def test_list_problems_sorts_by_last_test_date_with_never_tested_last_and_ties(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    older = make_problem(user_id, text="Older tested", last_tested_at=base)
+    never = make_problem(user_id, text="Never tested", last_tested_at=None)
+    same_a = make_problem(user_id, text="Same A", last_tested_at=base + timedelta(days=1))
+    same_b = make_problem(user_id, text="Same B", last_tested_at=base + timedelta(days=1))
+    same_a["_id"] = ObjectId("000000000000000000000001")
+    same_b["_id"] = ObjectId("000000000000000000000002")
+    database["problems"].seed(never, same_b, older, same_a)
+
+    asc_response = await client.get("/api/v1/problems?sortBy=lastTestDate&sortOrder=asc")
+    desc_response = await client.get("/api/v1/problems?sortBy=lastTestDate&sortOrder=desc")
+
+    assert asc_response.status_code == 200
+    assert [item["text"] for item in asc_response.json()["items"]] == [
+        "Older tested",
+        "Same A",
+        "Same B",
+        "Never tested",
+    ]
+    assert desc_response.status_code == 200
+    assert [item["text"] for item in desc_response.json()["items"]] == [
+        "Same A",
+        "Same B",
+        "Older tested",
+        "Never tested",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_problems_sorts_by_selection_score_using_configured_weights(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    from app.infrastructure.config.settings import Settings, get_settings
+
+    problems_app.dependency_overrides[get_settings] = lambda: Settings(
+        problem_selection_last_wrong_weight=10.0,
+        problem_selection_failure_rate_weight=0.0,
+        problem_selection_recency_weight=0.0,
+    )
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    now = datetime.now(UTC) - timedelta(days=30)
+    low = make_problem(user_id, text="Last correct", created_at=now, last_tested_at=now)
+    low["tracking"]["lastAttemptCorrect"] = True
+    high = make_problem(user_id, text="Last wrong", created_at=now, last_tested_at=now)
+    high["tracking"]["lastAttemptCorrect"] = False
+    database["problems"].seed(low, high)
+
+    asc_response = await client.get("/api/v1/problems?sortBy=selectionScore&sortOrder=asc")
+    desc_response = await client.get("/api/v1/problems?sortBy=selectionScore&sortOrder=desc")
+
+    assert asc_response.status_code == 200
+    assert [item["text"] for item in asc_response.json()["items"]] == ["Last correct", "Last wrong"]
+    assert desc_response.status_code == 200
+    assert [item["text"] for item in desc_response.json()["items"]] == ["Last wrong", "Last correct"]
+
+
+@pytest.mark.asyncio
+async def test_list_problems_sorting_composes_with_filters_and_rejects_invalid_values(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    folder = make_folder(user_id, "Chapter")
+    database["folders"].seed(folder)
+    old_matching = make_problem(
+        user_id,
+        text="Alpha matching",
+        problem_type="short-answer",
+        tags=["algebra"],
+        folder_id=str(folder["_id"]),
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    new_matching = make_problem(
+        user_id,
+        text="Alpha matching newer",
+        problem_type="short-answer",
+        tags=["algebra"],
+        folder_id=str(folder["_id"]),
+        created_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    non_matching = make_problem(
+        user_id,
+        text="Alpha other",
+        problem_type="single-choice",
+        tags=["algebra"],
+        folder_id=str(folder["_id"]),
+        created_at=datetime(2026, 1, 3, tzinfo=UTC),
+    )
+    database["problems"].seed(non_matching, new_matching, old_matching)
+
+    response = await client.get(
+        "/api/v1/problems",
+        params={
+            "sortBy": "addDate",
+            "sortOrder": "asc",
+            "folderId": str(folder["_id"]),
+            "tag": "algebra",
+            "type": "short-answer",
+            "q": "Alpha",
+        },
+    )
+    bad_sort_response = await client.get("/api/v1/problems?sortBy=updatedAt")
+    bad_order_response = await client.get("/api/v1/problems?sortBy=addDate&sortOrder=sideways")
+
+    assert response.status_code == 200
+    assert [item["text"] for item in response.json()["items"]] == ["Alpha matching", "Alpha matching newer"]
+    assert bad_sort_response.status_code == 422
+    assert bad_order_response.status_code == 422
 
 
 # Folder assignment and filtering tests

--- a/frontend/src/pages/ProblemsPage.test.tsx
+++ b/frontend/src/pages/ProblemsPage.test.tsx
@@ -226,6 +226,59 @@ describe("ProblemsPage", () => {
     });
   });
 
+  it("sends sort parameters with existing filters", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    expect(screen.getByRole("option", { name: "Selection score" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Add date" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Last test date" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
+    await user.selectOptions(screen.getByLabelText("Sort by:"), "selectionScore");
+    await user.selectOptions(screen.getByLabelText("Order:"), "asc");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=section-1");
+      expect(lastUrl).toContain("tag=algebra");
+      expect(lastUrl).toContain("sortBy=selectionScore");
+      expect(lastUrl).toContain("sortOrder=asc");
+      expect(lastUrl).toContain("page=1");
+    });
+  });
+
+  it("resets pagination and selection mode when sort changes", async () => {
+    const user = userEvent.setup();
+    installApiMock({ problems: [problem({ id: "p1" }), problem({ id: "p2", text: "Second problem" })], total: 25 });
+
+    renderProblemsPage();
+    await screen.findByText("Second problem");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    const card = screen.getByText("What is 2+2?").closest("div")!;
+    fireEvent.pointerDown(card);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    fireEvent.pointerUp(card);
+    await screen.findByRole("checkbox", { name: "Select problem p1" });
+
+    await user.selectOptions(screen.getByLabelText("Sort by:"), "addDate");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("sortBy=addDate");
+      expect(lastUrl).toContain("sortOrder=desc");
+      expect(lastUrl).toContain("page=1");
+    });
+    expect(screen.queryByLabelText("Bulk actions")).not.toBeInTheDocument();
+  });
+
   it("persists sidebar collapse state in session storage and shows the active label", async () => {
     const user = userEvent.setup();
     installApiMock();

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -15,6 +15,20 @@ const UNFILED_FOLDER_ID = "unfiled";
 const EMPTY_FOLDERS: FolderNode[] = [];
 
 type Feedback = { type: "success" | "error"; message: string } | null;
+type ProblemSortBy = "" | "selectionScore" | "addDate" | "lastTestDate";
+type ProblemSortOrder = "asc" | "desc";
+
+const SORT_BY_OPTIONS: Array<{ value: ProblemSortBy; label: string }> = [
+  { value: "", label: "Default" },
+  { value: "selectionScore", label: "Selection score" },
+  { value: "addDate", label: "Add date" },
+  { value: "lastTestDate", label: "Last test date" },
+];
+
+const SORT_ORDER_OPTIONS: Array<{ value: ProblemSortOrder; label: string }> = [
+  { value: "desc", label: "Descending" },
+  { value: "asc", label: "Ascending" },
+];
 
 function flattenFolders(folders: FolderNode[], depth = 0): Array<FolderNode & { depth: number }> {
   return folders.flatMap((folder) => [
@@ -63,6 +77,8 @@ export function ProblemsPage() {
   const [selectedTag, setSelectedTag] = useState<string>("");
   const [selectedProblemType, setSelectedProblemType] = useState<string>("");
   const [searchQuery, setSearchQuery] = useState<string>("");
+  const [sortBy, setSortBy] = useState<ProblemSortBy>("");
+  const [sortOrder, setSortOrder] = useState<ProblemSortOrder>("desc");
   const [selectedProblemIds, setSelectedProblemIds] = useState<Set<string>>(new Set());
   const [isSelectionMode, setIsSelectionMode] = useState(false);
   const [bulkTarget, setBulkTarget] = useState<string>(UNFILED_FOLDER_ID);
@@ -80,7 +96,7 @@ export function ProblemsPage() {
   const selectedFolderId = searchParams.get("folderId") ?? "";
 
   const { data: problemsData, isLoading: isLoadingProblems } = useQuery({
-    queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery, selectedFolderId],
+    queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery, selectedFolderId, sortBy, sortOrder],
     queryFn: async () => {
       const params = new URLSearchParams({
         page: String(page),
@@ -90,6 +106,10 @@ export function ProblemsPage() {
       if (selectedProblemType) params.append("type", selectedProblemType);
       if (searchQuery.trim()) params.append("q", searchQuery.trim());
       if (selectedFolderId) params.append("folderId", selectedFolderId);
+      if (sortBy) {
+        params.append("sortBy", sortBy);
+        params.append("sortOrder", sortOrder);
+      }
       return api.get<ProblemsResponse>(`/problems?${params.toString()}`);
     },
   });
@@ -170,6 +190,18 @@ export function ProblemsPage() {
     if (folderId) next.set("folderId", folderId);
     else next.delete("folderId");
     setSearchParams(next);
+    setPage(1);
+    exitSelectionMode();
+  };
+
+  const updateSortBy = (value: ProblemSortBy) => {
+    setSortBy(value);
+    setPage(1);
+    exitSelectionMode();
+  };
+
+  const updateSortOrder = (value: ProblemSortOrder) => {
+    setSortOrder(value);
     setPage(1);
     exitSelectionMode();
   };
@@ -541,6 +573,35 @@ export function ProblemsPage() {
             >
               {PROBLEM_TYPE_FILTER_OPTIONS.map((option) => (
                 <option key={option.value || "all"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="sort-by">Sort by: </label>
+            <select
+              id="sort-by"
+              value={sortBy}
+              onChange={(e) => updateSortBy(e.target.value as ProblemSortBy)}
+            >
+              {SORT_BY_OPTIONS.map((option) => (
+                <option key={option.value || "default"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="sort-order">Order: </label>
+            <select
+              id="sort-order"
+              value={sortOrder}
+              onChange={(e) => updateSortOrder(e.target.value as ProblemSortOrder)}
+              disabled={!sortBy}
+            >
+              {SORT_ORDER_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
                   {option.label}
                 </option>
               ))}


### PR DESCRIPTION
## Summary

- Add validated `sortBy` and `sortOrder` parameters for `GET /api/v1/problems`.
- Sort the complete filtered backend result set before pagination for selection score, add date, and last test date.
- Add Problems Page sort controls with request/query-key integration and selection/page reset behavior.
- Add backend and frontend coverage for sorting behavior and UI request/state changes.

## Linked Issue

Closes #300

## Issue Alignment

This PR implements the issue by:

- Supporting `selectionScore`, `addDate`, and `lastTestDate` sorting in both directions.
- Reusing `compute_problem_weight_breakdown` with current settings for selection-score ordering.
- Keeping never-tested problems last for last-test-date sorting in both directions.
- Applying sorting to the full filtered set before slicing the requested page.
- Preserving default `updatedAt desc` ordering when sort parameters are omitted.
- Adding accessible “Sort by” and “Order” selectors on the Problems Page.

Scope covered:

- Validated API query params.
- Server-side sorting before pagination.
- Deterministic `_id` tie behavior.
- Composition with existing filters.
- Backend and frontend tests for requested behavior.

Out of scope / intentionally not included:

- Persisting sort preferences.
- Showing score values on problem cards.
- Changing the practice/exam selection formula.
- Materialized/cached score optimization.

## Implementation Notes

- `addDate` uses Mongo sorting on `createdAt` with `_id` tie-breaker.
- `lastTestDate` loads the filtered set and orders tested problems separately from never-tested problems so null dates stay last for both directions.
- `selectionScore` converts documents through `problem_document_to_model` and calculates totals via the existing practice selection scoring logic.
- Frontend sort params are only sent after a sort method is selected, preserving existing default requests.

## Tests

Commands run:

- `cd backend && uv run pytest tests/api/test_problems.py -q` — passed (`34 passed`)
- `cd backend && uv run pytest` — passed (`502 passed, 1 skipped`)
- `cd frontend && npm ci` — passed (installed dependencies; npm reported existing audit findings)
- `cd frontend && npm test -- --run src/pages/ProblemsPage.test.tsx` — passed (`24 passed`)
- `cd frontend && npm test -- --run` — passed (`303 passed`)
- `cd frontend && npm run build` — passed (Vite chunk-size warning only)

Automated tests added or updated:

- Backend API tests for add-date sorting before pagination, last-test-date null-last/ties, selection-score configured weights, filter composition, invalid values, and preserved default coverage.
- Frontend tests for sort option rendering, generated request parameters, pagination reset, and selection-mode exit.

Manual verification:

- Not run in a browser during this automated implementation turn. Covered by targeted frontend tests and production build.

## Deviations From Issue Plan

- `lastTestDate` uses equivalent application-side server ordering after loading the complete filtered set, rather than Mongo aggregation, to keep the implementation small and compatible with the existing test doubles while still sorting before pagination.

## Follow-Up Work

- If real-world profiling shows selection-score or last-test-date in-memory sorting is too expensive for large datasets, evaluate a Mongo aggregation/materialized score strategy in a separate issue.
