### PR TITLE
feat(home): add Conquest Rate metric beside Problem Coverage (#307)

### DIFF
--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -6,17 +6,25 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from app.domain.models import ExamState
+from app.domain.models import ExamState, GradingStatus
 from app.presentation.deps import DatabaseDependency, get_current_user
 
 router = APIRouter(prefix="/home", tags=["home"])
 
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 
+_MASTERY_STATUSES = {GradingStatus.CORRECT.value, GradingStatus.INCORRECT.value}
+
 
 class HomeCoverage(BaseModel):
     totalProblems: int
     triedProblems: int
+    percentage: int
+
+
+class HomeConquest(BaseModel):
+    totalProblems: int
+    masteredProblems: int
     percentage: int
 
 
@@ -33,6 +41,7 @@ class HomeActivity(BaseModel):
 
 class HomeSummaryResponse(BaseModel):
     coverage: HomeCoverage
+    conquest: HomeConquest
     activity: HomeActivity
 
 
@@ -50,6 +59,17 @@ async def get_home_summary(
     total_problems = len(non_deleted_problem_ids)
 
     tried_problem_ids: set[Any] = set()
+    latest_mastery: dict[Any, tuple[datetime, bool]] = {}
+
+    def _consider_mastery(problem_id: Any, event_time: Any, status: str) -> None:
+        if status not in _MASTERY_STATUSES:
+            return
+        if not isinstance(event_time, datetime):
+            return
+        is_correct = status == GradingStatus.CORRECT.value
+        previous = latest_mastery.get(problem_id)
+        if previous is None or event_time > previous[0]:
+            latest_mastery[problem_id] = (event_time, is_correct)
 
     practice_attempts = await database["practice_attempts"].find(
         {"userId": user_id}
@@ -58,18 +78,36 @@ async def get_home_summary(
         problem_id = attempt.get("problemId")
         if problem_id in non_deleted_problem_ids:
             tried_problem_ids.add(problem_id)
+            _consider_mastery(
+                problem_id,
+                attempt.get("createdAt"),
+                str(attempt.get("gradingStatus", "")),
+            )
 
     submitted_exams = await database["exams"].find(
         {"userId": user_id, "state": ExamState.SUBMITTED.value}
     ).to_list(length=None)
     for exam in submitted_exams:
+        submitted_at = exam.get("submittedAt")
         for item in exam.get("items", []):
             problem_id = item.get("problemId")
-            if problem_id in non_deleted_problem_ids:
-                tried_problem_ids.add(problem_id)
+            if problem_id not in non_deleted_problem_ids:
+                continue
+            tried_problem_ids.add(problem_id)
+            grading = item.get("grading") or {}
+            _consider_mastery(
+                problem_id,
+                submitted_at,
+                str(grading.get("status", "")),
+            )
 
     tried_problems = len(tried_problem_ids)
     percentage = round((tried_problems / total_problems) * 100) if total_problems else 0
+
+    mastered_problems = sum(1 for _, is_correct in latest_mastery.values() if is_correct)
+    conquest_percentage = (
+        round((mastered_problems / total_problems) * 100) if total_problems else 0
+    )
 
     today = datetime.now(UTC).date()
     start_date = today - timedelta(days=364)
@@ -108,6 +146,11 @@ async def get_home_summary(
             totalProblems=total_problems,
             triedProblems=tried_problems,
             percentage=percentage,
+        ),
+        conquest=HomeConquest(
+            totalProblems=total_problems,
+            masteredProblems=mastered_problems,
+            percentage=conquest_percentage,
         ),
         activity=HomeActivity(
             startDate=start_date.strftime("%Y-%m-%d"),

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -44,13 +44,14 @@ def make_practice_attempt(
     problem_id: ObjectId,
     *,
     created_at: datetime,
+    grading_status: str = "correct",
 ) -> dict:
     return {
         "_id": ObjectId(),
         "userId": user_id,
         "problemId": problem_id,
         "submittedAnswer": "answer",
-        "gradingStatus": "correct",
+        "gradingStatus": grading_status,
         "gradingMethod": "normalized-match",
         "createdAt": created_at,
     }
@@ -61,11 +62,21 @@ def make_submitted_exam(
     *,
     problem_ids: list[ObjectId],
     submitted_at: datetime,
+    item_grading_statuses: list[str] | None = None,
 ) -> dict:
-    items = [
-        {"itemId": str(ObjectId()), "order": idx + 1, "problemId": pid}
-        for idx, pid in enumerate(problem_ids)
-    ]
+    items = []
+    for idx, pid in enumerate(problem_ids):
+        status = (
+            item_grading_statuses[idx]
+            if item_grading_statuses and idx < len(item_grading_statuses)
+            else "ungraded"
+        )
+        items.append({
+            "itemId": str(ObjectId()),
+            "order": idx + 1,
+            "problemId": pid,
+            "grading": {"status": status},
+        })
     now = datetime.now(UTC)
     return {
         "_id": ObjectId(),
@@ -88,6 +99,9 @@ async def test_summary_no_problems_returns_zero(home_app: FastAPI, client: Async
     assert data["coverage"]["totalProblems"] == 0
     assert data["coverage"]["triedProblems"] == 0
     assert data["coverage"]["percentage"] == 0
+    assert data["conquest"]["totalProblems"] == 0
+    assert data["conquest"]["masteredProblems"] == 0
+    assert data["conquest"]["percentage"] == 0
     assert data["activity"]["startDate"]
     assert data["activity"]["endDate"]
     assert len(data["activity"]["days"]) == 365
@@ -255,3 +269,211 @@ async def test_summary_excludes_discarded_and_in_progress_exams(
     today_str = now.strftime("%Y-%m-%d")
     today_day = next(d for d in data["activity"]["days"] if d["date"] == today_str)
     assert today_day["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_latest_correct_practice_marks_mastered(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    newer = datetime(2026, 2, 1, tzinfo=UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=older, grading_status="incorrect"),
+        make_practice_attempt(user_id, problem["_id"], created_at=newer, grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["totalProblems"] == 1
+    assert data["conquest"]["masteredProblems"] == 1
+    assert data["conquest"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_latest_incorrect_practice_not_mastered(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    newer = datetime(2026, 2, 1, tzinfo=UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=older, grading_status="correct"),
+        make_practice_attempt(user_id, problem["_id"], created_at=newer, grading_status="incorrect"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["masteredProblems"] == 0
+    assert data["conquest"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_exam_correct_item_marks_mastered(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("exams", [
+        make_submitted_exam(
+            user_id,
+            problem_ids=[problem["_id"]],
+            submitted_at=datetime(2026, 1, 15, tzinfo=UTC),
+            item_grading_statuses=["correct"],
+        )
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["masteredProblems"] == 1
+    assert data["conquest"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_exam_incorrect_item_not_mastered(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("exams", [
+        make_submitted_exam(
+            user_id,
+            problem_ids=[problem["_id"]],
+            submitted_at=datetime(2026, 1, 15, tzinfo=UTC),
+            item_grading_statuses=["incorrect"],
+        )
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["triedProblems"] == 1
+    assert data["conquest"]["masteredProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_pending_review_only_not_mastered(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("practice_attempts", [
+        make_practice_attempt(
+            user_id, problem["_id"],
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            grading_status="pending-review",
+        ),
+    ])
+    database.seed("exams", [
+        make_submitted_exam(
+            user_id,
+            problem_ids=[problem["_id"]],
+            submitted_at=datetime(2026, 1, 15, tzinfo=UTC),
+            item_grading_statuses=["pending-review"],
+        )
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["coverage"]["triedProblems"] == 1
+    assert data["conquest"]["masteredProblems"] == 0
+    assert data["conquest"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_pending_after_correct_does_not_override(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    correct_time = datetime(2026, 1, 1, tzinfo=UTC)
+    pending_time = datetime(2026, 2, 1, tzinfo=UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=correct_time, grading_status="correct"),
+        make_practice_attempt(user_id, problem["_id"], created_at=pending_time, grading_status="pending-review"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["masteredProblems"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_deleted_problems_excluded(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    active = make_problem(user_id)
+    deleted = make_problem(user_id, is_deleted=True)
+    database.seed("problems", [active, deleted])
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, deleted["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["totalProblems"] == 1
+    assert data["conquest"]["masteredProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_other_users_excluded(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    other_user_id = ObjectId()
+    own = make_problem(user_id)
+    other = make_problem(other_user_id)
+    database.seed("problems", [own, other])
+    database.seed("practice_attempts", [
+        make_practice_attempt(other_user_id, other["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["totalProblems"] == 1
+    assert data["conquest"]["masteredProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_conquest_exam_overrides_older_practice(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("practice_attempts", [
+        make_practice_attempt(
+            user_id, problem["_id"],
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            grading_status="correct",
+        ),
+    ])
+    database.seed("exams", [
+        make_submitted_exam(
+            user_id,
+            problem_ids=[problem["_id"]],
+            submitted_at=datetime(2026, 2, 1, tzinfo=UTC),
+            item_grading_statuses=["incorrect"],
+        )
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["conquest"]["masteredProblems"] == 0

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -70,6 +70,7 @@ describe("App", () => {
       ok: true,
       json: async () => ({
         coverage: { totalProblems: 0, triedProblems: 0, percentage: 0 },
+        conquest: { totalProblems: 0, masteredProblems: 0, percentage: 0 },
         activity: { startDate: "2024-01-01", endDate: "2024-12-31", days: [{ date: "2024-01-01", count: 0 }] },
       }),
     });

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -33,6 +33,8 @@ function summaryResponse(overrides: Partial<{
   totalProblems: number;
   triedProblems: number;
   percentage: number;
+  masteredProblems: number;
+  conquestPercentage: number;
   days: { date: string; count: number }[];
 }> = {}) {
   const today = new Date();
@@ -42,11 +44,17 @@ function summaryResponse(overrides: Partial<{
     d.setUTCDate(d.getUTCDate() - i);
     days.push({ date: d.toISOString().slice(0, 10), count: 0 });
   }
+  const totalProblems = overrides.totalProblems ?? 2;
   return {
     coverage: {
-      totalProblems: overrides.totalProblems ?? 2,
+      totalProblems,
       triedProblems: overrides.triedProblems ?? 1,
       percentage: overrides.percentage ?? 50,
+    },
+    conquest: {
+      totalProblems,
+      masteredProblems: overrides.masteredProblems ?? 0,
+      percentage: overrides.conquestPercentage ?? 0,
     },
     activity: {
       startDate: days[0].date,
@@ -82,13 +90,15 @@ describe("HomePage", () => {
   it("renders zero-problem state with 0% and note", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => summaryResponse({ totalProblems: 0, triedProblems: 0, percentage: 0 }),
+      json: async () => summaryResponse({ totalProblems: 0, triedProblems: 0, percentage: 0, masteredProblems: 0, conquestPercentage: 0 }),
     });
     renderHomePage();
     await waitFor(() => {
       expect(screen.getByTestId("home-coverage-percentage").textContent).toBe("0%");
     });
     expect(screen.getByTestId("home-coverage-text").textContent).toContain("No problems yet");
+    expect(screen.getByTestId("home-conquest-percentage").textContent).toBe("0%");
+    expect(screen.getByTestId("home-conquest-text").textContent).toContain("No problems yet");
   });
 
   it("renders coverage percentage and supporting text in normal state", async () => {
@@ -101,6 +111,24 @@ describe("HomePage", () => {
       expect(screen.getByTestId("home-coverage-percentage").textContent).toBe("50%");
     });
     expect(screen.getByTestId("home-coverage-text").textContent).toContain("2 of 4 problems tried");
+  });
+
+  it("renders conquest percentage and supporting text in normal state", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({
+        totalProblems: 4,
+        triedProblems: 3,
+        percentage: 75,
+        masteredProblems: 2,
+        conquestPercentage: 50,
+      }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-conquest-percentage").textContent).toBe("50%");
+    });
+    expect(screen.getByTestId("home-conquest-text").textContent).toContain("2 of 4 problems mastered");
   });
 
   it("renders activity grid cells with returned counts", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -8,6 +8,12 @@ interface HomeCoverage {
   percentage: number;
 }
 
+interface HomeConquest {
+  totalProblems: number;
+  masteredProblems: number;
+  percentage: number;
+}
+
 interface HomeActivityDay {
   date: string;
   count: number;
@@ -21,6 +27,7 @@ interface HomeActivity {
 
 interface HomeSummaryResponse {
   coverage: HomeCoverage;
+  conquest: HomeConquest;
   activity: HomeActivity;
 }
 
@@ -94,10 +101,20 @@ export function HomePage() {
     return null;
   }
 
-  const { coverage, activity } = data;
+  const { coverage, conquest, activity } = data;
   const maxCount = activity.days.reduce((max, day) => Math.max(max, day.count), 0);
   const weekColumns = buildWeekColumns(activity.days);
   const zeroProblems = coverage.totalProblems === 0;
+
+  const statCardStyle = {
+    flex: "1 1 0",
+    minWidth: "240px",
+    padding: "1.5rem",
+    backgroundColor: "var(--color-surface)",
+    border: "1px solid var(--color-border)",
+    borderRadius: "var(--radius-lg)",
+    boxShadow: "var(--shadow-sm)",
+  } as const;
 
   return (
     <div style={{ padding: "1.5rem", maxWidth: "1100px", margin: "0 auto" }}>
@@ -105,32 +122,43 @@ export function HomePage() {
         Home
       </h1>
 
-      <section
-        style={{
-          padding: "1.5rem",
-          marginBottom: "1.5rem",
-          backgroundColor: "var(--color-surface)",
-          border: "1px solid var(--color-border)",
-          borderRadius: "var(--radius-lg)",
-          boxShadow: "var(--shadow-sm)",
-        }}
-      >
-        <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.5rem" }}>
-          Problem Coverage
-        </div>
-        <div data-testid="home-coverage-percentage" style={{ fontSize: "3.5rem", fontWeight: 800, lineHeight: 1, color: "var(--color-primary)" }}>
-          {coverage.percentage}%
-        </div>
-        <div data-testid="home-coverage-text" style={{ marginTop: "0.5rem", color: "var(--color-text-muted)", fontSize: "0.95rem" }}>
-          {zeroProblems ? (
-            "No problems yet. Add problems to start tracking coverage."
-          ) : (
-            <>
-              {coverage.triedProblems} of {coverage.totalProblems} problems tried
-            </>
-          )}
-        </div>
-      </section>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem", marginBottom: "1.5rem" }}>
+        <section style={statCardStyle}>
+          <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.5rem" }}>
+            Problem Coverage
+          </div>
+          <div data-testid="home-coverage-percentage" style={{ fontSize: "3.5rem", fontWeight: 800, lineHeight: 1, color: "var(--color-primary)" }}>
+            {coverage.percentage}%
+          </div>
+          <div data-testid="home-coverage-text" style={{ marginTop: "0.5rem", color: "var(--color-text-muted)", fontSize: "0.95rem" }}>
+            {zeroProblems ? (
+              "No problems yet. Add problems to start tracking coverage."
+            ) : (
+              <>
+                {coverage.triedProblems} of {coverage.totalProblems} problems tried
+              </>
+            )}
+          </div>
+        </section>
+
+        <section style={statCardStyle}>
+          <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.5rem" }}>
+            Conquest Rate
+          </div>
+          <div data-testid="home-conquest-percentage" style={{ fontSize: "3.5rem", fontWeight: 800, lineHeight: 1, color: "var(--color-primary)" }}>
+            {conquest.percentage}%
+          </div>
+          <div data-testid="home-conquest-text" style={{ marginTop: "0.5rem", color: "var(--color-text-muted)", fontSize: "0.95rem" }}>
+            {zeroProblems ? (
+              "No problems yet. Add problems to start tracking conquest."
+            ) : (
+              <>
+                {conquest.masteredProblems} of {conquest.totalProblems} problems mastered
+              </>
+            )}
+          </div>
+        </section>
+      </div>
 
       <section
         style={{


### PR DESCRIPTION
## Summary

- Add a `Conquest Rate` stat card beside `Problem Coverage` on the Home dashboard.
- Extend `GET /api/v1/home/summary` with a `conquest` object (`totalProblems`, `masteredProblems`, `percentage`).
- Compute mastery from the latest known correct/incorrect event per non-deleted problem across practice attempts and submitted exam items; pending-review events are ignored for mastery.

## Linked Issue

Closes #307

## Issue Alignment

This PR implements the issue by:

- Extending the Home summary API response with `conquest` data.
- Computing mastered problems from the latest known correct/incorrect result per problem (later events override earlier ones).
- Ignoring `pending-review` events when deciding mastery (they still count for coverage and activity).
- Rendering a `Conquest Rate` card visually beside `Problem Coverage` with comparable prominence.
- Adding backend and frontend tests for the new metric.

Scope covered:

- API `conquest` fields and percentage rounding.
- Mastery is computed from practice attempts (`gradingStatus` + `createdAt`) and submitted exam items (`grading.status` + `exam.submittedAt`).
- Pending-review handling per the issue.
- Frontend: `Conquest Rate` sibling stat card, zero-state and normal supporting text.

Out of scope / intentionally not included:

- Drill-down list of mastered/unmastered problems.
- Subject/tag-specific conquest metrics.
- Changes to the activity grid or to the existing Problem Coverage formula.
- Dark-theme background work.

## Implementation Notes

- Mastery state is tracked as a per-problem `{event_time, is_correct}` tuple. Each mastery-relevant event (correct or incorrect) updates the tuple if its timestamp is newer; pending-review events do not update mastery.
- Submitted exam items use `exam.submittedAt` as the event time per the issue's chosen approach.
- Coverage logic and activity grid behavior are unchanged.
- The two stat cards share a `flex` row container and a common card style so they sit side-by-side and wrap on narrow widths.

## Tests

Commands run:

- `cd backend && uv run pytest tests/api/test_home.py` — passed (18 tests)
- `cd backend && uv run ruff check app/presentation/home.py tests/api/test_home.py` — passed
- `cd frontend && npm test -- --run HomePage` — passed (7 tests)
- `cd frontend && npm run build` — passed (typecheck via `tsc -b` in build)

Automated tests added or updated (backend, `backend/tests/api/test_home.py`):

- Zero-state test now also asserts `conquest` zeros.
- New: latest correct practice attempt marks a problem mastered.
- New: latest incorrect practice attempt makes it not mastered.
- New: latest submitted exam correct item participates in conquest.
- New: latest submitted exam incorrect item does not master.
- New: pending-review-only activity does not mark mastered.
- New: pending-review after correct does not override the latest known correct result.
- New: deleted problems excluded from conquest totals.
- New: other users' data excluded.
- New: exam event overrides older practice event.

Automated tests added or updated (frontend, `frontend/src/pages/HomePage.test.tsx`):

- Zero-state test now also asserts the conquest zero-state card text and `0%`.
- New: renders conquest percentage and `<mastered> of <total> problems mastered` in the normal state.

Manual verification:

- Zero-problem case verified through tests: both cards render `0%` with appropriate zero-state notes.
- Normal case verified through tests: e.g. `triedProblems=2, totalProblems=4` -> coverage `50%`; `masteredProblems=2, totalProblems=4` -> conquest `50%`.

## Deviations From Issue Plan

None.

## Follow-Up Work

None in this PR. Possible future work mentioned in the issue (drill-down lists, subject/tag conquest) is intentionally deferred.
