### PR TITLE
cleanup(#317): move test deps to dev extras and remove python-dotenv

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run backend test suite
         working-directory: backend
-        run: uv run --frozen pytest
+        run: uv run --frozen --extra dev pytest
 
   frontend-tests:
     name: Frontend Tests

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,17 +10,17 @@ dependencies = [
   "fastapi>=0.115.0,<1.0.0",
   "httpx>=0.27.0,<1.0.0",
   "pydantic>=2.7.0,<3.0.0",
-  "pydantic-settings>=2.3.0,<3.0.0",
+  "pydantic-settings[dotenv]>=2.3.0,<3.0.0",
   "pymongo>=4.8.0,<5.0.0",
-  "python-dotenv>=1.0.1,<2.0.0",
-  "pytest>=8.2.0,<9.0.0",
-  "pytest-asyncio>=0.23.7,<1.0.0",
   "uvicorn>=0.30.0,<1.0.0",
   "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]
-dev = []
+dev = [
+  "pytest>=8.2.0,<9.0.0",
+  "pytest-asyncio>=0.23.7,<1.0.0",
+]
 
 [build-system]
 requires = ["hatchling>=1.25.0"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -232,11 +232,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
 ]
 
 [package.metadata]
@@ -246,11 +249,10 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
     { name = "pydantic", specifier = ">=2.7.0,<3.0.0" },
-    { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
+    { name = "pydantic-settings", extras = ["dotenv"], specifier = ">=2.3.0,<3.0.0" },
     { name = "pymongo", specifier = ">=4.8.0,<5.0.0" },
-    { name = "pytest", specifier = ">=8.2.0,<9.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23.7,<1.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.1,<2.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0,<9.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.7,<1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "uvicorn", specifier = ">=0.30.0,<1.0.0" },
 ]


### PR DESCRIPTION
## Summary

This PR cleans up the backend dependencies by moving test-specific dependencies to the `dev` optional-dependencies extra and removing the redundant direct `python-dotenv` dependency, replacing it with `pydantic-settings[dotenv]`.

## Linked Issue

Closes #317

## Issue Alignment

This PR implements the issue by:
- Moving `pytest` and `pytest-asyncio` from production dependencies to `[project.optional-dependencies] dev`.
- Removing the direct `python-dotenv` dependency.
- Adding `pydantic-settings[dotenv]` to explicitly declare the transitive dependency required for loading `.env` files.
- Regenerating `uv.lock`.

Scope covered:
- Moving `pytest` and `pytest-asyncio` to dev extras in `pyproject.toml`.
- Removing direct `python-dotenv` dependency.
- Changing `pydantic-settings` to `pydantic-settings[dotenv]`.
- Updating `uv.lock`.

Out of scope / intentionally not included:
- Changing the Dockerfile.
- Auditing other dependencies for misclassification.
- Changing any application code.

## Implementation Notes

None.

## Tests

Commands run:

- `uv run pytest tests/ -v` — passed (524 passed, 1 skipped)

Automated tests added or updated:

- None (dependency-only change).

Manual verification:
- Run: `uv sync --no-dev && .venv/bin/python -c "import pytest"` — failed with `ModuleNotFoundError` as expected.
- Run: `uv sync --no-dev && .venv/bin/python -c "from app.infrastructure.config.settings import Settings; print(Settings())"` — succeeded as expected.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
