### PR TITLE
Fix blank pages in Active Exam print preview

### DIFF
--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -521,6 +521,28 @@ describe("ActiveExamPage", () => {
     );
   });
 
+  it("renders the printable paper wrapper when print preview is open", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: baseExam }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("print-preview-paper")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("print-preview-paper")).toHaveTextContent("Exam Paper");
+    expect(screen.getByTestId("print-preview-paper")).toHaveTextContent("What is 2+2?");
+  });
+
   it("does not render uploaded images in the print preview", async () => {
     const user = userEvent.setup();
     const examWithImage = {

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -496,7 +496,10 @@ export function ActiveExamPage() {
                 Print
               </button>
             </div>
-            <div className="print-preview-content">
+            <div
+              className="print-preview-content print-preview-paper"
+              data-testid="print-preview-paper"
+            >
               <h2 style={{ marginTop: 0, textAlign: "center" }}>Exam Paper</h2>
               {items.map((item, index) => (
                 <div

--- a/frontend/src/theme.css
+++ b/frontend/src/theme.css
@@ -388,37 +388,43 @@ select:disabled {
   body,
   html {
     background: white !important;
+    height: auto !important;
+    min-height: auto !important;
   }
 
-  body * {
-    visibility: hidden;
+  /* Hide app chrome and the normal active-exam content. The print-preview
+     overlay sits as a sibling of that content, so we collapse main and its
+     wrapper and hide every sibling of the overlay. Only the paper prints. */
+  header,
+  .glass-header {
+    display: none !important;
   }
 
-  [data-testid="print-preview-overlay"],
-  [data-testid="print-preview-overlay"] * {
-    visibility: visible;
+  main,
+  main > div {
+    display: contents !important;
+  }
+
+  main > div > *:not([data-testid="print-preview-overlay"]) {
+    display: none !important;
   }
 
   [data-testid="print-preview-overlay"] {
-    position: absolute !important;
-    top: 0 !important;
-    left: 0 !important;
-    right: auto !important;
-    bottom: auto !important;
+    position: static !important;
     display: block !important;
-    width: 100% !important;
+    width: auto !important;
     height: auto !important;
-    min-height: 100% !important;
+    min-height: auto !important;
     align-items: flex-start !important;
     justify-content: flex-start !important;
-    background-color: white !important;
+    background: transparent !important;
     padding: 0 !important;
     margin: 0 !important;
     overflow: visible !important;
   }
 
   [data-testid="print-preview-overlay"] > div {
-    background: white !important;
+    background: transparent !important;
     box-shadow: none !important;
     border: none !important;
     border-radius: 0 !important;
@@ -426,8 +432,22 @@ select:disabled {
     width: 100% !important;
     max-height: none !important;
     overflow: visible !important;
-    padding: 1rem !important;
+    padding: 0 !important;
+    margin: 0 !important;
     color: black !important;
+  }
+
+  [data-testid="print-preview-paper"] {
+    position: static !important;
+    display: block !important;
+    width: 100% !important;
+    height: auto !important;
+    min-height: auto !important;
+    background-color: white !important;
+    color: black !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    overflow: visible !important;
   }
 
   .print-preview-controls {

--- a/frontend/tests/active-exam-print.spec.ts
+++ b/frontend/tests/active-exam-print.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  addAuthenticatedSession,
+  APP_BASE,
+  DEFAULT_TEST_PASSWORD,
+  registerAndLogin,
+  seedActiveExam,
+  type AuthSession,
+} from "./helpers";
+
+test.use({ baseURL: APP_BASE });
+
+async function createSession(
+  request: Parameters<typeof registerAndLogin>[0],
+  prefix: string,
+): Promise<AuthSession> {
+  return registerAndLogin(request, `e2e_${prefix}_${Date.now()}_${Math.random()}`, DEFAULT_TEST_PASSWORD);
+}
+
+test.describe("Active Exam print preview", () => {
+  test("renders all exam content in the print preview for a one-problem exam", async ({ page, request }) => {
+    const session = await createSession(request, "active_exam_print");
+    const problemText = "What is 2+2?";
+    await seedActiveExam(request, session, {
+      text: problemText,
+      problemType: "fill-in-the-blank",
+      correctAnswer: "4",
+    });
+    await addAuthenticatedSession(page, session);
+
+    await page.goto("/exams/active");
+    await expect(page.getByRole("heading", { name: "Active Exam" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Print" }).click();
+
+    const paper = page.getByTestId("print-preview-paper");
+    await expect(paper).toBeVisible();
+    await expect(paper.getByText("Exam Paper")).toBeVisible();
+    await expect(paper.getByText("Question 1")).toBeVisible();
+    await expect(paper.getByText(problemText)).toBeVisible();
+  });
+
+  test("print preview hides controls and app shell under print media", async ({ page, request }) => {
+    const session = await createSession(request, "active_exam_print_media");
+    await seedActiveExam(request, session, {
+      text: "Short question?",
+      problemType: "fill-in-the-blank",
+      correctAnswer: "yes",
+    });
+    await addAuthenticatedSession(page, session);
+
+    await page.goto("/exams/active");
+    await page.getByRole("button", { name: "Print" }).click();
+    const paper = page.getByTestId("print-preview-paper");
+    await expect(paper).toBeVisible();
+
+    await page.emulateMedia({ media: "print" });
+
+    // Paper content remains visible.
+    await expect(paper.getByText("Exam Paper")).toBeVisible();
+    await expect(paper.getByText("Question 1")).toBeVisible();
+
+    // Preview controls and app shell should be hidden by print CSS.
+    await expect(page.getByTestId("print-preview-print-button")).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Cancel" }).first()).not.toBeVisible();
+    await expect(page.locator("header")).not.toBeVisible();
+  });
+});

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -136,3 +136,21 @@ export async function submitPracticeAttempt(
   await expectOk(response, "submit practice attempt");
   return response.json();
 }
+
+export async function seedActiveExam(
+  request: APIRequestContext,
+  session: AuthSession,
+  problemInput: ProblemSeedInput,
+) {
+  const problem = await seedProblem(request, session, problemInput);
+
+  const createResponse = await request.post(`${API_BASE}/exams`, {
+    headers: { Cookie: session.cookieHeader },
+    data: { maxProblemCount: 1 },
+  });
+  await expectOk(createResponse, "create active exam");
+
+  const createPayload = await createResponse.json();
+  expect(createPayload.exam?.id, "created exam id should be present").toBeTruthy();
+  return createPayload.exam;
+}


### PR DESCRIPTION
## Summary

Fixes the Active Exam print preview so a one-problem exam prints as a single non-empty page instead of producing blank trailing pages or fully blank hosted output.

## Linked Issue

Closes #342

## Issue Alignment

This PR implements the issue by:

- Adding a `data-testid="print-preview-paper"` wrapper around the printable exam paper content in `ActiveExamPage.tsx` so CSS can target the paper directly instead of the full-screen modal overlay.
- Rewriting the `@media print` rules in `theme.css` to:
  - hide the app shell (`header`/`.glass-header`);
  - collapse `main` and its content wrapper so they cannot generate blank pages;
  - hide every sibling of the print-preview overlay;
  - reset the overlay/card to normal document flow with transparent backgrounds and no box shadow/border;
  - show only the paper content, with controls hidden via `.print-preview-controls { display: none }`.
- Adding a Playwright regression spec that seeds a one-problem active exam, opens the print preview, and verifies the paper content is visible and the controls/app shell are hidden under print media.
- Adding a component test verifying the printable paper wrapper is rendered when the preview is open.

Scope covered:

- Active Exam print-preview CSS/layout fix.
- Printable paper wrapper/test ID.
- Component and Playwright regression tests.
- Manual verification with PDF output.

Out of scope / intentionally not included:

- Backend changes, exam scoring, custom PDF generator, print settings UI, unrelated modal styling.

## Implementation Notes

- The previous `@media print` block made the full modal overlay printable with `position: absolute; min-height: 100%`, which introduced viewport-sized empty space and caused blank trailing pages.
- The new rules instead collapse `main` with `display: contents` and hide all of the content-wrapper siblings of the overlay, so only the paper remains in the printed document flow.
- The overlay and its card are reset to `position: static`, transparent backgrounds, and no shadows/borders, so they no longer behave like a modal in print output.
- `height: auto`, `min-height: auto`, and `overflow: visible` are used throughout to avoid forcing extra page area.

## Tests

Commands run:

- `cd frontend && npm test -- ActiveExamPage.test.tsx --run` — 16 tests passed.
- `cd frontend && npx playwright test tests/active-exam-print.spec.ts` — 2 tests passed.
- `cd frontend && npm run build` — passed.

Automated tests added or updated:

- `frontend/tests/active-exam-print.spec.ts` — Playwright regression for one-problem print preview (visible content and print-media hiding of controls/app shell).
- `frontend/src/pages/ActiveExamPage.test.tsx` — component test asserting `print-preview-paper` wrapper and its content.

Manual verification:

- Generated a PDF via Playwright for a one-problem active exam after emulating print media.
- `pdfinfo` reported `Pages: 1`.
- `pdftotext` extracted: `Exam Paper`, `Question 1`, `What is 2+2?`.
- The extracted text did not include the app shell (`Active Exam`, `Previous`, `Next`, `Submit Exam`) or preview controls (`Print`, `Cancel`, `Discard`).

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
