### PR TITLE
Remember Problems Page filters and sorting during SPA navigation

### DIFF
--- a/frontend/src/pages/ProblemsPage.test.tsx
+++ b/frontend/src/pages/ProblemsPage.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { ProblemsPage } from "./ProblemsPage";
+import { ProblemsPage, _resetProblemsPagePreferencesForTests } from "./ProblemsPage";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
@@ -158,6 +158,7 @@ describe("ProblemsPage", () => {
     mockNavigate.mockReset();
     window.sessionStorage.clear();
     vi.restoreAllMocks();
+    _resetProblemsPagePreferencesForTests();
   });
 
   it("defaults to All Problems without a folderId query param", async () => {
@@ -224,6 +225,104 @@ describe("ProblemsPage", () => {
       expect(lastUrl).toContain("q=proof");
       expect(lastUrl).toContain("page=1");
     });
+  });
+
+  it("remembers all list controls across remounts", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    const { unmount } = renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
+    await user.selectOptions(screen.getByLabelText("Filter by Type:"), "short-answer");
+    await user.type(screen.getByLabelText("Search problems:"), "proof");
+    await user.selectOptions(screen.getByLabelText("Sort by:"), "selectionScore");
+    await user.selectOptions(screen.getByLabelText("Order:"), "asc");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=section-1");
+      expect(lastUrl).toContain("tag=algebra");
+      expect(lastUrl).toContain("type=short-answer");
+      expect(lastUrl).toContain("q=proof");
+      expect(lastUrl).toContain("sortBy=selectionScore");
+      expect(lastUrl).toContain("sortOrder=asc");
+    });
+
+    unmount();
+    renderProblemsPage();
+
+    await screen.findByText("What is 2+2?");
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=section-1");
+      expect(lastUrl).toContain("tag=algebra");
+      expect(lastUrl).toContain("type=short-answer");
+      expect(lastUrl).toContain("q=proof");
+      expect(lastUrl).toContain("sortBy=selectionScore");
+      expect(lastUrl).toContain("sortOrder=asc");
+    });
+
+    // Controls should render the remembered values.
+    expect(screen.getByLabelText("Filter by Tag:")).toHaveValue("algebra");
+    expect(screen.getByLabelText("Filter by Type:")).toHaveValue("short-answer");
+    expect(screen.getByLabelText("Search problems:")).toHaveValue("proof");
+    expect(screen.getByLabelText("Sort by:")).toHaveValue("selectionScore");
+    expect(screen.getByLabelText("Order:")).toHaveValue("asc");
+  });
+
+  it("does not write folderId to URL search params", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=section-1");
+    });
+    expect(window.location.search).not.toContain("folderId=");
+  });
+
+  it("resets list controls to defaults when preferences are cleared", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    const { unmount } = renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
+    await user.type(screen.getByLabelText("Search problems:"), "proof");
+    await user.selectOptions(screen.getByLabelText("Sort by:"), "selectionScore");
+    await user.selectOptions(screen.getByLabelText("Order:"), "asc");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("folderId=section-1");
+    });
+
+    unmount();
+    _resetProblemsPagePreferencesForTests();
+    renderProblemsPage();
+
+    await screen.findByText("What is 2+2?");
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).not.toContain("folderId=");
+      expect(lastUrl).not.toContain("tag=");
+      expect(lastUrl).not.toContain("q=");
+      expect(lastUrl).not.toContain("sortBy=");
+    });
+    expect(screen.getByLabelText("Filter by Tag:")).toHaveValue("");
+    expect(screen.getByLabelText("Search problems:")).toHaveValue("");
+    expect(screen.getByLabelText("Sort by:")).toHaveValue("");
+    expect(screen.getByLabelText("Order:")).toHaveValue("desc");
   });
 
   it("sends sort parameters with existing filters", async () => {
@@ -293,15 +392,24 @@ describe("ProblemsPage", () => {
     expect(screen.getByText("Folder: Chapter 1")).toBeInTheDocument();
   });
 
-  it("expands ancestors of the selected folder on load", async () => {
+  it("expands ancestors of the selected folder after remount", async () => {
+    const user = userEvent.setup();
     installApiMock();
 
-    renderProblemsPage(["/problems?folderId=section-1"]);
+    const { unmount } = renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await waitFor(() => {
+      expect(problemRequestUrls().at(-1) ?? "").toContain("folderId=section-1");
+    });
+
+    unmount();
+    renderProblemsPage();
 
     await screen.findByRole("button", { name: "Select folder Section 1" });
     expect(screen.getByRole("button", { name: "Collapse Chapter 1" })).toBeInTheDocument();
     await waitFor(() => {
-      expect(problemRequestUrls()[0]).toContain("folderId=section-1");
+      expect(problemRequestUrls().at(-1) ?? "").toContain("folderId=section-1");
     });
   });
 
@@ -420,10 +528,19 @@ describe("ProblemsPage", () => {
     });
   });
 
-  it("uses folder-aware empty state copy", async () => {
+  it("uses folder-aware empty state copy after remount", async () => {
+    const user = userEvent.setup();
     installApiMock({ problems: [], total: 0 });
 
-    renderProblemsPage(["/problems?folderId=unfiled"]);
+    const { unmount } = renderProblemsPage();
+    await screen.findByRole("button", { name: "Show Unfiled" });
+    await user.click(screen.getByRole("button", { name: "Show Unfiled" }));
+    await waitFor(() => {
+      expect(problemRequestUrls().at(-1) ?? "").toContain("folderId=unfiled");
+    });
+
+    unmount();
+    renderProblemsPage();
 
     await screen.findAllByText("No problems found in Unfiled");
   });

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { formatProblemReference } from "@/utils/format";
@@ -29,6 +29,31 @@ const SORT_ORDER_OPTIONS: Array<{ value: ProblemSortOrder; label: string }> = [
   { value: "desc", label: "Descending" },
   { value: "asc", label: "Ascending" },
 ];
+
+type ProblemsPagePreferences = {
+  selectedFolderId: string;
+  selectedTag: string;
+  selectedProblemType: string;
+  searchQuery: string;
+  sortBy: ProblemSortBy;
+  sortOrder: ProblemSortOrder;
+};
+
+const DEFAULT_PREFERENCES: ProblemsPagePreferences = {
+  selectedFolderId: "",
+  selectedTag: "",
+  selectedProblemType: "",
+  searchQuery: "",
+  sortBy: "",
+  sortOrder: "desc",
+};
+
+let problemsPagePreferences: ProblemsPagePreferences = { ...DEFAULT_PREFERENCES };
+
+// Test-only helper to reset the in-memory preferences between test runs.
+export function _resetProblemsPagePreferencesForTests() {
+  problemsPagePreferences = { ...DEFAULT_PREFERENCES };
+}
 
 function flattenFolders(folders: FolderNode[], depth = 0): Array<FolderNode & { depth: number }> {
   return folders.flatMap((folder) => [
@@ -71,14 +96,14 @@ function getErrorMessage(error: unknown) {
 
 export function ProblemsPage() {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
-  const [selectedTag, setSelectedTag] = useState<string>("");
-  const [selectedProblemType, setSelectedProblemType] = useState<string>("");
-  const [searchQuery, setSearchQuery] = useState<string>("");
-  const [sortBy, setSortBy] = useState<ProblemSortBy>("");
-  const [sortOrder, setSortOrder] = useState<ProblemSortOrder>("desc");
+  const [selectedFolderId, setSelectedFolderId] = useState<string>(problemsPagePreferences.selectedFolderId);
+  const [selectedTag, setSelectedTag] = useState<string>(problemsPagePreferences.selectedTag);
+  const [selectedProblemType, setSelectedProblemType] = useState<string>(problemsPagePreferences.selectedProblemType);
+  const [searchQuery, setSearchQuery] = useState<string>(problemsPagePreferences.searchQuery);
+  const [sortBy, setSortBy] = useState<ProblemSortBy>(problemsPagePreferences.sortBy);
+  const [sortOrder, setSortOrder] = useState<ProblemSortOrder>(problemsPagePreferences.sortOrder);
   const [selectedProblemIds, setSelectedProblemIds] = useState<Set<string>>(new Set());
   const [isSelectionMode, setIsSelectionMode] = useState(false);
   const [bulkTarget, setBulkTarget] = useState<string>(UNFILED_FOLDER_ID);
@@ -93,7 +118,6 @@ export function ProblemsPage() {
     return window.sessionStorage.getItem(SIDEBAR_COLLAPSED_KEY) === "true";
   });
   const pageSize = 20;
-  const selectedFolderId = searchParams.get("folderId") ?? "";
 
   const { data: problemsData, isLoading: isLoadingProblems } = useQuery({
     queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery, selectedFolderId, sortBy, sortOrder],
@@ -186,22 +210,22 @@ export function ProblemsPage() {
 
   const updateFolderFilter = (folderId: string) => {
     setOpenFolderActionsId(null);
-    const next = new URLSearchParams(searchParams);
-    if (folderId) next.set("folderId", folderId);
-    else next.delete("folderId");
-    setSearchParams(next);
+    setSelectedFolderId(folderId);
+    problemsPagePreferences.selectedFolderId = folderId;
     setPage(1);
     exitSelectionMode();
   };
 
   const updateSortBy = (value: ProblemSortBy) => {
     setSortBy(value);
+    problemsPagePreferences.sortBy = value;
     setPage(1);
     exitSelectionMode();
   };
 
   const updateSortOrder = (value: ProblemSortOrder) => {
     setSortOrder(value);
+    problemsPagePreferences.sortOrder = value;
     setPage(1);
     exitSelectionMode();
   };
@@ -551,6 +575,7 @@ export function ProblemsPage() {
               value={searchQuery}
               onChange={(e) => {
                 setSearchQuery(e.target.value);
+                problemsPagePreferences.searchQuery = e.target.value;
                 setPage(1);
                 exitSelectionMode();
               }}
@@ -574,6 +599,7 @@ export function ProblemsPage() {
               value={selectedTag}
               onChange={(e) => {
                 setSelectedTag(e.target.value);
+                problemsPagePreferences.selectedTag = e.target.value;
                 setPage(1);
                 exitSelectionMode();
               }}
@@ -603,6 +629,7 @@ export function ProblemsPage() {
               value={selectedProblemType}
               onChange={(e) => {
                 setSelectedProblemType(e.target.value);
+                problemsPagePreferences.selectedProblemType = e.target.value;
                 setPage(1);
                 exitSelectionMode();
               }}


### PR DESCRIPTION
## Summary

This PR makes the Problems Page list controls (folder, tag, type, search, sort by, sort order) persist across normal SPA navigation and remounts, while resetting to defaults after a full browser reload or hard refresh.

## Linked Issue

Closes #340

## Issue Alignment

This PR implements the issue by:

- Introducing a small, module-level in-memory preference model for the six listed list controls.
- Initializing Problems Page component state from that model on mount.
- Updating the in-memory model whenever the user changes any listed control.
- Removing active `folderId` URL query support from Problems Page state management.
- Preserving existing backend request behavior by still sending active control values as API query params.
- Preserving current behavior that list-control changes reset pagination to page 1 and exit selection mode.

Scope covered:

- In-memory runtime persistence for folder, tag, type, search, sort by, and sort order.
- Removal of `folderId` URL query param handling.
- Frontend test coverage for remount persistence, reset behavior, and URL regression.

Out of scope / intentionally not included:

- Backend API changes.
- Database or durable browser storage (`localStorage`/`sessionStorage`) persistence for list controls.
- Visible reset/save filters UI.
- Persistence for pagination, selection mode, selected IDs, feedback, expanded folders, etc.
- Unrelated Problems Page UI or folder management refactors.

## Implementation Notes

- `ProblemsPagePreferences` is a plain module-level object with defaults. It lives only in JavaScript memory, so a full page reload naturally resets it.
- A test-only helper `_resetProblemsPagePreferencesForTests` is exported for test isolation.
- `useSearchParams` and all URL-query `folderId` logic were removed.
- Control change handlers now update both React state and the in-memory preference object.

## Tests

Commands run:

- `cd frontend && npm test -- ProblemsPage.test.tsx --run` — **27 passed**
- `cd frontend && npm run build` — **built successfully**

Automated tests added or updated:

- `remembers all list controls across remounts` — changes every control, unmounts/remounts, and verifies controls and the API request are restored.
- `does not write folderId to URL search params` — clicks a folder and asserts the browser URL stays clean.
- `resets list controls to defaults when preferences are cleared` — simulates the runtime-reset boundary and verifies defaults.
- Updated existing folder-related tests that previously relied on `/problems?folderId=...` to instead select the folder and remount.

Manual verification:

- Ran the frontend dev server (`npm run dev`) against the existing local backend.
- Registered a test user, logged in, and navigated to `/problems`.
- Set search to `geometry proof`, sort by to `addDate`, sort order to `asc`.
- Clicked the nav **Home** button, then the nav **Problems** button.
- Verified the controls were restored: search still `geometry proof`, sort by `addDate`, sort order `asc`.
- Reloaded the page and verified controls reset to defaults: search empty, sort by empty/default, sort order `desc`.
- Clicked **Unfiled** in the folder sidebar and verified the URL remained `http://localhost:5173/problems` (no `folderId` query param).

## Deviations From Issue Plan

None.

## Follow-Up Work

None required. A future explicit reset-control UI could be considered separately if users need it.
