### PR TITLE
Add protected Home dashboard with problem coverage and activity grid

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.presentation.practice import router as practice_router
 from app.presentation.settings import router as settings_router
 from app.presentation.teacher_password import router as teacher_password_router
 from app.presentation.coaching import router as coaching_router
+from app.presentation.home import router as home_router
 
 logger = logging.getLogger(__name__)
 
@@ -84,6 +85,7 @@ def create_app() -> FastAPI:
     api_v1_router.include_router(settings_router)
     api_v1_router.include_router(teacher_password_router)
     api_v1_router.include_router(coaching_router)
+    api_v1_router.include_router(home_router)
     application.include_router(api_v1_router)
 
     return application

--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.domain.models import ExamState
+from app.presentation.deps import DatabaseDependency, get_current_user
+
+router = APIRouter(prefix="/home", tags=["home"])
+
+CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
+
+
+class HomeCoverage(BaseModel):
+    totalProblems: int
+    triedProblems: int
+    percentage: int
+
+
+class HomeActivityDay(BaseModel):
+    date: str
+    count: int
+
+
+class HomeActivity(BaseModel):
+    startDate: str
+    endDate: str
+    days: list[HomeActivityDay]
+
+
+class HomeSummaryResponse(BaseModel):
+    coverage: HomeCoverage
+    activity: HomeActivity
+
+
+@router.get("/summary", response_model=HomeSummaryResponse)
+async def get_home_summary(
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> HomeSummaryResponse:
+    user_id = current_user["_id"]
+
+    problem_documents = await database["problems"].find(
+        {"userId": user_id, "isDeleted": False}
+    ).to_list(length=None)
+    non_deleted_problem_ids = {doc["_id"] for doc in problem_documents}
+    total_problems = len(non_deleted_problem_ids)
+
+    tried_problem_ids: set[Any] = set()
+
+    practice_attempts = await database["practice_attempts"].find(
+        {"userId": user_id}
+    ).to_list(length=None)
+    for attempt in practice_attempts:
+        problem_id = attempt.get("problemId")
+        if problem_id in non_deleted_problem_ids:
+            tried_problem_ids.add(problem_id)
+
+    submitted_exams = await database["exams"].find(
+        {"userId": user_id, "state": ExamState.SUBMITTED.value}
+    ).to_list(length=None)
+    for exam in submitted_exams:
+        for item in exam.get("items", []):
+            problem_id = item.get("problemId")
+            if problem_id in non_deleted_problem_ids:
+                tried_problem_ids.add(problem_id)
+
+    tried_problems = len(tried_problem_ids)
+    percentage = round((tried_problems / total_problems) * 100) if total_problems else 0
+
+    today = datetime.now(UTC).date()
+    start_date = today - timedelta(days=364)
+
+    daily_counts: dict[str, int] = {}
+    current = start_date
+    while current <= today:
+        daily_counts[current.strftime("%Y-%m-%d")] = 0
+        current += timedelta(days=1)
+
+    def _date_key(value: Any) -> str | None:
+        if not isinstance(value, datetime):
+            return None
+        event_date = value.astimezone(UTC).date()
+        if start_date <= event_date <= today:
+            return event_date.strftime("%Y-%m-%d")
+        return None
+
+    for attempt in practice_attempts:
+        date_str = _date_key(attempt.get("createdAt"))
+        if date_str is not None:
+            daily_counts[date_str] += 1
+
+    for exam in submitted_exams:
+        date_str = _date_key(exam.get("submittedAt"))
+        if date_str is not None:
+            daily_counts[date_str] += len(exam.get("items", []))
+
+    days = [
+        HomeActivityDay(date=date_str, count=count)
+        for date_str, count in daily_counts.items()
+    ]
+
+    return HomeSummaryResponse(
+        coverage=HomeCoverage(
+            totalProblems=total_problems,
+            triedProblems=tried_problems,
+            percentage=percentage,
+        ),
+        activity=HomeActivity(
+            startDate=start_date.strftime("%Y-%m-%d"),
+            endDate=today.strftime("%Y-%m-%d"),
+            days=days,
+        ),
+    )

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from copy import deepcopy
+from datetime import UTC, datetime
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.infrastructure.config.settings import Settings
+from app.main import create_app
+from app.presentation.deps import get_app_settings, get_current_user, get_database
+from tests.api.conftest import FakeDatabase, make_problem, make_user
+
+
+@pytest.fixture
+def home_app() -> FastAPI:
+    application = create_app()
+    database = FakeDatabase()
+    settings = Settings(problem_selection_min_age_days=0)
+    user = make_user(ObjectId(), "student")
+
+    application.state.fake_database = database
+    application.state.user = user
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_app_settings] = lambda: settings
+    application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
+    return application
+
+
+@pytest_asyncio.fixture
+async def client(home_app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=home_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+def make_practice_attempt(
+    user_id: ObjectId,
+    problem_id: ObjectId,
+    *,
+    created_at: datetime,
+) -> dict:
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "problemId": problem_id,
+        "submittedAnswer": "answer",
+        "gradingStatus": "correct",
+        "gradingMethod": "normalized-match",
+        "createdAt": created_at,
+    }
+
+
+def make_submitted_exam(
+    user_id: ObjectId,
+    *,
+    problem_ids: list[ObjectId],
+    submitted_at: datetime,
+) -> dict:
+    items = [
+        {"itemId": str(ObjectId()), "order": idx + 1, "problemId": pid}
+        for idx, pid in enumerate(problem_ids)
+    ]
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "state": "submitted",
+        "items": items,
+        "summary": {},
+        "createdAt": now,
+        "startedAt": now,
+        "submittedAt": submitted_at,
+        "updatedAt": now,
+    }
+
+
+@pytest.mark.asyncio
+async def test_summary_no_problems_returns_zero(home_app: FastAPI, client: AsyncClient) -> None:
+    response = await client.get("/api/v1/home/summary")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["coverage"]["totalProblems"] == 0
+    assert data["coverage"]["triedProblems"] == 0
+    assert data["coverage"]["percentage"] == 0
+    assert data["activity"]["startDate"]
+    assert data["activity"]["endDate"]
+    assert len(data["activity"]["days"]) == 365
+
+
+@pytest.mark.asyncio
+async def test_summary_coverage_with_practice_attempt(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=datetime.now(UTC))
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["coverage"]["totalProblems"] == 1
+    assert data["coverage"]["triedProblems"] == 1
+    assert data["coverage"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_coverage_with_submitted_exam_items(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("exams", [
+        make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=datetime.now(UTC))
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["coverage"]["triedProblems"] == 1
+    assert data["coverage"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_pending_review_exam_items_count(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("exams", [
+        make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=datetime.now(UTC))
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["triedProblems"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_duplicate_events_do_not_double_count_coverage(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    now = datetime.now(UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=now),
+        make_practice_attempt(user_id, problem["_id"], created_at=now),
+    ])
+    database.seed("exams", [
+        make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=now)
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["triedProblems"] == 1
+    assert data["coverage"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_multiple_events_same_day_increase_activity(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    now = datetime.now(UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=now),
+        make_practice_attempt(user_id, problem["_id"], created_at=now),
+    ])
+    database.seed("exams", [
+        make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=now)
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    today_str = now.strftime("%Y-%m-%d")
+    today_day = next(d for d in data["activity"]["days"] if d["date"] == today_str)
+    assert today_day["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_summary_deleted_problems_excluded_from_total(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    active = make_problem(user_id)
+    deleted = make_problem(user_id, is_deleted=True)
+    database.seed("problems", [active, deleted])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["totalProblems"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_excludes_other_users_data(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    other_user_id = ObjectId()
+    own_problem = make_problem(user_id)
+    other_problem = make_problem(other_user_id)
+    database.seed("problems", [own_problem, other_problem])
+    now = datetime.now(UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(other_user_id, other_problem["_id"], created_at=now),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["totalProblems"] == 1
+    assert data["coverage"]["triedProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_excludes_discarded_and_in_progress_exams(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    now = datetime.now(UTC)
+
+    in_progress_exam = make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=now)
+    in_progress_exam["state"] = "in-progress"
+    in_progress_exam["submittedAt"] = None
+    discarded_exam = make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=now)
+    discarded_exam["state"] = "discarded"
+    database.seed("exams", [in_progress_exam, discarded_exam])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["triedProblems"] == 0
+    today_str = now.strftime("%Y-%m-%d")
+    today_day = next(d for d in data["activity"]["days"] if d["date"] == today_str)
+    assert today_day["count"] == 0

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -60,16 +60,30 @@ describe("App", () => {
     });
   });
 
-  it("redirects from root to problems when authenticated", async () => {
+  it("redirects from root to home when authenticated", async () => {
     renderWithRouterAndAuth(["/"], {
       authenticated: true,
       user: { id: "abc123", username: "test" },
     });
 
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Problems" })).toBeInTheDocument();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        coverage: { totalProblems: 0, triedProblems: 0, percentage: 0 },
+        activity: { startDate: "2024-01-01", endDate: "2024-12-31", days: [{ date: "2024-01-01", count: 0 }] },
+      }),
     });
-    expect(screen.getByRole("button", { name: "Problems" })).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Home" })).toBeInTheDocument();
+    });
+    const navButtons = screen.getAllByRole("button");
+    const labels = navButtons.map((b) => b.textContent);
+    const homeIndex = labels.indexOf("Home");
+    const problemsIndex = labels.indexOf("Problems");
+    expect(homeIndex).toBeGreaterThanOrEqual(0);
+    expect(problemsIndex).toBeGreaterThanOrEqual(0);
+    expect(homeIndex).toBeLessThan(problemsIndex);
     expect(screen.getByRole("button", { name: "Ingest" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Exams" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Logout" })).toBeInTheDocument();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { ProtectedRoute } from "@/components/ProtectedRoute";
 
 import { LoginPage } from "@/pages/LoginPage";
 import { RegisterPage } from "@/pages/RegisterPage";
+import { HomePage } from "@/pages/HomePage";
 import { ProblemsPage } from "@/pages/ProblemsPage";
 import { ProblemDetailPage } from "@/pages/ProblemDetailPage";
 import { IngestPage } from "@/pages/IngestPage";
@@ -26,6 +27,7 @@ function AppShell({ children }: { children: ReactNode }) {
   const location = useLocation();
 
   const navItems = [
+    { label: "Home", path: "/home" },
     { label: "Problems", path: "/problems" },
     { label: "Ingest", path: "/ingest" },
     { label: "Exams", path: "/exams" },
@@ -171,6 +173,14 @@ export function AppRoutes() {
       <Route path="/login" element={<LoginPage />} />
       <Route path="/register" element={<RegisterPage />} />
       <Route
+        path="/home"
+        element={
+          <ProtectedPage>
+            <HomePage />
+          </ProtectedPage>
+        }
+      />
+      <Route
         path="/problems"
         element={
           <ProtectedPage>
@@ -258,8 +268,8 @@ export function AppRoutes() {
           </ProtectedPage>
         }
       />
-      <Route path="/" element={<Navigate to="/problems" replace />} />
-      <Route path="*" element={<Navigate to="/problems" replace />} />
+      <Route path="/" element={<Navigate to="/home" replace />} />
+      <Route path="*" element={<Navigate to="/home" replace />} />
     </Routes>
   );
 }

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,0 +1,168 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { HomePage } from "./HomePage";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+}
+
+function renderHomePage() {
+  return render(
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter>
+        <ThemeProvider>
+          <HomePage />
+        </ThemeProvider>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function summaryResponse(overrides: Partial<{
+  totalProblems: number;
+  triedProblems: number;
+  percentage: number;
+  days: { date: string; count: number }[];
+}> = {}) {
+  const today = new Date();
+  const days: { date: string; count: number }[] = [];
+  for (let i = 364; i >= 0; i--) {
+    const d = new Date(today);
+    d.setUTCDate(d.getUTCDate() - i);
+    days.push({ date: d.toISOString().slice(0, 10), count: 0 });
+  }
+  return {
+    coverage: {
+      totalProblems: overrides.totalProblems ?? 2,
+      triedProblems: overrides.triedProblems ?? 1,
+      percentage: overrides.percentage ?? 50,
+    },
+    activity: {
+      startDate: days[0].date,
+      endDate: days[days.length - 1].date,
+      days: overrides.days ?? days,
+    },
+  };
+}
+
+describe("HomePage", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("renders loading state initially", () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    renderHomePage();
+    expect(screen.getByTestId("loading")).toBeInTheDocument();
+  });
+
+  it("renders error state when request fails", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: { message: "boom" } }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("error").textContent).toContain("boom");
+  });
+
+  it("renders zero-problem state with 0% and note", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ totalProblems: 0, triedProblems: 0, percentage: 0 }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-coverage-percentage").textContent).toBe("0%");
+    });
+    expect(screen.getByTestId("home-coverage-text").textContent).toContain("No problems yet");
+  });
+
+  it("renders coverage percentage and supporting text in normal state", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ totalProblems: 4, triedProblems: 2, percentage: 50 }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-coverage-percentage").textContent).toBe("50%");
+    });
+    expect(screen.getByTestId("home-coverage-text").textContent).toContain("2 of 4 problems tried");
+  });
+
+  it("renders activity grid cells with returned counts", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const days: { date: string; count: number }[] = [];
+    for (let i = 364; i >= 0; i--) {
+      const d = new Date(today);
+      d.setUTCDate(d.getUTCDate() - i);
+      const dateStr = d.toISOString().slice(0, 10);
+      days.push({ date: dateStr, count: dateStr === todayStr ? 5 : 0 });
+    }
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+    const cells = screen.getAllByTestId("home-activity-cell");
+    const activeCell = cells.find((c) => c.getAttribute("data-count") === "5");
+    expect(activeCell).toBeDefined();
+    expect(activeCell?.getAttribute("data-date")).toBe(todayStr);
+  });
+
+  it("uses higher intensity for higher activity counts (theme-aware)", async () => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const todayStr = today.toISOString().slice(0, 10);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+    const days: { date: string; count: number }[] = [];
+    for (let i = 364; i >= 0; i--) {
+      const d = new Date(today);
+      d.setUTCDate(d.getUTCDate() - i);
+      const dateStr = d.toISOString().slice(0, 10);
+      let count = 0;
+      if (dateStr === todayStr) count = 5;
+      if (dateStr === yesterdayStr) count = 1;
+      days.push({ date: dateStr, count });
+    }
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+    const cells = screen.getAllByTestId("home-activity-cell");
+    const highCell = cells.find((c) => c.getAttribute("data-date") === todayStr) as HTMLElement;
+    const lowCell = cells.find((c) => c.getAttribute("data-date") === yesterdayStr) as HTMLElement;
+    const zeroCell = cells.find((c) => c.getAttribute("data-count") === "0") as HTMLElement;
+
+    const highBg = highCell.style.backgroundColor;
+    const lowBg = lowCell.style.backgroundColor;
+    const zeroBg = zeroCell.style.backgroundColor;
+
+    const highPct = parseInt(highBg.match(/(\d+)%/)?.[1] ?? "0", 10);
+    const lowPct = parseInt(lowBg.match(/(\d+)%/)?.[1] ?? "0", 10);
+    expect(highPct).toBeGreaterThan(lowPct);
+    expect(zeroBg).toBe("var(--color-surface-muted)");
+  });
+});

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,187 @@
+import { useQuery } from "@tanstack/react-query";
+import { useTheme } from "@/contexts/ThemeContext";
+import { api, ApiError } from "@/api/client";
+
+interface HomeCoverage {
+  totalProblems: number;
+  triedProblems: number;
+  percentage: number;
+}
+
+interface HomeActivityDay {
+  date: string;
+  count: number;
+}
+
+interface HomeActivity {
+  startDate: string;
+  endDate: string;
+  days: HomeActivityDay[];
+}
+
+interface HomeSummaryResponse {
+  coverage: HomeCoverage;
+  activity: HomeActivity;
+}
+
+const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+function mondayIndex(date: Date): number {
+  return (date.getDay() + 6) % 7;
+}
+
+function buildWeekColumns(days: HomeActivityDay[]): (HomeActivityDay | null)[][] {
+  const columns: (HomeActivityDay | null)[][] = [];
+  days.forEach((day) => {
+    const date = new Date(`${day.date}T00:00:00Z`);
+    const row = mondayIndex(date);
+    const lastColumn = columns[columns.length - 1];
+    if (!lastColumn || lastColumn.every((cell) => cell === null)) {
+      const column: (HomeActivityDay | null)[] = new Array(7).fill(null);
+      column[row] = day;
+      columns.push(column);
+    } else {
+      const firstDayInColumn = lastColumn.find((cell) => cell !== null);
+      if (firstDayInColumn) {
+        const firstDate = new Date(`${firstDayInColumn.date}T00:00:00Z`);
+        const dayDiff = Math.round(
+          (date.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24),
+        );
+        const expectedColumnIndex = Math.floor((dayDiff + mondayIndex(firstDate)) / 7);
+        if (expectedColumnIndex === columns.length - 1) {
+          lastColumn[row] = day;
+        } else {
+          const column: (HomeActivityDay | null)[] = new Array(7).fill(null);
+          column[row] = day;
+          columns.push(column);
+        }
+      }
+    }
+  });
+  return columns;
+}
+
+function cellIntensity(count: number, maxCount: number): number {
+  if (count <= 0 || maxCount <= 0) return 0;
+  return Math.min(0.25 + (count / maxCount) * 0.75, 1);
+}
+
+export function HomePage() {
+  const { theme } = useTheme();
+  const { data, isLoading, error } = useQuery<HomeSummaryResponse>({
+    queryKey: ["home-summary"],
+    queryFn: () => api.get<HomeSummaryResponse>("/home/summary"),
+  });
+
+  if (isLoading) {
+    return (
+      <div data-testid="loading" style={{ padding: "2rem", color: "var(--color-text-muted)" }}>
+        Loading dashboard...
+      </div>
+    );
+  }
+
+  if (error) {
+    const message = error instanceof ApiError ? error.message : "Failed to load dashboard";
+    return (
+      <div data-testid="error" style={{ padding: "2rem", color: "var(--color-text-danger)" }}>
+        {message}
+      </div>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  const { coverage, activity } = data;
+  const maxCount = activity.days.reduce((max, day) => Math.max(max, day.count), 0);
+  const weekColumns = buildWeekColumns(activity.days);
+  const zeroProblems = coverage.totalProblems === 0;
+
+  return (
+    <div style={{ padding: "1.5rem", maxWidth: "1100px", margin: "0 auto" }}>
+      <h1 style={{ fontSize: "1.75rem", fontWeight: 800, marginBottom: "1.5rem", color: "var(--color-text)" }}>
+        Home
+      </h1>
+
+      <section
+        style={{
+          padding: "1.5rem",
+          marginBottom: "1.5rem",
+          backgroundColor: "var(--color-surface)",
+          border: "1px solid var(--color-border)",
+          borderRadius: "var(--radius-lg)",
+          boxShadow: "var(--shadow-sm)",
+        }}
+      >
+        <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.5rem" }}>
+          Problem Coverage
+        </div>
+        <div data-testid="home-coverage-percentage" style={{ fontSize: "3.5rem", fontWeight: 800, lineHeight: 1, color: "var(--color-primary)" }}>
+          {coverage.percentage}%
+        </div>
+        <div data-testid="home-coverage-text" style={{ marginTop: "0.5rem", color: "var(--color-text-muted)", fontSize: "0.95rem" }}>
+          {zeroProblems ? (
+            "No problems yet. Add problems to start tracking coverage."
+          ) : (
+            <>
+              {coverage.triedProblems} of {coverage.totalProblems} problems tried
+            </>
+          )}
+        </div>
+      </section>
+
+      <section
+        style={{
+          padding: "1.5rem",
+          backgroundColor: "var(--color-surface)",
+          border: "1px solid var(--color-border)",
+          borderRadius: "var(--radius-lg)",
+          boxShadow: "var(--shadow-sm)",
+        }}
+      >
+        <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.75rem" }}>
+          Activity (last year)
+        </div>
+        <div data-testid="home-activity-grid" style={{ overflowX: "auto" }}>
+          <div style={{ display: "flex", gap: "0.25rem" }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: "0.125rem", marginRight: "0.25rem", justifyContent: "space-around" }}>
+              {WEEKDAY_LABELS.map((label) => (
+                <div key={label} style={{ fontSize: "0.625rem", color: "var(--color-text-muted)", height: "12px", lineHeight: "12px" }}>
+                  {label}
+                </div>
+              ))}
+            </div>
+            {weekColumns.map((column, colIndex) => (
+              <div key={colIndex} style={{ display: "flex", flexDirection: "column", gap: "0.125rem" }}>
+                {column.map((day, rowIndex) => {
+                  const intensity = day ? cellIntensity(day.count, maxCount) : 0;
+                  const background =
+                    day && day.count > 0
+                      ? `color-mix(in srgb, var(--color-primary) ${Math.round(intensity * 100)}%, transparent)`
+                      : "var(--color-surface-muted)";
+                  return (
+                    <div
+                      key={rowIndex}
+                      data-testid="home-activity-cell"
+                      data-date={day?.date ?? ""}
+                      data-count={day?.count ?? 0}
+                      title={day ? `${day.date}: ${day.count} event${day.count === 1 ? "" : "s"}` : ""}
+                      style={{
+                        width: "12px",
+                        height: "12px",
+                        borderRadius: "2px",
+                        backgroundColor: background,
+                      }}
+                    />
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a protected Home dashboard as the default authenticated landing page.
- Add `GET /api/v1/home/summary` returning problem coverage and last-year daily activity counts.
- Add a `HomePage` component rendering a large coverage percentage, supporting text, and a GitHub-style activity grid (Mon–Sun rows, week columns).
- Place `Home` before `Problems` in the top navigation.
- Redirect `/` and unknown routes (`*`) to `/home` (was `/problems`).

## Linked Issue

Closes #305

## Issue Alignment

This PR implements the issue by:

- Adding a backend Home summary endpoint scoped to the current user.
- Computing coverage as unique tried problems (practice attempts or submitted exam items) over total non-deleted problems.
- Computing last-year (365-day) daily activity counts: practice attempts on `createdAt`, submitted exam items on `exam.submittedAt`, excluding discarded and in-progress exams.
- Rendering the coverage and activity sections on the Home page without re-querying paginated histories.
- Updating routing/nav so Home appears first and `/` plus `*` redirect to `/home`.

Scope covered:

- Protected Home route/page.
- Home nav item before Problems.
- `/` and `*` fallback changed to `/home`.
- Backend dashboard summary endpoint.
- Coverage and activity rendering.
- Backend and frontend tests.

Out of scope / intentionally not included:

- User timezone-aware date grouping (UTC for v1, per issue).
- Configurable activity date ranges.
- Tooltips/drill-down or additional dashboard sections.
- New charting libraries.

## Implementation Notes

- Coverage numerator counts a problem as tried if it has any practice attempt OR appears in any submitted exam item (including pending-review items), deduplicated by problem ID and restricted to non-deleted problems.
- Activity returns zero-count days for the full 365-day range so the frontend renders a complete grid.
- Theme-aware intensity uses `color-mix(in srgb, var(--color-primary) N%, transparent)` with the primary CSS variable. In light theme `--color-primary` is a dark indigo, so higher intensity reads as darker; in dark theme it is a lighter indigo, so higher intensity reads as lighter. Zero-count cells use `var(--color-surface-muted)`.
- The grid arranges days into week columns starting Monday, with 7 rows Mon–Sun.

## Tests

Commands run:

- `cd backend && uv run pytest tests/api/test_home.py -q` — passed (9 tests)
- `cd backend && uv run pytest -q` — passed (515 passed, 1 skipped)
- `cd backend && uv run ruff check app/presentation/home.py tests/api/test_home.py` — passed
- `cd frontend && npm test -- --run src/pages/HomePage.test.tsx src/App.test.tsx` — passed (17 tests)
- `cd frontend && npm test -- --run` — passed (321 tests, 25 files)
- `cd frontend && npm run build` — passed (tsc + vite)

Automated tests added or updated:

- `backend/tests/api/test_home.py`: no-problems zero state, coverage with practice attempts, coverage with submitted exam items, pending-review items count as examined, duplicate events do not double-count coverage, multiple same-day events increase activity count, deleted problems excluded from total, other users' data excluded, discarded/in-progress exams excluded.
- `frontend/src/pages/HomePage.test.tsx`: loading, error, zero-problem, normal coverage, activity grid renders counts, higher counts use higher intensity than lower counts.
- `frontend/src/App.test.tsx`: updated root-redirect test to expect Home, and asserts Home appears before Problems in nav.

Manual verification:

- Not performed in a running browser this turn; automated routing and rendering tests cover the `/` → Home redirect, nav ordering, and Home page states. Theme-aware intensity direction is verified indirectly via intensity scaling and CSS-variable-based coloring (jsdom does not resolve `color-mix`, so a live-browser toggle check is recommended at review).

## Deviations From Issue Plan

None. UTC calendar dates used for v1 as specified.

## Follow-Up Work

None (issue-listed follow-ups such as timezone-aware grouping, configurable ranges, and tooltips remain intentionally out of scope).
