### PR TITLE
Update problem selection failure scoring formula

### DIFF
--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import List, Optional
+import math
 import random
 
 from .models import Problem
@@ -68,12 +69,11 @@ def compute_score_breakdown(
         recency_score = 1.0
 
     # Failure score
-    attempt_count = problem.tracking.correctCount + problem.tracking.failedCount
-    if attempt_count == 0:
-        failure_score = 1.0
+    diff = problem.tracking.failedCount - problem.tracking.correctCount
+    if diff == 0:
+        failure_score = 0.0
     else:
-        failure_rate = problem.tracking.failedCount / attempt_count
-        failure_score = 1.0 + (failure_rate - 0.5) / 0.5
+        failure_score = math.copysign(math.sqrt(abs(diff)), diff)
 
     # Last wrong score
     if problem.tracking.lastTestedAt is None:
@@ -89,11 +89,13 @@ def compute_score_breakdown(
     failure = failure_score * config.failure_rate_weight
     last_wrong = last_wrong_score * config.last_wrong_weight
 
+    total = max(0.0, recency + failure + last_wrong)
+
     return ScoreBreakdown(
         recency=recency,
         failure=failure,
         last_wrong=last_wrong,
-        total=last_wrong + failure + recency,
+        total=total,
     )
 
 
@@ -102,24 +104,27 @@ def _weighted_sample_without_replacement(
     count: int,
     rng: random.Random,
 ) -> list[Problem]:
-    """Select up to `count` unique problems using weighted random sampling."""
+    """Select up to `count` unique problems using weighted random sampling.
+
+    Candidates are expected to have positive weights; zero or negative weights
+    are filtered out by ``select_problems`` before this function is called.
+    """
     selected: list[Problem] = []
     remaining = list(candidates)
 
     while len(selected) < count and remaining:
         total_weight = sum(weight for _, weight in remaining)
         if total_weight <= 0:
-            # Uniform fallback when all weights are zero
-            chosen_idx = rng.randrange(len(remaining))
-        else:
-            r = rng.random() * total_weight
-            cumulative = 0.0
-            chosen_idx = 0
-            for idx, (_, weight) in enumerate(remaining):
-                cumulative += weight
-                if r <= cumulative:
-                    chosen_idx = idx
-                    break
+            break
+
+        r = rng.random() * total_weight
+        cumulative = 0.0
+        chosen_idx = 0
+        for idx, (_, weight) in enumerate(remaining):
+            cumulative += weight
+            if r <= cumulative:
+                chosen_idx = idx
+                break
 
         problem, _ = remaining.pop(chosen_idx)
         selected.append(problem)
@@ -142,7 +147,11 @@ def select_problems(
     weighted = []
     for problem in eligible:
         breakdown = compute_score_breakdown(problem, config, now)
-        weighted.append((problem, breakdown.total))
+        if breakdown.total > 0:
+            weighted.append((problem, breakdown.total))
+
+    if not weighted:
+        return []
 
     if rng is None:
         rng = random.Random()

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -346,9 +346,9 @@ async def test_problem_tracking_includes_practice_weight_with_exact_values(
     assert body["problemId"] == str(problem["_id"])
     assert body["practiceWeight"] == {
         "lastWrong": 1.5,
-        "failure": 2.0,
+        "failure": 0.0,
         "recency": 1.0,
-        "total": 4.5,
+        "total": 2.5,
     }
 
 

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -383,7 +383,8 @@ def test_compute_problem_weight_breakdown_all_components():
         "p1",
         last_attempt_correct=False,
         exposure_count=10,
-        failed_count=5,
+        failed_count=7,
+        correct_count=3,
         last_tested_at=last_tested,
     )
     config = PracticeSelectionConfig(
@@ -397,15 +398,14 @@ def test_compute_problem_weight_breakdown_all_components():
     # lastWrong = 2.0 * 1.5 = 3.0
     assert breakdown.lastWrong == 3.0
 
-    # failure_rate = 5 / 10 = 0.5, failure_score = 1.0 + (0.5 - 0.5)/0.5 = 1.0
-    # failure = 1.0 * 2.0 = 2.0
-    assert breakdown.failure == 2.0
+    # diff = 7 - 3 = 4, failure_score = sqrt(4) = 2.0, failure = 2.0 * 2.0 = 4.0
+    assert breakdown.failure == 4.0
 
     # days_since = 30, recency_score = 1.0 + 30/30 = 2.0
     # recency = 2.0 * 1.0 = 2.0
     assert breakdown.recency == 2.0
 
-    assert breakdown.total == 7.0
+    assert breakdown.total == 9.0
     assert breakdown.total == breakdown.lastWrong + breakdown.failure + breakdown.recency
 
 
@@ -416,10 +416,10 @@ def test_compute_problem_weight_breakdown_never_tested():
     breakdown = compute_problem_weight_breakdown(problem, config, now)
 
     assert breakdown.lastWrong == 1.0
-    assert breakdown.failure == 1.0
+    assert breakdown.failure == 0.0
     # Recency falls back to createdAt (30 days ago): score = 1.0 + 30/30 = 2.0
     assert breakdown.recency == 2.0
-    assert breakdown.total == 4.0
+    assert breakdown.total == 3.0
 
 
 def test_compute_problem_weight_breakdown_zero_attempts():
@@ -429,10 +429,10 @@ def test_compute_problem_weight_breakdown_zero_attempts():
     breakdown = compute_problem_weight_breakdown(problem, config, now)
 
     assert breakdown.lastWrong == 1.0
-    assert breakdown.failure == 1.0
+    assert breakdown.failure == 0.0
     # Recency falls back to createdAt (30 days ago): score = 1.0 + 30/30 = 2.0
     assert breakdown.recency == 2.0
-    assert breakdown.total == 4.0
+    assert breakdown.total == 3.0
 
 
 def test_compute_problem_weight_breakdown_uses_same_total_as_selection():

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -150,39 +150,52 @@ def test_recency_uses_created_at_when_not_tested():
     assert breakdown.recency == 2.5
 
 
-def test_failure_score_zero_percent():
-    now = datetime.now(timezone.utc)
-    problem = create_test_problem("p1", exposure_count=10, failed_count=0, correct_count=10)
-    config = ProblemSelectionConfig(failure_rate_weight=1.0)
-    breakdown = compute_score_breakdown(problem, config, now)
-    # failure_rate = 0/10 = 0, failure_score = 1.0 + (0 - 0.5)/0.5 = 0.0
-    assert breakdown.failure == 0.0
-
-
-def test_failure_score_fifty_percent():
-    now = datetime.now(timezone.utc)
-    problem = create_test_problem("p1", exposure_count=10, failed_count=5, correct_count=5)
-    config = ProblemSelectionConfig(failure_rate_weight=1.0)
-    breakdown = compute_score_breakdown(problem, config, now)
-    # failure_rate = 5/10 = 0.5, failure_score = 1.0 + (0.5 - 0.5)/0.5 = 1.0
-    assert breakdown.failure == 1.0
-
-
-def test_failure_score_hundred_percent():
-    now = datetime.now(timezone.utc)
-    problem = create_test_problem("p1", exposure_count=10, failed_count=10, correct_count=0)
-    config = ProblemSelectionConfig(failure_rate_weight=1.0)
-    breakdown = compute_score_breakdown(problem, config, now)
-    # failure_rate = 10/10 = 1.0, failure_score = 1.0 + (1.0 - 0.5)/0.5 = 2.0
-    assert breakdown.failure == 2.0
-
-
 def test_failure_score_no_attempts():
     now = datetime.now(timezone.utc)
     problem = create_test_problem("p1", exposure_count=0, failed_count=0, correct_count=0)
     config = ProblemSelectionConfig(failure_rate_weight=1.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    assert breakdown.failure == 1.0
+    assert breakdown.failure == 0.0
+
+
+def test_failure_score_more_correct_than_failed():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=4, failed_count=0, correct_count=4)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == -2.0
+
+
+def test_failure_score_more_failed_than_correct():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=4, failed_count=4, correct_count=0)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 2.0
+
+
+def test_failure_score_equal_failed_and_correct():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=10, failed_count=5, correct_count=5)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 0.0
+
+
+def test_failure_score_large_difference():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=9, failed_count=9, correct_count=0)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 3.0
+
+
+def test_failure_score_weighted_multiplier():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=4, failed_count=4, correct_count=0)
+    config = ProblemSelectionConfig(failure_rate_weight=2.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 4.0
 
 
 def test_last_wrong_never_tested():
@@ -225,8 +238,8 @@ def test_weighted_total_equals_component_sum():
         last_tested_at=last_tested,
         last_attempt_correct=False,
         exposure_count=10,
-        failed_count=5,
-        correct_count=5,
+        failed_count=7,
+        correct_count=3,
     )
     config = ProblemSelectionConfig(
         recency_weight=1.0,
@@ -236,12 +249,31 @@ def test_weighted_total_equals_component_sum():
     breakdown = compute_score_breakdown(problem, config, now)
     # recency_score = 1.0 + 30/30 = 2.0, recency = 2.0 * 1.0 = 2.0
     assert breakdown.recency == 2.0
-    # failure_rate = 5/10 = 0.5, failure_score = 1.0 + (0.5 - 0.5)/0.5 = 1.0, failure = 1.0 * 2.0 = 2.0
-    assert breakdown.failure == 2.0
+    # diff = 7 - 3 = 4, failure_score = sqrt(4) = 2.0, failure = 2.0 * 2.0 = 4.0
+    assert breakdown.failure == 4.0
     # last_wrong_score = 2.0, last_wrong = 2.0 * 1.5 = 3.0
     assert breakdown.last_wrong == 3.0
-    assert breakdown.total == 7.0
+    assert breakdown.total == 9.0
     assert breakdown.total == breakdown.recency + breakdown.failure + breakdown.last_wrong
+
+
+def test_total_score_capped_at_zero():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem(
+        "p1",
+        exposure_count=10,
+        failed_count=0,
+        correct_count=10,
+        last_attempt_correct=True,
+    )
+    config = ProblemSelectionConfig(
+        recency_weight=0.0,
+        failure_rate_weight=1.0,
+        last_wrong_weight=1.0,
+    )
+    breakdown = compute_score_breakdown(problem, config, now)
+    # failure = -sqrt(10) ≈ -3.162, last_wrong = 0.5, recency = 0
+    assert breakdown.total == 0.0
 
 
 def test_cooldown_excludes_recent():
@@ -257,7 +289,7 @@ def test_cooldown_excludes_recent():
     assert "recent" not in ids
 
 
-def test_zero_total_weights_fallback_uniform():
+def test_zero_total_weights_excludes_all_candidates():
     now = datetime.now(timezone.utc)
     problems = [
         create_test_problem("a"),
@@ -271,8 +303,25 @@ def test_zero_total_weights_fallback_uniform():
     import random
     rng = random.Random(42)
     selected = select_problems(problems, 1, config, now=now, rng=rng)
+    assert selected == []
+
+
+def test_zero_score_candidates_excluded_from_selection():
+    now = datetime.now(timezone.utc)
+    problems = [
+        create_test_problem("zero", exposure_count=10, failed_count=0, correct_count=10, last_attempt_correct=True),
+        create_test_problem("positive", exposure_count=10, failed_count=4, correct_count=0),
+    ]
+    config = ProblemSelectionConfig(
+        recency_weight=0.0,
+        failure_rate_weight=1.0,
+        last_wrong_weight=0.0,
+    )
+    import random
+    rng = random.Random(42)
+    selected = select_problems(problems, 10, config, now=now, rng=rng)
     assert len(selected) == 1
-    assert selected[0].id in ("a", "b")
+    assert selected[0].id == "positive"
 
 
 def test_multi_selection_no_duplicates():


### PR DESCRIPTION
## Summary

Updates the shared problem selection scoring so the failure component reflects net struggle (failed minus correct attempts) using a signed square-root, caps the final total score at zero, and excludes zero-score problems from random selection.

## Linked Issue

Closes #329

## Issue Alignment

This PR implements the issue by:

- Replacing the rate-based failure formula with `sign(failedCount - correctCount) * sqrt(abs(failedCount - correctCount))`.
- Continuing to multiply the new failure component by `failureRateWeight` for API/settings compatibility.
- Capping `ScoreBreakdown.total` at `0` after summing weighted recency, failure, and last-wrong components.
- Filtering out candidates with `total <= 0` before weighted random sampling in `select_problems`.
- Updating focused backend tests for the new formula, capped totals, and zero-score exclusion.

Scope covered:

- Shared scoring logic in `backend/app/domain/selection.py`.
- Practice selection weight breakdown via `backend/app/domain/practice_selection.py`.
- Exam selection (uses the shared `select_problems`).
- Problem tracking weight payload in `backend/app/presentation/problems.py`.
- Backend tests in `test_selection.py`, `test_practice_selection.py`, and `test_problems.py`.

Out of scope / intentionally not included:

- No renaming of `failureRateWeight` or other public settings/API fields.
- No data migrations.
- No frontend UI changes.
- No changes to recency, last-wrong, cooldown, or minimum-age eligibility.
- No broad refactors unrelated to selection scoring.
- Problem-list `selectionScore` sorting does not currently exist in the codebase, so no sorting endpoint was added or modified.

## Implementation Notes

- Added `import math` and replaced the failure-rate branch with a single signed square-root calculation.
- `total` is now `max(0.0, recency + failure + last_wrong)`.
- `_weighted_sample_without_replacement` now breaks instead of falling back to uniform selection when the remaining weight is non-positive; zero/negative candidates are filtered out upstream.
- Test expectations were updated to match the new formula examples from the issue (`failed=0,correct=0 -> 0`, `failed=4,correct=0 -> 2`, `failed=0,correct=4 -> -2`, `failed=9,correct=0 -> 3`, etc.).

## Tests

Commands run:

- `uv run --extra dev pytest tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/api/test_problems.py tests/api/test_exams.py -q` — 109 passed
- `uv run --extra dev pytest -q` — 533 passed, 1 skipped

Automated tests added or updated:

- `test_selection.py`: updated failure-score tests to the signed square-root formula; added tests for capped totals and zero-score exclusion.
- `test_practice_selection.py`: updated weight-breakdown expectations for zero-attempt and multi-component cases.
- `test_problems.py`: updated exact `practiceWeight` payload expectation for a zero-attempt problem.

Manual verification:

- Verified representative score breakdowns:
  - Never attempted: failure = 0, total from recency + last_wrong.
  - Mostly correct: failure negative, total capped at 0 if weighted sum is negative.
  - Equal correct/failed: failure = 0.
  - Mostly failed: failure positive, increasing with sqrt of the difference.
- Confirmed `failureRateWeight` still scales the failure component.
- Confirmed zero-score candidates are not returned by `select_problems`.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
