### PR TITLE
fix: match problem detail Graph DSL viewport to ingestion preview

### DIFF
--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -20,6 +20,14 @@ vi.mock("@/api/client", () => ({
   },
 }));
 
+vi.mock("@/components/GraphSandbox", () => ({
+  GraphSandbox: ({ dsl, height }: { dsl: string; height?: number }) => (
+    <div data-testid="graph-sandbox" data-dsl={dsl} data-height={height}>
+      GraphSandbox
+    </div>
+  ),
+}));
+
 import { api } from "@/api/client";
 
 const mockNavigate = vi.fn();
@@ -132,6 +140,21 @@ describe("ProblemDetailPage", () => {
       expect(screen.getByRole("button", { name: "Hide Answer" })).toBeInTheDocument();
     });
     expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("renders graph DSL with 300px height and no 400px max-width wrapper", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: { ...baseProblem, graphDsl: "board.create('point', [0, 0]);" } })
+      .mockResolvedValueOnce(baseTracking);
+
+    renderProblemDetailPage();
+
+    const sandbox = await screen.findByTestId("graph-sandbox");
+    expect(sandbox).toHaveAttribute("data-dsl", "board.create('point', [0, 0]);");
+    expect(sandbox).toHaveAttribute("data-height", "300");
+
+    const wrapper = sandbox.parentElement;
+    expect(wrapper).not.toHaveStyle({ maxWidth: "400px" });
   });
 
   it("enters edit mode when clicking edit", async () => {

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -456,8 +456,8 @@ export function ProblemDetailPage() {
                 style={{ width: "100%", minHeight: "100px", marginTop: "0.25rem", fontFamily: "monospace", fontSize: "0.875rem" }}
               />
             ) : (
-              <div style={{ marginTop: "0.5rem", maxWidth: "400px" }}>
-                <GraphSandbox dsl={problem.graphDsl ?? ""} />
+              <div style={{ marginTop: "0.5rem" }}>
+                <GraphSandbox dsl={problem.graphDsl ?? ""} height={300} />
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

Fixes the problem detail page Graph DSL viewport so it no longer appears forced into a 400×400 square. The detail page now matches the ingestion preview behavior: full-width/responsive container with a 300px-tall graph viewport.

## Linked Issue

Closes #325

## Issue Alignment

This PR implements the issue by:

- Updating the non-edit Graph DSL section in `ProblemDetailPage`.
- Removing the `maxWidth: "400px"` wrapper that produced the square viewport.
- Passing `height={300}` to `GraphSandbox`, matching ingestion preview.
- Adding a regression test that verifies the 300px height and the absence of the 400px max-width wrapper.

Scope covered:

- Caller-level sizing fix in `ProblemDetailPage`.
- Targeted regression test for problem detail graph sizing.

Out of scope / intentionally not included:

- No changes to `GraphSandbox` defaults, iframe security, DSL execution, or backend behavior.
- No audit or changes to other graph surfaces (active practice, active exam, exam detail, coaching).

## Implementation Notes

- The fix is limited to `frontend/src/pages/ProblemDetailPage.tsx`.
- The ingestion preview surfaces (`ConfirmingStep.tsx` and `EditingStep.tsx`) already render `<GraphSandbox dsl={...} height={300} />` without a `maxWidth` wrapper; the detail page now uses the same pattern.
- `GraphSandbox` remains unchanged globally.

## Tests

Commands run:

- `cd frontend && npm test -- ProblemDetailPage.test.tsx --run` — passed (26 tests)
- `cd frontend && npm run build` — passed
- `cd frontend && npm test -- --run` — passed (326 tests across 25 files)

Automated tests added or updated:

- Added `renders graph DSL with 300px height and no 400px max-width wrapper` in `ProblemDetailPage.test.tsx`.
- Added a `GraphSandbox` mock in `ProblemDetailPage.test.tsx` to assert the props and wrapper styles directly.

Manual verification:

- Full visual comparison between ingestion preview and saved problem detail requires a running backend with a problem that contains `graphDsl`, which is not available in this automated environment.
- The code change exactly mirrors the ingestion preview implementation, and the regression test verifies the observable React-rendered props and wrapper styles.
- Recommended manual flow for a human reviewer:
  1. Open or create an ingestion preview containing Graph DSL.
  2. Observe the graph preview proportions (full-width, 300px height).
  3. Confirm/save the problem.
  4. Open the saved problem detail page.
  5. Confirm the graph viewport is full-width/responsive with a 300px height and matches ingestion preview proportions.

## Deviations From Issue Plan

None.

## Follow-Up Work

None required. A broader audit of graph sizing across other surfaces remains out of scope per the issue.
