### PR TITLE
Add click-only tooltip to Home activity grid

### DIFF
--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { HomePage } from "./HomePage";
 import { ThemeProvider } from "@/contexts/ThemeContext";
@@ -67,6 +68,10 @@ function summaryResponse(overrides: Partial<{
 describe("HomePage", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders loading state initially", () => {
@@ -251,6 +256,189 @@ describe("HomePage", () => {
     expect(weekdayLabels.map((l) => l.textContent)).toEqual([
       "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun",
     ]);
+  });
+
+  it("shows a custom tooltip when clicking a real activity cell", async () => {
+    const user = userEvent.setup();
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const days: { date: string; count: number }[] = [];
+    for (let i = 364; i >= 0; i--) {
+      const d = new Date(today);
+      d.setUTCDate(d.getUTCDate() - i);
+      const dateStr = d.toISOString().slice(0, 10);
+      days.push({ date: dateStr, count: dateStr === todayStr ? 5 : 0 });
+    }
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    const activeCell = screen.getAllByTestId("home-activity-cell").find((c) => c.getAttribute("data-date") === todayStr);
+    expect(activeCell).toBeDefined();
+    await user.click(activeCell as HTMLElement);
+
+    const tooltip = screen.getByTestId("home-activity-tooltip");
+    expect(tooltip.textContent).toBe(`${todayStr}: 5 events`);
+  });
+
+  it("uses singular event text for count of 1", async () => {
+    const user = userEvent.setup();
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const days = [{ date: todayStr, count: 1 }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    const activeCell = screen.getByLabelText(`${todayStr}: 1 event`);
+    await user.click(activeCell);
+
+    expect(screen.getByTestId("home-activity-tooltip").textContent).toBe(`${todayStr}: 1 event`);
+  });
+
+  it("hides the tooltip after 3 seconds", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const days = [{ date: todayStr, count: 2 }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    const activeCell = screen.getByLabelText(`${todayStr}: 2 events`);
+    await user.click(activeCell);
+    expect(screen.getByTestId("home-activity-tooltip")).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(screen.queryByTestId("home-activity-tooltip")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("replaces tooltip and restarts timer when clicking a different cell", async () => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    const todayStr = today.toISOString().slice(0, 10);
+    const yesterdayStr = yesterday.toISOString().slice(0, 10);
+    const days = [
+      { date: yesterdayStr, count: 1 },
+      { date: todayStr, count: 2 },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    const yesterdayCell = screen.getByLabelText(`${yesterdayStr}: 1 event`);
+    const todayCell = screen.getByLabelText(`${todayStr}: 2 events`);
+
+    await user.click(yesterdayCell);
+    expect(screen.getByTestId("home-activity-tooltip").textContent).toBe(`${yesterdayStr}: 1 event`);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await user.click(todayCell);
+    expect(screen.getByTestId("home-activity-tooltip").textContent).toBe(`${todayStr}: 2 events`);
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(screen.getByTestId("home-activity-tooltip")).toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(screen.queryByTestId("home-activity-tooltip")).not.toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("no longer renders native title attribute on real cells", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const days = [{ date: todayStr, count: 2 }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    const activeCell = screen.getByLabelText(`${todayStr}: 2 events`);
+    expect(activeCell).not.toHaveAttribute("title");
+  });
+
+  it("keeps padding cells inert and without tooltip", async () => {
+    const user = userEvent.setup();
+    const days = buildDayRange("2025-06-22", 365);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    const paddingCell = screen.getAllByTestId("home-activity-cell").find((c) => c.getAttribute("data-date") === "");
+    expect(paddingCell).toBeDefined();
+    expect(paddingCell).toHaveAttribute("aria-hidden", "true");
+    expect(paddingCell).not.toHaveAttribute("tabindex");
+
+    await user.click(paddingCell as HTMLElement);
+    expect(screen.queryByTestId("home-activity-tooltip")).not.toBeInTheDocument();
+  });
+
+  it("activates tooltip with Enter and Space on real cells", async () => {
+    const today = new Date();
+    const todayStr = today.toISOString().slice(0, 10);
+    const days = [{ date: todayStr, count: 3 }];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+    const activeCell = screen.getByLabelText(`${todayStr}: 3 events`);
+    activeCell.focus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByTestId("home-activity-tooltip").textContent).toBe(`${todayStr}: 3 events`);
+
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(screen.queryByTestId("home-activity-tooltip")).not.toBeInTheDocument();
+
+    await user.keyboard(" ");
+    expect(screen.getByTestId("home-activity-tooltip").textContent).toBe(`${todayStr}: 3 events`);
+
+    vi.useRealTimers();
   });
 });
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -315,12 +315,6 @@ export function HomePage() {
                           type="button"
                           aria-label={tooltipText}
                           onClick={() => showTooltip(day.date, tooltipText)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === " ") {
-                              e.preventDefault();
-                              showTooltip(day.date, tooltipText);
-                            }
-                          }}
                           style={{
                             width: `${CELL_SIZE_PX}px`,
                             height: `${CELL_SIZE_PX}px`,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef, useState } from "react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { api, ApiError } from "@/api/client";
 
@@ -99,6 +100,27 @@ export function HomePage() {
     queryFn: () => api.get<HomeSummaryResponse>("/home/summary"),
   });
 
+  const [activeTooltip, setActiveTooltip] = useState<{ date: string; text: string } | null>(null);
+  const tooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showTooltip = (date: string, text: string) => {
+    if (tooltipTimerRef.current) {
+      clearTimeout(tooltipTimerRef.current);
+    }
+    setActiveTooltip({ date, text });
+    tooltipTimerRef.current = setTimeout(() => {
+      setActiveTooltip(null);
+    }, 3000);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (tooltipTimerRef.current) {
+        clearTimeout(tooltipTimerRef.current);
+      }
+    };
+  }, []);
+
   const pageCanvasStyle = {
     minHeight: "calc(100vh - 60px)",
     backgroundColor: "var(--color-bg)",
@@ -150,6 +172,12 @@ export function HomePage() {
 
   return (
     <main style={pageCanvasStyle}>
+      <style dangerouslySetInnerHTML={{ __html: `
+        @keyframes home-tooltip-fade-in {
+          from { opacity: 0; transform: translateX(-50%) translateY(4px); }
+          to { opacity: 1; transform: translateX(-50%) translateY(0); }
+        }
+      ` }} />
       <div style={contentStyle}>
         <h1 style={{ fontSize: "1.75rem", fontWeight: 800, marginBottom: "1.5rem", color: "var(--color-text)" }}>
           Home
@@ -258,20 +286,75 @@ export function HomePage() {
                       day && day.count > 0
                         ? `color-mix(in srgb, var(--color-primary) ${Math.round(intensity * 100)}%, transparent)`
                         : "var(--color-surface-muted)";
+                    if (!day) {
+                      return (
+                        <div
+                          key={rowIndex}
+                          data-testid="home-activity-cell"
+                          data-date=""
+                          data-count={0}
+                          aria-hidden="true"
+                          style={{
+                            width: `${CELL_SIZE_PX}px`,
+                            height: `${CELL_SIZE_PX}px`,
+                            borderRadius: "2px",
+                            backgroundColor: background,
+                          }}
+                        />
+                      );
+                    }
+
+                    const tooltipText = `${day.date}: ${day.count} event${day.count === 1 ? "" : "s"}`;
+                    const isActive = activeTooltip?.date === day.date;
                     return (
-                      <div
-                        key={rowIndex}
-                        data-testid="home-activity-cell"
-                        data-date={day?.date ?? ""}
-                        data-count={day?.count ?? 0}
-                        title={day ? `${day.date}: ${day.count} event${day.count === 1 ? "" : "s"}` : ""}
-                        style={{
-                          width: `${CELL_SIZE_PX}px`,
-                          height: `${CELL_SIZE_PX}px`,
-                          borderRadius: "2px",
-                          backgroundColor: background,
-                        }}
-                      />
+                      <div key={rowIndex} style={{ position: "relative" }}>
+                        <button
+                          data-testid="home-activity-cell"
+                          data-date={day.date}
+                          data-count={day.count}
+                          type="button"
+                          aria-label={tooltipText}
+                          onClick={() => showTooltip(day.date, tooltipText)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              showTooltip(day.date, tooltipText);
+                            }
+                          }}
+                          style={{
+                            width: `${CELL_SIZE_PX}px`,
+                            height: `${CELL_SIZE_PX}px`,
+                            borderRadius: "2px",
+                            backgroundColor: background,
+                            border: "none",
+                            padding: 0,
+                            cursor: "default",
+                          }}
+                        />
+                        {isActive && (
+                          <span
+                            data-testid="home-activity-tooltip"
+                            style={{
+                              position: "absolute",
+                              bottom: "calc(100% + 4px)",
+                              left: "50%",
+                              transform: "translateX(-50%)",
+                              whiteSpace: "nowrap",
+                              padding: "0.25rem 0.5rem",
+                              backgroundColor: "var(--color-surface)",
+                              color: "var(--color-text)",
+                              border: "1px solid var(--color-border)",
+                              borderRadius: "var(--radius-md)",
+                              fontSize: "0.75rem",
+                              boxShadow: "var(--shadow-md)",
+                              zIndex: 10,
+                              animation: "home-tooltip-fade-in 150ms ease-out",
+                            }}
+                          >
+                            {tooltipText}
+                          </span>
+                        )}
+                      </div>
                     );
                   })}
                 </div>


### PR DESCRIPTION
## Summary

Adds a click-only custom tooltip to the Home page activity grid. Real day cells now show a small tooltip on click/tap/keyboard activation, keep the old date/count text format, and auto-hide after 3 seconds. Hover no longer triggers the browser native `title` tooltip.

## Linked Issue

Closes #330

## Issue Alignment

This PR implements the issue by:

- Removing the native `title` attribute from real activity-grid cells.
- Adding React state and a 3-second timer for one active clicked-cell tooltip.
- Rendering the tooltip near the clicked real day cell with a simple fade-in animation.
- Making real day cells keyboard-activatable via reset `<button>` elements.
- Keeping empty padding cells inert (`aria-hidden`, no handlers, no focus).
- Updating `HomePage.test.tsx` with `user-event` and fake timers.

Scope covered:

- `frontend/src/pages/HomePage.tsx`
- `frontend/src/pages/HomePage.test.tsx`

Out of scope / intentionally not included:

- No backend/API changes.
- No global tooltip or toast system.
- No click styling effects on the cell itself.
- No redesign of the activity grid.

## Implementation Notes

- Real day cells render as `<button type="button">` with border/padding reset so they remain visually identical to the previous `<div>` cells while being keyboard-focusable and activatable.
- Tooltip text is built from the same `${date}: ${count} event(s)` format that was previously used for `title`.
- A single `setTimeout` is stored in a ref; repeated clicks clear the previous timer before starting a new 3-second hide timer.
- Cleanup on unmount clears any pending timer.
- The fade-in animation is a local `@keyframes` block injected via a `<style>` tag scoped to the Home page render.

## Tests

Commands run:

- `npm test -- HomePage.test.tsx --run` — 17 passed
- `npm test -- --run` — 333 passed
- `npm run build` — succeeded

Automated tests added or updated:

- Clicking a real activity cell shows the tooltip with the correct date/count text.
- Singular/plural event text is correct.
- Tooltip disappears after 3 seconds using fake timers.
- Clicking a second real cell replaces the tooltip and restarts the timer.
- Real cells no longer expose the native `title` attribute.
- Padding cells remain inert and do not show tooltips.
- Keyboard Enter and Space activation works for real cells.

Manual verification:

- Verified the tooltip renders near the clicked cell in the built output.
- Confirmed the text format matches the old title exactly.
- Confirmed padding cells have no interactive attributes.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
