### PR TITLE
Add print preview for active exams

### DIFF
--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -75,6 +75,11 @@ describe("ActiveExamPage", () => {
   beforeEach(() => {
     mockFetch.mockReset();
     mockNavigate.mockReset();
+    vi.stubGlobal("print", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("shows loading state initially", () => {
@@ -346,5 +351,205 @@ describe("ActiveExamPage", () => {
     expect(discardCall[1].method).toBe("POST");
 
     expect(mockNavigate).toHaveBeenCalledWith("/exams");
+  });
+
+  it("renders a Print button when an active exam is loaded", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: baseExam }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "Print" })).toBeInTheDocument();
+  });
+
+  it("opens print preview with all problem texts in order when Print is clicked", async () => {
+    const user = userEvent.setup();
+    const examWithTwoItems = {
+      ...baseExam,
+      items: [
+        { ...baseExamItem, itemId: "item1", order: 1, problem: { ...baseExamItem.problem, text: "First question?" } },
+        { ...baseExamItem, itemId: "item2", order: 2, problem: { ...baseExamItem.problem, text: "Second question?" } },
+      ],
+      summary: { ...baseExam.summary, totalProblems: 2 },
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: examWithTwoItems }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    const previewItems = screen.getAllByTestId("print-preview-item");
+    expect(previewItems).toHaveLength(2);
+    expect(previewItems[0]).toHaveTextContent("First question?");
+    expect(previewItems[1]).toHaveTextContent("Second question?");
+  });
+
+  it("renders a graph preview for problems with graphDsl and full-width text for problems without", async () => {
+    const user = userEvent.setup();
+    const examWithMixedProblems = {
+      ...baseExam,
+      items: [
+        {
+          ...baseExamItem,
+          itemId: "item1",
+          problem: { ...baseExamItem.problem, text: "Graph problem?", graphDsl: "graph LR; A-->B" },
+        },
+        {
+          ...baseExamItem,
+          itemId: "item2",
+          problem: { ...baseExamItem.problem, text: "Text only problem?" },
+        },
+      ],
+      summary: { ...baseExam.summary, totalProblems: 2 },
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: examWithMixedProblems }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("print-preview-graph")).toBeInTheDocument();
+    expect(screen.getByTestId("print-preview-text-full")).toBeInTheDocument();
+  });
+
+  it("closes the preview and does not call window.print when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: baseExam }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Exam Paper")).not.toBeInTheDocument();
+    });
+
+    expect(window.print).not.toHaveBeenCalled();
+  });
+
+  it("calls window.print exactly once when preview Print is clicked", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: baseExam }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("print-preview-print-button"));
+
+    expect(window.print).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call the save-answer endpoint when opening preview or clicking preview Print", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: baseExam }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("print-preview-print-button"));
+
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.stringContaining("/api/v1/exams/exam123/items/item1/answer"),
+      expect.anything(),
+    );
+  });
+
+  it("does not render uploaded images in the print preview", async () => {
+    const user = userEvent.setup();
+    const examWithImage = {
+      ...baseExam,
+      items: [
+        {
+          ...baseExamItem,
+          problem: { ...baseExamItem.problem, imageUrl: "https://example.com/image.png" },
+        },
+      ],
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: examWithImage }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -48,6 +48,7 @@ export function ActiveExamPage() {
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">("idle");
   const [showSubmitConfirm, setShowSubmitConfirm] = useState(false);
   const [showDiscardConfirm, setShowDiscardConfirm] = useState(false);
+  const [showPrintPreview, setShowPrintPreview] = useState(false);
 
   const {
     data: examData,
@@ -165,6 +166,18 @@ export function ActiveExamPage() {
   const handleCreateExam = useCallback(() => {
     createExamMutation.mutate({ maxProblemCount: 10 });
   }, [createExamMutation]);
+
+  const handleOpenPrintPreview = useCallback(() => {
+    setShowPrintPreview(true);
+  }, []);
+
+  const handleClosePrintPreview = useCallback(() => {
+    setShowPrintPreview(false);
+  }, []);
+
+  const handlePrint = useCallback(() => {
+    window.print();
+  }, []);
 
   const pageCanvasStyle: React.CSSProperties = {
     minHeight: "calc(100vh - 60px)",
@@ -285,6 +298,16 @@ export function ActiveExamPage() {
           </button>
         </div>
         <div style={{ display: "flex", gap: "0.5rem" }}>
+          <button
+            onClick={handleOpenPrintPreview}
+            disabled={isMutating}
+            style={{
+              padding: "0.5rem 1rem",
+              cursor: isMutating ? "not-allowed" : "pointer",
+            }}
+          >
+            Print
+          </button>
           <button
             onClick={handleDiscard}
             disabled={isMutating}
@@ -429,6 +452,79 @@ export function ActiveExamPage() {
             >
               {discardExamMutation.isPending ? "Discarding..." : "Discard Exam"}
             </button>
+          </div>
+        </Modal>
+      )}
+
+      {showPrintPreview && (
+        <Modal
+          isOpen={true}
+          onClose={handleClosePrintPreview}
+          overlayTestId="print-preview-overlay"
+          cardStyle={{
+            padding: "1.5rem",
+            borderRadius: "0.5rem",
+            maxWidth: "900px",
+            width: "95vw",
+            maxHeight: "90vh",
+            overflow: "auto",
+          }}
+        >
+          <div className="print-preview-modal">
+            <div
+              className="print-preview-controls"
+              style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem", marginBottom: "1rem" }}
+            >
+              <button
+                onClick={handleClosePrintPreview}
+                style={{ padding: "0.5rem 1rem" }}
+              >
+                Cancel
+              </button>
+              <button
+                data-testid="print-preview-print-button"
+                onClick={handlePrint}
+                style={{
+                  padding: "0.5rem 1rem",
+                  backgroundColor: "var(--color-primary)",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "0.25rem",
+                  cursor: "pointer",
+                }}
+              >
+                Print
+              </button>
+            </div>
+            <div className="print-preview-content">
+              <h2 style={{ marginTop: 0, textAlign: "center" }}>Exam Paper</h2>
+              {items.map((item, index) => (
+                <div
+                  key={item.itemId}
+                  className="print-preview-item"
+                  data-testid="print-preview-item"
+                  style={{ marginBottom: "1.5rem", breakInside: "avoid" }}
+                >
+                  <div style={{ fontWeight: 600, marginBottom: "0.5rem" }}>
+                    Question {index + 1}
+                  </div>
+                  {item.problem.graphDsl ? (
+                    <div style={{ display: "flex", gap: "1rem" }}>
+                      <div style={{ flex: 1 }}>
+                        <LatexText text={item.problem.text} />
+                      </div>
+                      <div style={{ flex: 1 }} data-testid="print-preview-graph">
+                        <GraphSandbox dsl={item.problem.graphDsl} height={250} />
+                      </div>
+                    </div>
+                  ) : (
+                    <div data-testid="print-preview-text-full">
+                      <LatexText text={item.problem.text} />
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
           </div>
         </Modal>
       )}

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -382,3 +382,35 @@ select:disabled {
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
+
+/* Print preview: only the paper content should be printed */
+@media print {
+  [data-testid="print-preview-overlay"] {
+    position: fixed !important;
+    top: 0 !important;
+    left: 0 !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    align-items: flex-start !important;
+    justify-content: flex-start !important;
+    background-color: white !important;
+    padding: 1rem !important;
+  }
+
+  [data-testid="print-preview-overlay"] > div {
+    background: white !important;
+    box-shadow: none !important;
+    border: none !important;
+    border-radius: 0 !important;
+    max-width: none !important;
+    width: 100% !important;
+    max-height: none !important;
+    overflow: visible !important;
+    padding: 0 !important;
+    color: black !important;
+  }
+
+  .print-preview-controls {
+    display: none !important;
+  }
+}

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -385,16 +385,36 @@ select:disabled {
 
 /* Print preview: only the paper content should be printed */
 @media print {
+  body,
+  html {
+    background: white !important;
+  }
+
+  body * {
+    visibility: hidden;
+  }
+
+  [data-testid="print-preview-overlay"],
+  [data-testid="print-preview-overlay"] * {
+    visibility: visible;
+  }
+
   [data-testid="print-preview-overlay"] {
-    position: fixed !important;
+    position: absolute !important;
     top: 0 !important;
     left: 0 !important;
-    right: 0 !important;
-    bottom: 0 !important;
+    right: auto !important;
+    bottom: auto !important;
+    display: block !important;
+    width: 100% !important;
+    height: auto !important;
+    min-height: 100% !important;
     align-items: flex-start !important;
     justify-content: flex-start !important;
     background-color: white !important;
-    padding: 1rem !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    overflow: visible !important;
   }
 
   [data-testid="print-preview-overlay"] > div {
@@ -406,7 +426,7 @@ select:disabled {
     width: 100% !important;
     max-height: none !important;
     overflow: visible !important;
-    padding: 0 !important;
+    padding: 1rem !important;
     color: black !important;
   }
 


### PR DESCRIPTION
## Summary

Adds a read-only print preview workflow to the active exam page. Users can click `Print` to open a modal preview of all exam problems, then click `Print` again to invoke the browser/system print dialog.

## Linked Issue

Closes #333

## Issue Alignment

This PR implements the issue by:

- Adding a `Print` button to active exam controls when an in-progress exam is loaded.
- Adding local state and a modal preview overlay.
- Rendering every exam problem in order inside the preview.
- Rendering problem text with `LatexText`.
- Rendering graph DSL problems side-by-side with `GraphSandbox`.
- Rendering non-graph problems as full-width text.
- Adding `Cancel` (closes preview) and `Print` (calls `window.print()`) actions.
- Adding `@media print` CSS so printed output contains only the paper content.
- Updating `ActiveExamPage.test.tsx` with required tests.

Scope covered:

- `frontend/src/pages/ActiveExamPage.tsx`
- `frontend/src/pages/ActiveExamPage.test.tsx`
- `frontend/src/theme.css`

Out of scope / intentionally not included:

- No backend/API changes.
- No database or exam state mutations.
- No saving answers before previewing or printing.
- No PDF generation or dedicated printable route.
- No uploaded/source images in the preview.
- No correct answers, saved answers, grading, submit/discard controls, or navigation in the preview.

## Implementation Notes

- Reused the existing `Modal`, `LatexText`, and `GraphSandbox` components.
- The preview modal uses `overlayTestId="print-preview-overlay"` so `@media print` CSS can target it specifically.
- Print CSS hides all app chrome via `body * { visibility: hidden; }`, then re-shows only the print preview overlay and its descendants; the control bar is hidden with `display: none`.
- The overlay is pulled out of the fixed viewport for print (`position: absolute`) so multi-page paper content paginates correctly.
- The print workflow never calls `handleSaveAnswer` or any exam mutation.

## Tests

Commands run:

- `npm test -- ActiveExamPage.test.tsx --run` — 15 passed
- `npm test -- --run` — 333 passed
- `npm run build` — succeeded

Automated tests added or updated:

- Print button appears when an active exam is loaded.
- Clicking Print opens a preview with all problem texts in order.
- Problems with `graphDsl` render a graph preview; problems without render full-width text.
- Cancel closes the preview and does not call `window.print()`.
- Preview Print calls `window.print()` exactly once.
- Opening preview and printing do not call the save-answer endpoint.
- Problems with `imageUrl` do not render uploaded images in the preview.

Manual verification (browser print preview, Chromium 120 via Playwright print-media emulation):

- Started the Vite dev server and navigated to `/exams/active` with a mocked active exam (3 items: text-only, graph DSL, and image-url).
- Opened the print preview and emulated `@media print`.
- Confirmed the printed view shows only the paper content (`Exam Paper`, Question 1–3 texts, and the graph DSL container for Question 2).
- Confirmed the app header, navigation, answer inputs, Previous/Next/Discard/Submit buttons, and modal Cancel/Print controls are hidden.
- Confirmed the image-url problem renders only its text, not the uploaded image.
- Computed-style checks: `header { visibility: hidden }`, `.print-preview-controls { display: none }`, `[data-testid="print-preview-overlay"] { visibility: visible }`, and all three `[data-testid="print-preview-item"]` elements are visible.
- Screenshot saved at `/tmp/learnloop-print-preview.png`.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
