### PR TITLE
feat: allow configurable exam problem count

### DIFF
--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -12,7 +12,7 @@ from app.presentation.schemas import CorrectAnswerPayload, SourceImagePayload
 
 
 class CreateExamRequest(BaseModel):
-    maxProblemCount: int = Field(ge=1, le=100)
+    maxProblemCount: int = Field(ge=1, le=20)
 
 
 class SaveAnswerRequest(BaseModel):

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -313,6 +313,48 @@ async def test_create_exam_snapshots_selected_problems(exams_app: FastAPI, clien
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("max_problem_count", [1, 20])
+async def test_create_exam_accepts_problem_count_boundaries(
+    exams_app: FastAPI,
+    client: AsyncClient,
+    max_problem_count: int,
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    storage: FakeStorage = exams_app.state.fake_storage
+    user_id = exams_app.state.primary_user["_id"]
+    problems = [
+        make_problem(
+            user_id,
+            text=f"Problem {index}?",
+            problem_type="fill-in-the-blank",
+            correct_answer=str(index),
+        )
+        for index in range(max_problem_count)
+    ]
+    database["problems"].seed(*problems)
+    for problem in problems:
+        storage.seed(problem["sourceImage"]["bucket"], problem["sourceImage"]["objectKey"], b"img")
+
+    response = await client.post("/api/v1/exams", json={"maxProblemCount": max_problem_count})
+
+    assert response.status_code == 201
+    body = response.json()["exam"]
+    assert body["configSnapshot"]["maxProblemCount"] == max_problem_count
+    assert len(body["items"]) == max_problem_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("max_problem_count", [0, 21])
+async def test_create_exam_rejects_problem_count_outside_product_limit(
+    client: AsyncClient,
+    max_problem_count: int,
+) -> None:
+    response = await client.post("/api/v1/exams", json={"maxProblemCount": max_problem_count})
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_create_exam_rejects_when_active_exam_exists(exams_app: FastAPI, client: AsyncClient) -> None:
     database: FakeDatabase = exams_app.state.fake_database
     user_id = exams_app.state.primary_user["_id"]

--- a/frontend/src/pages/ExamsPage.test.tsx
+++ b/frontend/src/pages/ExamsPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -25,6 +25,48 @@ function renderExamsPage() {
       </MemoryRouter>
     </QueryClientProvider>,
   );
+}
+
+async function renderLoadedExamsPage() {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ items: [], page: 1, pageSize: 10, total: 0 }),
+  });
+
+  renderExamsPage();
+  await screen.findByText("No submitted exams yet");
+}
+
+function createExamResponse() {
+  return {
+    exam: {
+      id: "exam-new",
+      state: "in-progress",
+      configSnapshot: {
+        maxProblemCount: 5,
+        selectionPolicy: {
+          cooldownDays: 7,
+          lastWrongWeight: 1,
+          failureRateWeight: 1,
+          recencyWeight: 1,
+          minProblemAgeDays: 0,
+        },
+        generatedAt: "2024-01-01T00:00:00Z",
+      },
+      items: [],
+      summary: {
+        totalProblems: 0,
+        answeredProblems: 0,
+        gradedProblems: 0,
+        pendingProblems: 0,
+        correctProblems: 0,
+        failedProblems: 0,
+        score: null,
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    },
+  };
 }
 
 describe("ExamsPage", () => {
@@ -79,5 +121,150 @@ describe("ExamsPage", () => {
       );
     });
     expect(await screen.findByText("Exam exam-discarded")).toBeInTheDocument();
+  });
+
+  it("opens the create modal without sending a create request", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByRole("heading", { name: "Start New Exam" })).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows default synchronized controls with product limits", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    const input = screen.getByLabelText("Problem count");
+    const slider = screen.getByLabelText("Problem count slider");
+    expect(input).toHaveValue(5);
+    expect(input).toHaveAttribute("min", "1");
+    expect(input).toHaveAttribute("max", "20");
+    expect(input).toHaveAttribute("step", "1");
+    expect(slider).toHaveValue("5");
+    expect(slider).toHaveAttribute("min", "1");
+    expect(slider).toHaveAttribute("max", "20");
+    expect(slider).toHaveAttribute("step", "1");
+  });
+
+  it("keeps numeric and slider controls synchronized", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    const input = screen.getByLabelText("Problem count");
+    const slider = screen.getByLabelText("Problem count slider");
+    await user.clear(input);
+    await user.type(input, "12");
+    expect(slider).toHaveValue("12");
+
+    fireEvent.change(slider, { target: { value: "7" } });
+    expect(input).toHaveValue(7);
+  });
+
+  it.each(["", "1.5", "0", "-1", "21"])(
+    "shows validation and disables creation for invalid value %s",
+    async (value) => {
+      const user = userEvent.setup();
+      await renderLoadedExamsPage();
+      await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+      const input = screen.getByLabelText("Problem count");
+      await user.clear(input);
+      if (value) {
+        await user.type(input, value);
+      }
+
+      expect(screen.getByRole("alert")).toHaveTextContent("Enter a whole number from 1 to 20.");
+      expect(screen.getByRole("button", { name: "Create Exam" })).toBeDisabled();
+    },
+  );
+
+  it("clears validation and submits the selected valid problem count", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => createExamResponse(),
+    });
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    const input = screen.getByLabelText("Problem count");
+    await user.clear(input);
+    await user.type(input, "21");
+    expect(screen.getByRole("button", { name: "Create Exam" })).toBeDisabled();
+
+    await user.clear(input);
+    await user.type(input, "8");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Create Exam" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/v1/exams"),
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ maxProblemCount: 8 }),
+        }),
+      );
+    });
+  });
+
+  it("closes without creating an exam when canceled and resets on reopen", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    const input = screen.getByLabelText("Problem count");
+    await user.clear(input);
+    await user.type(input, "9");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+    expect(screen.getByLabelText("Problem count")).toHaveValue(5);
+  });
+
+  it("prevents duplicate submission and displays loading feedback while creating", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+    let resolveCreate: (value: unknown) => void = () => undefined;
+    mockFetch.mockReturnValueOnce(new Promise((resolve) => {
+      resolveCreate = resolve;
+    }));
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    await user.click(screen.getByRole("button", { name: "Create Exam" }));
+
+    expect(screen.getByRole("button", { name: "Creating..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    resolveCreate({ ok: true, json: async () => createExamResponse() });
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+  });
+
+  it("closes the configuration modal and shows the continuation prompt when an active exam exists", async () => {
+    const user = userEvent.setup();
+    await renderLoadedExamsPage();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      json: async () => ({ error: { code: "ACTIVE_EXAM_EXISTS", message: "Active exam exists" } }),
+    });
+    await user.click(screen.getByRole("button", { name: "Start New Exam" }));
+
+    await user.click(screen.getByRole("button", { name: "Create Exam" }));
+
+    expect(await screen.findByText("An active exam already exists. Would you like to continue it?")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -6,6 +6,11 @@ import { api } from "@/api/client";
 import { formatDate, formatScore } from "@/utils/format";
 import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest, CreateExamResponse } from "@/types/exam";
 import Pagination from "@/components/Pagination";
+import { Modal } from "@/components/Modal";
+
+const EXAM_PROBLEM_COUNT_MIN = 1;
+const EXAM_PROBLEM_COUNT_MAX = 20;
+const EXAM_PROBLEM_COUNT_DEFAULT = 5;
 
 function getStateStyle(state: string) {
   switch (state) {
@@ -105,6 +110,8 @@ export function ExamsPage() {
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
   const [showActiveExamPrompt, setShowActiveExamPrompt] = useState(false);
+  const [showCreateExamModal, setShowCreateExamModal] = useState(false);
+  const [problemCountInput, setProblemCountInput] = useState(String(EXAM_PROBLEM_COUNT_DEFAULT));
   const [showDiscarded, setShowDiscarded] = useState(false);
   const pageSize = 10;
 
@@ -119,17 +126,44 @@ export function ExamsPage() {
   const createExamMutation = useMutation({
     mutationFn: (req: CreateExamRequest) => api.post<CreateExamResponse>("/exams", req),
     onSuccess: () => {
+      setShowCreateExamModal(false);
       queryClient.invalidateQueries({ queryKey: ["exams"] });
       navigate("/exams/active");
     },
   });
 
+  const parsedProblemCount = /^\d+$/.test(problemCountInput) ? Number(problemCountInput) : null;
+  const validProblemCount =
+    parsedProblemCount !== null &&
+    parsedProblemCount >= EXAM_PROBLEM_COUNT_MIN &&
+    parsedProblemCount <= EXAM_PROBLEM_COUNT_MAX
+      ? parsedProblemCount
+      : null;
+  const problemCountError =
+    validProblemCount === null
+      ? `Enter a whole number from ${EXAM_PROBLEM_COUNT_MIN} to ${EXAM_PROBLEM_COUNT_MAX}.`
+      : null;
+
+  const handleOpenCreateExamModal = () => {
+    setProblemCountInput(String(EXAM_PROBLEM_COUNT_DEFAULT));
+    setShowCreateExamModal(true);
+  };
+
+  const handleCloseCreateExamModal = () => {
+    if (!createExamMutation.isPending) {
+      setShowCreateExamModal(false);
+    }
+  };
+
   const handleCreateExam = async () => {
+    if (validProblemCount === null) return;
+
     try {
-      await createExamMutation.mutateAsync({ maxProblemCount: 10 });
+      await createExamMutation.mutateAsync({ maxProblemCount: validProblemCount });
     } catch (err) {
       const code = (err as Error & { code?: string }).code;
       if (code === "ACTIVE_EXAM_EXISTS") {
+        setShowCreateExamModal(false);
         setShowActiveExamPrompt(true);
       }
     }
@@ -160,21 +194,129 @@ export function ExamsPage() {
         </div>
         <button
           type="button"
-          onClick={() => void handleCreateExam()}
-          disabled={createExamMutation.isPending}
+          onClick={handleOpenCreateExamModal}
           style={{
             padding: "0.75rem 1rem",
-            backgroundColor: createExamMutation.isPending ? "var(--color-primary-disabled)" : "var(--color-primary)",
+            backgroundColor: "var(--color-primary)",
             color: "white",
             border: "none",
             borderRadius: "0.375rem",
-            cursor: createExamMutation.isPending ? "not-allowed" : "pointer",
+            cursor: "pointer",
             fontWeight: 600,
           }}
         >
-          {createExamMutation.isPending ? "Creating..." : "Start New Exam"}
+          Start New Exam
         </button>
       </div>
+
+
+
+      <Modal
+        isOpen={showCreateExamModal}
+        onClose={handleCloseCreateExamModal}
+        ariaLabelledby="create-exam-title"
+      >
+        <h2 id="create-exam-title" style={{ marginTop: 0 }}>Start New Exam</h2>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleCreateExam();
+          }}
+        >
+          <p style={{ color: "var(--color-text-muted)", marginTop: 0 }}>
+            Choose how many problems to include.
+          </p>
+          <label htmlFor="exam-problem-count" style={{ display: "block", fontWeight: 600, marginBottom: "0.5rem" }}>
+            Problem count
+          </label>
+          <input
+            id="exam-problem-count"
+            type="number"
+            min={EXAM_PROBLEM_COUNT_MIN}
+            max={EXAM_PROBLEM_COUNT_MAX}
+            step={1}
+            value={problemCountInput}
+            onChange={(event) => setProblemCountInput(event.target.value)}
+            aria-invalid={problemCountError ? "true" : "false"}
+            aria-describedby={problemCountError ? "exam-problem-count-error" : undefined}
+            style={{
+              width: "100%",
+              padding: "0.5rem",
+              border: `1px solid ${problemCountError ? "var(--color-danger-border)" : "var(--color-border)"}`,
+              borderRadius: "0.375rem",
+              marginBottom: "0.75rem",
+            }}
+          />
+          <label htmlFor="exam-problem-count-slider" style={{ display: "block", fontWeight: 600, marginBottom: "0.5rem" }}>
+            Problem count slider
+          </label>
+          <input
+            id="exam-problem-count-slider"
+            type="range"
+            min={EXAM_PROBLEM_COUNT_MIN}
+            max={EXAM_PROBLEM_COUNT_MAX}
+            step={1}
+            value={validProblemCount ?? EXAM_PROBLEM_COUNT_DEFAULT}
+            onChange={(event) => setProblemCountInput(event.target.value)}
+            style={{ width: "100%" }}
+          />
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              color: "var(--color-text-muted)",
+              fontSize: "0.875rem",
+              marginBottom: "0.75rem",
+            }}
+          >
+            <span>{EXAM_PROBLEM_COUNT_MIN}</span>
+            <span>{EXAM_PROBLEM_COUNT_MAX}</span>
+          </div>
+          {problemCountError && (
+            <div
+              id="exam-problem-count-error"
+              role="alert"
+              style={{ color: "var(--color-text-danger)", marginBottom: "0.75rem" }}
+            >
+              {problemCountError}
+            </div>
+          )}
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem" }}>
+            <button
+              type="button"
+              onClick={handleCloseCreateExamModal}
+              disabled={createExamMutation.isPending}
+              style={{
+                padding: "0.5rem 1rem",
+                backgroundColor: "var(--color-disabled-bg)",
+                border: "1px solid var(--color-border-muted)",
+                borderRadius: "0.375rem",
+                cursor: createExamMutation.isPending ? "not-allowed" : "pointer",
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={validProblemCount === null || createExamMutation.isPending}
+              style={{
+                padding: "0.5rem 1rem",
+                backgroundColor:
+                  validProblemCount === null || createExamMutation.isPending
+                    ? "var(--color-primary-disabled)"
+                    : "var(--color-primary)",
+                color: "white",
+                border: "none",
+                borderRadius: "0.375rem",
+                cursor: validProblemCount === null || createExamMutation.isPending ? "not-allowed" : "pointer",
+                fontWeight: 600,
+              }}
+            >
+              {createExamMutation.isPending ? "Creating..." : "Create Exam"}
+            </button>
+          </div>
+        </form>
+      </Modal>
 
       {showActiveExamPrompt && (
         <div


### PR DESCRIPTION
## Summary

- Adds a Start New Exam configuration modal with synchronized numeric and slider controls defaulting to 5 problems.
- Enforces whole-number 1–20 validation in the frontend before creating an exam.
- Updates backend create-exam request validation to reject `maxProblemCount` values outside 1–20.

## Linked Issue

Closes #302

## Issue Alignment

This PR implements the issue by:

- Opening a modal from **Start New Exam** instead of immediately creating an exam.
- Submitting the validated selected value as `maxProblemCount` through the existing create-exam request.
- Preserving existing navigation, query invalidation, loading feedback, and active-exam conflict handling.
- Applying the same 1–20 product limit to backend request validation.

Scope covered:

- Exams page configuration modal.
- Synchronized numeric and range inputs.
- Client-side whole-number and range validation.
- Backend API boundary validation.
- Focused frontend and backend tests.

Out of scope / intentionally not included:

- Persisting the previously selected count between modal openings or sessions.
- Changing problem selection scoring, eligibility, or fewer-than-requested behavior.
- Redesigning exam history or active exam pages.
- Introducing reusable form abstractions beyond this modal.

## Implementation Notes

- Reuses `Modal` for the local Exams page dialog.
- Keeps the numeric input as string state so temporary invalid values can be represented and validated.
- Keeps the slider bound to the current valid count, falling back to the default while typed input is invalid.
- Closes the configuration modal before showing the existing active-exam continuation prompt.

## Tests

Commands run:

- `cd frontend && npm test -- --run src/pages/ExamsPage.test.tsx` — passed (13 tests)
- `cd frontend && npm run build` — passed
- `cd backend && uv run pytest tests/api/test_exams.py` — passed (18 tests)

Automated tests added or updated:

- Added Exams page tests for modal opening without POST, default values and limits, two-way synchronization, invalid typed input, valid submission body, cancel/reset, pending state, and active-exam conflict behavior.
- Added backend API tests for accepted boundaries 1 and 20 and rejected boundaries 0 and 21.

Manual verification:

- Launched the frontend with `cd frontend && npm run dev -- --host 127.0.0.1 --port 5174` and drove `/exams` with Playwright using mocked authenticated API responses.
- Verified **Start New Exam** opens the modal with numeric and slider values at 5 and limits 1–20.
- Verified numeric input `12` updates the slider and slider value `7` updates the numeric input.
- Verified Cancel closes the modal and reopening resets the value to 5.
- Verified creating with value 8 sends `{"maxProblemCount":8}` and navigates to `/exams/active`.
- Verified an `ACTIVE_EXAM_EXISTS` response closes the modal and shows the existing continuation prompt.
- Probed invalid typed values ``, `1.5`, `0`, `-1`, and `21`; each showed `Enter a whole number from 1 to 20.` and disabled creation. Re-entering `20` cleared validation and enabled creation.
- Attempted live backend boundary probes against `uvicorn app.main:create_app --factory --host 127.0.0.1 --port 8001`; unauthenticated requests returned `401 UNAUTHENTICATED`, so backend boundary behavior is verified by the API tests above.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
