### PR TITLE
Normalize VLM thinking content into reasoning_content

### DIFF
--- a/backend/app/infrastructure/vlm/base_client.py
+++ b/backend/app/infrastructure/vlm/base_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Callable
 
 import httpx
@@ -151,6 +152,20 @@ class BaseVLMClient:
             return stripped
 
         return "\n".join(lines[1:-1]).strip()
+
+    @staticmethod
+    def _strip_thinking_content(content: str) -> tuple[str, str | None]:
+        """Strip a single leading <think>...</think> block and return the rest plus reasoning.
+
+        Only a complete leading block (allowing leading whitespace) is removed.
+        Returns (content_with_block_removed, extracted_reasoning_or_none).
+        """
+        match = re.match(r"^\s*<think>(.*?)</think>", content, re.DOTALL)
+        if not match:
+            return content, None
+        reasoning = match.group(1).strip()
+        remaining = content[match.end() :].strip()
+        return remaining, reasoning or None
 
     def _load_json_content(self, content: str) -> dict[str, Any]:
         candidates = [self._strip_json_code_fences(content), content.strip()]

--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -365,7 +365,8 @@ class VLMClient(BaseVLMClient):
                 raw_provider_response=raw_body,
             )
 
-        content = completion.choices[0].message.content
+        message = completion.choices[0].message
+        content = message.content
         if not content:
             raise VLMError(
                 "VLM provider response content was empty",
@@ -374,4 +375,11 @@ class VLMClient(BaseVLMClient):
                 raw_provider_response=raw_body,
             )
 
-        return self._load_json_content(content)
+        stripped_content, extracted_reasoning = self._strip_thinking_content(content)
+        parsed = self._load_json_content(stripped_content)
+        reasoning_content = message.reasoning_content
+        if reasoning_content is None:
+            reasoning_content = extracted_reasoning
+        if reasoning_content is not None:
+            parsed["reasoning_content"] = reasoning_content
+        return parsed

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -221,9 +221,13 @@ class _BaseSolutionCoachingVLMClient(BaseVLMClient):
                 raw_provider_response=raw_body,
             )
 
-        parsed = self._load_json_content(content)
-        if message.reasoning_content is not None:
-            parsed["reasoning_content"] = message.reasoning_content
+        stripped_content, extracted_reasoning = self._strip_thinking_content(content)
+        parsed = self._load_json_content(stripped_content)
+        reasoning_content = message.reasoning_content
+        if reasoning_content is None:
+            reasoning_content = extracted_reasoning
+        if reasoning_content is not None:
+            parsed["reasoning_content"] = reasoning_content
         return parsed
 
 

--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -721,3 +721,101 @@ async def test_solution_vlm_client_preserves_reasoning_content_in_raw_response()
     await client.aclose()
 
     assert result.raw_provider_response["reasoning_content"] == "推理过程"
+
+
+@pytest.mark.asyncio
+async def test_solution_vlm_client_normalizes_leading_think_block() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "<think>internal reasoning</think>\n"
+                            + json.dumps(
+                                {"steps_markdown": "步骤", "final_answer": "42", "level_classification": "primary"}
+                            ),
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_solution_client(handler)
+    result = await client.generate_solution(
+        SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+    )
+    await client.aclose()
+
+    assert result.steps_markdown == "步骤"
+    assert result.raw_provider_response["reasoning_content"] == "internal reasoning"
+
+
+@pytest.mark.asyncio
+async def test_coaching_vlm_client_normalizes_leading_think_block() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "<think>internal reasoning</think>"
+                            + json.dumps({"text": "先看等式两边同时减 3。"}),
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_coaching_client(handler)
+    result = await client.send_message(
+        CoachingVLMRequest(
+            problem_text="x + 3 = 5",
+            correct_answer="2",
+            canonical_steps_markdown="步骤",
+            canonical_final_answer="2",
+            level_classification="primary",
+            new_message="怎么做？",
+        )
+    )
+    await client.aclose()
+
+    assert result.text == "先看等式两边同时减 3。"
+    assert result.reasoning_content == "internal reasoning"
+
+
+@pytest.mark.asyncio
+async def test_solution_vlm_client_explicit_reasoning_wins_over_think_block() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "<think>think reasoning</think>"
+                            + json.dumps(
+                                {"steps_markdown": "步骤", "final_answer": "42", "level_classification": "primary"}
+                            ),
+                            "reasoning_content": "explicit reasoning",
+                        },
+                    }
+                ]
+            },
+        )
+
+    client = _build_solution_client(handler)
+    result = await client.generate_solution(
+        SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+    )
+    await client.aclose()
+
+    assert result.raw_provider_response["reasoning_content"] == "explicit reasoning"

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -695,3 +695,124 @@ async def test_vlm_classification_rejects_confidence_above_one() -> None:
 
     assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
     assert exc_info.value.retryable is False
+
+
+@pytest.mark.asyncio
+async def test_vlm_extract_normalizes_leading_think_block() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "<think>internal reasoning</think>\n"
+                            + json.dumps(
+                                {
+                                    "text": "Solve x + 1 = 2",
+                                    "problemType": "short-answer",
+                                    "graphDsl": None,
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert result.text == "Solve x + 1 = 2"
+    assert result.raw_provider_response["reasoning_content"] == "internal reasoning"
+
+
+@pytest.mark.asyncio
+async def test_vlm_extract_preserves_explicit_reasoning_content() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "text": "Find x",
+                                    "problemType": "short-answer",
+                                    "graphDsl": None,
+                                }
+                            ),
+                            "reasoning_content": "explicit reasoning",
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert result.raw_provider_response["reasoning_content"] == "explicit reasoning"
+
+
+@pytest.mark.asyncio
+async def test_vlm_extract_explicit_reasoning_wins_over_think_block() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "<think>think reasoning</think>"
+                            + json.dumps(
+                                {
+                                    "text": "Find x",
+                                    "problemType": "short-answer",
+                                    "graphDsl": None,
+                                }
+                            ),
+                            "reasoning_content": "explicit reasoning",
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert result.raw_provider_response["reasoning_content"] == "explicit reasoning"
+
+
+def test_strip_thinking_content_extracts_leading_block() -> None:
+    content, reasoning = VLMClient._strip_thinking_content(
+        "  <think>reasoning</think>{\"text\":\"hello\"}"
+    )
+
+    assert content == '{"text":"hello"}'
+    assert reasoning == "reasoning"
+
+
+def test_strip_thinking_content_leaves_content_unchanged_when_no_block() -> None:
+    content, reasoning = VLMClient._strip_thinking_content('{"text":"hello"}')
+
+    assert content == '{"text":"hello"}'
+    assert reasoning is None
+
+
+def test_strip_thinking_content_leaves_incomplete_block_unchanged() -> None:
+    content, reasoning = VLMClient._strip_thinking_content("<think>incomplete")
+
+    assert content == "<think>incomplete"
+    assert reasoning is None


### PR DESCRIPTION
## Summary

Normalize VLM provider thinking content so all backend VLM response paths support both `choices[0].message.reasoning_content` and a leading `<think>...</think>` block embedded in `choices[0].message.content`.

## Linked Issue

Closes #336

## Issue Alignment

This PR implements the issue by:

- Adding a shared `_strip_thinking_content` helper on `BaseVLMClient` that extracts a single complete leading `<think>...</think>` block (allowing leading whitespace) and returns the remaining content plus the trimmed reasoning text.
- Updating the generic ingestion/classification/grading VLM client to strip any leading `<think>` block before JSON parsing and to populate `raw_provider_response["reasoning_content"]`.
- Updating the solution/coaching VLM client to use the same helper and precedence rules.
- Preserving explicit `message.reasoning_content` precedence over extracted `<think>` content.

Scope covered:

- Shared parsing/normalization for one leading `<think>...</think>` block.
- Both backend VLM parser paths (generic and solution/coaching).
- Regression tests for both parser paths.

Out of scope / intentionally not included:

- Persisting solution VLM reasoning content to `canonical_solutions`.
- Adding `reasoning_content` as a top-level field to generic extraction/classification/grading/solution result models.
- Frontend rendering or coaching UI changes.
- Prompt changes.
- Supporting arbitrary thinking formats beyond an exact leading `<think>...</think>` block.

## Implementation Notes

- The helper uses a regex anchored at the start of the content so only a leading complete block is stripped; `<think>` blocks inside JSON strings or later visible content are left untouched.
- `reasoning_content` precedence is: explicit `message.reasoning_content` > extracted leading `<think>` content > omitted entirely.
- The solution/coaching path now strips the block before calling `_load_json_content`, matching the generic path behavior.

## Tests

Commands run:

- `cd backend && uv run --extra dev pytest tests/infrastructure/test_vlm.py tests/infrastructure/test_solution_coaching_client.py` — 81 passed

Automated tests added or updated:

- `test_vlm_extract_normalizes_leading_think_block`
- `test_vlm_extract_preserves_explicit_reasoning_content`
- `test_vlm_extract_explicit_reasoning_wins_over_think_block`
- `test_strip_thinking_content_extracts_leading_block`
- `test_strip_thinking_content_leaves_content_unchanged_when_no_block`
- `test_strip_thinking_content_leaves_incomplete_block_unchanged`
- `test_solution_vlm_client_normalizes_leading_think_block`
- `test_coaching_vlm_client_normalizes_leading_think_block`
- `test_solution_vlm_client_explicit_reasoning_wins_over_think_block`

Manual verification:

- Confirmed no DB schema or frontend files were modified.
- Confirmed solution canonical persistence still only writes `steps_markdown`, `final_answer`, `level_classification`, and existing metadata fields.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
