### PR TITLE
feat: increase exam problem count limit to 30

### DIFF
--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -12,7 +12,7 @@ from app.presentation.schemas import CorrectAnswerPayload, SourceImagePayload
 
 
 class CreateExamRequest(BaseModel):
-    maxProblemCount: int = Field(ge=1, le=20)
+    maxProblemCount: int = Field(ge=1, le=30)
 
 
 class SaveAnswerRequest(BaseModel):

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -220,7 +220,7 @@ async def test_create_exam_snapshots_selected_problems(exams_app: FastAPI, clien
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("max_problem_count", [1, 20])
+@pytest.mark.parametrize("max_problem_count", [1, 30])
 async def test_create_exam_accepts_problem_count_boundaries(
     exams_app: FastAPI,
     client: AsyncClient,
@@ -251,7 +251,7 @@ async def test_create_exam_accepts_problem_count_boundaries(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("max_problem_count", [0, 21])
+@pytest.mark.parametrize("max_problem_count", [0, 31])
 async def test_create_exam_rejects_problem_count_outside_product_limit(
     client: AsyncClient,
     max_problem_count: int,

--- a/frontend/src/pages/ExamsPage.test.tsx
+++ b/frontend/src/pages/ExamsPage.test.tsx
@@ -144,11 +144,11 @@ describe("ExamsPage", () => {
     const slider = screen.getByLabelText("Problem count slider");
     expect(input).toHaveValue(5);
     expect(input).toHaveAttribute("min", "1");
-    expect(input).toHaveAttribute("max", "20");
+    expect(input).toHaveAttribute("max", "30");
     expect(input).toHaveAttribute("step", "1");
     expect(slider).toHaveValue("5");
     expect(slider).toHaveAttribute("min", "1");
-    expect(slider).toHaveAttribute("max", "20");
+    expect(slider).toHaveAttribute("max", "30");
     expect(slider).toHaveAttribute("step", "1");
   });
 
@@ -167,7 +167,7 @@ describe("ExamsPage", () => {
     expect(input).toHaveValue(7);
   });
 
-  it.each(["", "1.5", "0", "-1", "21"])(
+  it.each(["", "1.5", "0", "-1", "31"])(
     "shows validation and disables creation for invalid value %s",
     async (value) => {
       const user = userEvent.setup();
@@ -180,7 +180,7 @@ describe("ExamsPage", () => {
         await user.type(input, value);
       }
 
-      expect(screen.getByRole("alert")).toHaveTextContent("Enter a whole number from 1 to 20.");
+      expect(screen.getByRole("alert")).toHaveTextContent("Enter a whole number from 1 to 30.");
       expect(screen.getByRole("button", { name: "Create Exam" })).toBeDisabled();
     },
   );
@@ -196,7 +196,7 @@ describe("ExamsPage", () => {
 
     const input = screen.getByLabelText("Problem count");
     await user.clear(input);
-    await user.type(input, "21");
+    await user.type(input, "31");
     expect(screen.getByRole("button", { name: "Create Exam" })).toBeDisabled();
 
     await user.clear(input);

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -9,7 +9,7 @@ import Pagination from "@/components/Pagination";
 import { Modal } from "@/components/Modal";
 
 const EXAM_PROBLEM_COUNT_MIN = 1;
-const EXAM_PROBLEM_COUNT_MAX = 20;
+const EXAM_PROBLEM_COUNT_MAX = 30;
 const EXAM_PROBLEM_COUNT_DEFAULT = 5;
 
 function getStateStyleClass(state: string) {


### PR DESCRIPTION
## Summary

Increases the maximum number of problems allowed when creating a new exam from 20 to 30, keeping the minimum at 1 and the default at 5. The change is applied consistently across the frontend exam creation modal and backend API request validation.

## Linked Issue

Closes #327

## Issue Alignment

This PR implements the issue by:

- Updating the frontend exam creation maximum from 20 to 30.
- Updating backend `CreateExamRequest.maxProblemCount` validation from `le=20` to `le=30`.
- Updating frontend tests for the new max, validation text, and invalid above-max value.
- Updating backend API tests for the new accepted and rejected boundaries.

Scope covered:

- Frontend input max, slider max, slider max label, and validation message now derive from the updated `EXAM_PROBLEM_COUNT_MAX = 30` constant.
- Backend request validation accepts 30 and rejects 31.
- Test coverage for the new boundary.

Out of scope / intentionally not included:

- Minimum problem count, default problem count, and exam selection algorithm behavior remain unchanged.
- Pagination limits, coaching message caps, practice history limits, and other unrelated limits were not changed.
- No new shared configuration or cross-layer constants were introduced.

## Implementation Notes

- The change is limited to the existing hard-coded max in `ExamsPage.tsx` and the Pydantic `Field(le=...)` in `exam_serialization.py`.
- All UI controls and messages derive from `EXAM_PROBLEM_COUNT_MAX`, so a single constant change updates the number input, range slider, visible max label, and validation text.

## Tests

Commands run:

- `cd frontend && npm test -- ExamsPage.test.tsx --run` — passed (13 tests)
- `cd frontend && npm run build` — passed
- `cd backend && uv run pytest tests/api/test_exams.py` — passed (18 tests)

Automated tests added or updated:

- `frontend/src/pages/ExamsPage.test.tsx`:
  - Updated `shows default synchronized controls with product limits` to assert `max="30"` on input and slider.
  - Updated `shows validation and disables creation for invalid value %s` to use `31` as the above-max invalid value and expect `Enter a whole number from 1 to 30.`
  - Updated `clears validation and submits the selected valid problem count` to type `31` as the disabled value.
- `backend/tests/api/test_exams.py`:
  - Updated `test_create_exam_accepts_problem_count_boundaries` to parametrize `[1, 30]`.
  - Updated `test_create_exam_rejects_problem_count_outside_product_limit` to parametrize `[0, 31]`.

Manual verification:

- Full manual UI verification (opening the modal, verifying the slider/input allow 30, and creating an exam with 30 problems) requires a running backend with enough eligible problems, which is not available in this automated environment.
- Recommended manual flow for a human reviewer:
  1. Open the exam creation modal.
  2. Verify the number input and slider allow values up to 30.
  3. Enter 31 and confirm the validation message `Enter a whole number from 1 to 30.` appears and `Create Exam` is disabled.
  4. Enter 30 and confirm `Create Exam` is enabled.
  5. With enough eligible problems, create an exam with 30 problems and verify the request succeeds.

## Deviations From Issue Plan

None.

## Follow-Up Work

None required.
