### PR TITLE
fix(home): paint full-height themed background to remove dark-theme bottom white gap (#309)

### DIFF
--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -99,25 +99,37 @@ export function HomePage() {
     queryFn: () => api.get<HomeSummaryResponse>("/home/summary"),
   });
 
+  const pageCanvasStyle = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-bg)",
+    color: "var(--color-text)",
+    padding: "1.5rem",
+  } as const;
+  const contentStyle = { maxWidth: "1100px", margin: "0 auto" } as const;
+
   if (isLoading) {
     return (
-      <div data-testid="loading" style={{ padding: "2rem", color: "var(--color-text-muted)" }}>
-        Loading dashboard...
-      </div>
+      <main style={pageCanvasStyle}>
+        <div data-testid="loading" style={{ ...contentStyle, padding: "0.5rem 0", color: "var(--color-text-muted)" }}>
+          Loading dashboard...
+        </div>
+      </main>
     );
   }
 
   if (error) {
     const message = error instanceof ApiError ? error.message : "Failed to load dashboard";
     return (
-      <div data-testid="error" style={{ padding: "2rem", color: "var(--color-text-danger)" }}>
-        {message}
-      </div>
+      <main style={pageCanvasStyle}>
+        <div data-testid="error" style={{ ...contentStyle, padding: "0.5rem 0", color: "var(--color-text-danger)" }}>
+          {message}
+        </div>
+      </main>
     );
   }
 
   if (!data) {
-    return null;
+    return <main style={pageCanvasStyle} />;
   }
 
   const { coverage, conquest, activity } = data;
@@ -137,10 +149,11 @@ export function HomePage() {
   } as const;
 
   return (
-    <div style={{ padding: "1.5rem", maxWidth: "1100px", margin: "0 auto" }}>
-      <h1 style={{ fontSize: "1.75rem", fontWeight: 800, marginBottom: "1.5rem", color: "var(--color-text)" }}>
-        Home
-      </h1>
+    <main style={pageCanvasStyle}>
+      <div style={contentStyle}>
+        <h1 style={{ fontSize: "1.75rem", fontWeight: 800, marginBottom: "1.5rem", color: "var(--color-text)" }}>
+          Home
+        </h1>
 
       <div style={{ display: "flex", flexWrap: "wrap", gap: "1rem", marginBottom: "1.5rem" }}>
         <section style={statCardStyle}>
@@ -268,5 +281,6 @@ export function HomePage() {
         </div>
       </section>
     </div>
+    </main>
   );
 }

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -156,7 +156,7 @@ body {
 }
 
 html, #root {
-  height: 100%;
+  min-height: 100%;
   background: var(--color-bg);
   color: var(--color-text);
 }

--- a/frontend/tests/theme.spec.ts
+++ b/frontend/tests/theme.spec.ts
@@ -194,6 +194,81 @@ test.describe("Theme E2E", () => {
   });
 });
 
+test.describe("Home Page Theme", () => {
+  test("home page renders in light theme", async ({ page, request }) => {
+    const session = await createSession(request, "home_light");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "light");
+
+    await page.goto("/");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("light");
+
+    await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
+  });
+
+  test("home page renders in dark theme", async ({ page, request }) => {
+    const session = await createSession(request, "home_dark");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
+  });
+
+  test("home page dark theme paints a non-white full-page background", async ({ page, request }) => {
+    const session = await createSession(request, "home_dark_bg");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/");
+
+    const themeAttr = await page.locator("html").getAttribute("data-theme");
+    expect(themeAttr).toBe("dark");
+
+    await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
+
+    const mainBg = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      if (!main) return null;
+      return window.getComputedStyle(main).backgroundColor;
+    });
+    expect(mainBg).not.toBe("rgb(255, 255, 255)");
+    expect(mainBg).not.toBe("rgba(0, 0, 0, 0)");
+
+    const mainHeight = await page.evaluate(() => {
+      const main = document.querySelector("main");
+      return main ? main.getBoundingClientRect().height : 0;
+    });
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    expect(mainHeight).toBeGreaterThanOrEqual(viewportHeight - 60);
+  });
+
+  test("home page dark theme has no white pixel below the fold", async ({ page, request }) => {
+    const session = await createSession(request, "home_dark_no_white");
+    await addAuthenticatedSession(page, session);
+    await setTheme(page, "dark");
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { name: "Home" })).toBeVisible();
+
+    const bottomBg = await page.evaluate(() => {
+      const x = Math.floor(window.innerWidth / 2);
+      const y = window.innerHeight - 5;
+      const el = document.elementFromPoint(x, y);
+      if (!el) return null;
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    expect(bottomBg).not.toBe("rgb(255, 255, 255)");
+  });
+});
+
 test.describe("Problems Page Theme", () => {
   test("problems page renders in light theme", async ({ page, request }) => {
     const session = await createSession(request, "problems_light");


### PR DESCRIPTION
Closes #309

## Root Cause
`HomePage` returned plain `<div>` wrappers for every state (loading, error, null, loaded) with no `minHeight` and no background. When the loaded content was shorter than the viewport (or while loading), the area below the content exposed whatever background was painted by `body`/`#root`. The root rule used `height: 100%` which doesn't stretch when content overflows, leaving a white/non-themed gap at the bottom — most visible in dark theme.

Every other page (`ProblemsPage`, `SettingsPage`, `TagsPage`, `ProblemDetailPage`, etc.) already wraps content in `<main style={{ minHeight: 'calc(100vh - 60px)', backgroundColor: 'var(--color-bg)' }}>`. `HomePage` was the only outlier.

## Changes
- `frontend/src/pages/HomePage.tsx`: wrap loading, error, null, and loaded states in a `<main>` with `minHeight: calc(100vh - 60px)` and `backgroundColor: var(--color-bg)`, matching the app-wide pattern. Inner container retains `maxWidth: 1100px` centering.
- `frontend/src/theme.css`: change `html, #root` from `height: 100%` to `min-height: 100%` so the themed root background extends below the viewport when content is taller, guarding future pages that forget their own background.
- `frontend/tests/theme.spec.ts`: add **Home Page Theme** suite — light render, dark render, dark `<main>` background is non-white and fills viewport minus header, and bottom-of-fold element is non-white.

## Verification
- `npm test -- --run` → 325/325 unit tests pass
- `npx tsc --noEmit` → clean
- `npx playwright test theme.spec.ts` → 42/42 theme E2E tests pass (4 new Home tests included)

## Scope
Surgical fix only: no metric, layout, or visual changes beyond restoring full-height themed background on Home.