### PR TITLE
Fix Home activity grid layout after tooltip change

### DIFF
--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -219,6 +219,37 @@ describe("HomePage", () => {
     expect(realCells.length).toBe(365);
   });
 
+  it("renders uniform fixed-size slots for real and padding cells", async () => {
+    const days = buildDayRange("2025-06-22", 365);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ days }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+
+    const columns = screen.getAllByTestId("home-activity-week-column");
+    const slots = columns.flatMap((column) => Array.from(column.children));
+    expect(slots.length).toBe(columns.length * 7);
+
+    const firstSlot = slots[0] as HTMLElement;
+    for (const slot of slots) {
+      const el = slot as HTMLElement;
+      expect(el.style.position).toBe("relative");
+      expect(el.style.width).toBe(firstSlot.style.width);
+      expect(el.style.height).toBe(firstSlot.style.height);
+    }
+
+    const cells = screen.getAllByTestId("home-activity-cell");
+    const realCell = cells.find((c) => c.getAttribute("data-date") !== "");
+    const paddingCell = cells.find((c) => c.getAttribute("data-date") === "");
+    expect(realCell?.tagName).toBe("BUTTON");
+    expect(paddingCell?.tagName).toBe("DIV");
+    expect(paddingCell).toHaveAttribute("aria-hidden", "true");
+  });
+
   it("renders month labels for months in the visible range", async () => {
     const days = buildDayRange("2025-06-22", 365);
     mockFetch.mockResolvedValueOnce({

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -286,45 +286,51 @@ export function HomePage() {
                       day && day.count > 0
                         ? `color-mix(in srgb, var(--color-primary) ${Math.round(intensity * 100)}%, transparent)`
                         : "var(--color-surface-muted)";
-                    if (!day) {
-                      return (
-                        <div
-                          key={rowIndex}
-                          data-testid="home-activity-cell"
-                          data-date=""
-                          data-count={0}
-                          aria-hidden="true"
-                          style={{
-                            width: `${CELL_SIZE_PX}px`,
-                            height: `${CELL_SIZE_PX}px`,
-                            borderRadius: "2px",
-                            backgroundColor: background,
-                          }}
-                        />
-                      );
-                    }
+                    const tooltipText = day ? `${day.date}: ${day.count} event${day.count === 1 ? "" : "s"}` : "";
+                    const isActive = day ? activeTooltip?.date === day.date : false;
 
-                    const tooltipText = `${day.date}: ${day.count} event${day.count === 1 ? "" : "s"}`;
-                    const isActive = activeTooltip?.date === day.date;
                     return (
-                      <div key={rowIndex} style={{ position: "relative" }}>
-                        <button
-                          data-testid="home-activity-cell"
-                          data-date={day.date}
-                          data-count={day.count}
-                          type="button"
-                          aria-label={tooltipText}
-                          onClick={() => showTooltip(day.date, tooltipText)}
-                          style={{
-                            width: `${CELL_SIZE_PX}px`,
-                            height: `${CELL_SIZE_PX}px`,
-                            borderRadius: "2px",
-                            backgroundColor: background,
-                            border: "none",
-                            padding: 0,
-                            cursor: "default",
-                          }}
-                        />
+                      <div
+                        key={rowIndex}
+                        style={{
+                          position: "relative",
+                          width: `${CELL_SIZE_PX}px`,
+                          height: `${CELL_SIZE_PX}px`,
+                        }}
+                      >
+                        {day ? (
+                          <button
+                            data-testid="home-activity-cell"
+                            data-date={day.date}
+                            data-count={day.count}
+                            type="button"
+                            aria-label={tooltipText}
+                            onClick={() => showTooltip(day.date, tooltipText)}
+                            style={{
+                              width: "100%",
+                              height: "100%",
+                              borderRadius: "2px",
+                              backgroundColor: background,
+                              border: "none",
+                              padding: 0,
+                              display: "block",
+                              cursor: "default",
+                            }}
+                          />
+                        ) : (
+                          <div
+                            data-testid="home-activity-cell"
+                            data-date=""
+                            data-count={0}
+                            aria-hidden="true"
+                            style={{
+                              width: "100%",
+                              height: "100%",
+                              borderRadius: "2px",
+                              backgroundColor: background,
+                            }}
+                          />
+                        )}
                         {isActive && (
                           <span
                             data-testid="home-activity-tooltip"


### PR DESCRIPTION
## Summary

Restores the Home activity grid's clean pre-tooltip visual alignment by rendering every day slot inside a uniform fixed-size wrapper. Real activity cells remain clickable buttons with the custom tooltip; padding cells remain visible, inert, and non-focusable.

## Linked Issue

Closes #338

## Issue Alignment

This PR implements the issue by:

- Updating `HomePage.tsx` so every grid row uses the same `position: relative` fixed-size slot wrapper.
- Rendering real-day activity as a reset-styled `button` that fills the slot (`width: 100%`, `height: 100%`, `display: block`, `border: none`, `padding: 0`).
- Rendering padding days as the same-sized muted square `div`, still `aria-hidden` and without tooltip behavior.
- Keeping the custom tooltip anchored to the uniform slot wrapper and preserving click/keyboard activation, singular/plural text, no native `title`, timer reset, and 3-second auto-hide.
- Adding a regression test that verifies every week column has exactly 7 uniform slots, that real and padding cells share the same wrapper dimensions, and that real cells are buttons while padding cells are inert `div`s.

Scope covered:

- Activity grid layout restoration.
- Preservation of click-only custom tooltip behavior.
- Preservation of keyboard tooltip activation.
- Preservation of inert padding cells.
- Focused regression test coverage.

Out of scope / intentionally not included:

- Home dashboard redesign.
- Activity counting semantics changes.
- Backend `/home/summary` changes.
- Native `title` tooltips.
- Unrelated Home page refactors.

## Implementation Notes

- The previous implementation rendered padding cells as direct `div` children of the week column while real cells were wrapped in an extra `position: relative` `div` for the tooltip. This mismatch distorted partial-week columns.
- The fix unifies both paths: a single fixed-size wrapper per row, with either a `button` (real) or `div` (padding) filling it. The tooltip is rendered inside the same wrapper for real cells.

## Tests

Commands run:

- `cd frontend && npm test -- --run src/pages/HomePage.test.tsx` — passed (18/18)
- `cd frontend && npm run build` — passed

Automated tests added or updated:

- Added `renders uniform fixed-size slots for real and padding cells` to catch the layout regression.
- Existing tooltip timing, keyboard activation, padding inertness, and native-title tests continue to pass.

Manual verification:

- Started the built frontend via `npm run preview` and used Playwright to mock `/api/v1/auth/me` and `/api/v1/home/summary` with a 365-day response.
- Verified the activity grid renders aligned weekday rows with consistent square cells and no dangling far-right tail in both light and dark themes.
- Verified clicking a real activity cell shows the custom tooltip above the cell.
- Verified the tooltip auto-hides after 3 seconds.
- Verified clicking a padding cell does not show a tooltip.
- Verified keyboard Enter on a focused real cell shows the tooltip.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
