### PR TITLE
Define bulk ingestion domain states and configuration

### DIFF
--- a/backend/app/domain/ingestion/__init__.py
+++ b/backend/app/domain/ingestion/__init__.py
@@ -1,1 +1,37 @@
 """Ingestion domain namespace."""
+
+from .state import (
+    BatchState,
+    ImageState,
+    ItemState,
+    BATCH_TRANSITIONS,
+    IMAGE_TRANSITIONS,
+    ITEM_TRANSITIONS,
+    BATCH_TERMINAL_STATES,
+    IMAGE_TERMINAL_STATES,
+    ITEM_TERMINAL_STATES,
+    transition_batch_state,
+    transition_image_state,
+    transition_item_state,
+    is_batch_terminal,
+    is_image_terminal,
+    is_item_terminal,
+)
+
+__all__ = [
+    "BatchState",
+    "ImageState",
+    "ItemState",
+    "BATCH_TRANSITIONS",
+    "IMAGE_TRANSITIONS",
+    "ITEM_TRANSITIONS",
+    "BATCH_TERMINAL_STATES",
+    "IMAGE_TERMINAL_STATES",
+    "ITEM_TERMINAL_STATES",
+    "transition_batch_state",
+    "transition_image_state",
+    "transition_item_state",
+    "is_batch_terminal",
+    "is_image_terminal",
+    "is_item_terminal",
+]

--- a/backend/app/domain/ingestion/state.py
+++ b/backend/app/domain/ingestion/state.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from app.domain.state import InvalidStateTransitionError
+
+
+class BatchState(str, Enum):
+    """Lifecycle states for a server-backed bulk ingestion batch."""
+
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    EXPIRED = "expired"
+    DELETED = "deleted"
+
+
+class ImageState(str, Enum):
+    """Lifecycle states for an image inside a bulk ingestion batch."""
+
+    UPLOADED = "uploaded"
+    DETECTING = "detecting"
+    DETECT_FAILED = "detect-failed"
+    READY = "ready"
+    COMMITTED = "committed"
+    DELETED = "deleted"
+
+
+class ItemState(str, Enum):
+    """Lifecycle states for an extraction item inside a bulk ingestion batch."""
+
+    QUEUED = "queued"
+    EXTRACTING = "extracting"
+    READY = "ready"
+    FAILED = "failed"
+    SUBMIT_FAILED = "submit-failed"
+    DELETED = "deleted"
+    SUBMITTED = "submitted"
+
+
+BATCH_TRANSITIONS: dict[BatchState, list[BatchState]] = {
+    BatchState.ACTIVE: [BatchState.COMPLETED, BatchState.EXPIRED, BatchState.DELETED],
+    BatchState.COMPLETED: [],
+    BatchState.EXPIRED: [],
+    BatchState.DELETED: [],
+}
+
+IMAGE_TRANSITIONS: dict[ImageState, list[ImageState]] = {
+    ImageState.UPLOADED: [ImageState.DETECTING, ImageState.DELETED],
+    ImageState.DETECTING: [ImageState.READY, ImageState.DETECT_FAILED],
+    ImageState.DETECT_FAILED: [ImageState.DETECTING, ImageState.READY, ImageState.DELETED],
+    ImageState.READY: [ImageState.COMMITTED, ImageState.DELETED],
+    ImageState.COMMITTED: [ImageState.DELETED],
+    ImageState.DELETED: [],
+}
+
+ITEM_TRANSITIONS: dict[ItemState, list[ItemState]] = {
+    ItemState.QUEUED: [ItemState.EXTRACTING, ItemState.DELETED],
+    ItemState.EXTRACTING: [ItemState.READY, ItemState.FAILED],
+    ItemState.FAILED: [ItemState.QUEUED, ItemState.DELETED],
+    ItemState.READY: [ItemState.SUBMITTED, ItemState.SUBMIT_FAILED, ItemState.DELETED],
+    ItemState.SUBMIT_FAILED: [ItemState.QUEUED, ItemState.DELETED],
+    ItemState.DELETED: [],
+    ItemState.SUBMITTED: [],
+}
+
+BATCH_TERMINAL_STATES = {BatchState.COMPLETED, BatchState.EXPIRED, BatchState.DELETED}
+IMAGE_TERMINAL_STATES = {ImageState.DELETED}
+ITEM_TERMINAL_STATES = {ItemState.DELETED, ItemState.SUBMITTED}
+
+
+def transition_batch_state(current: BatchState, target: BatchState) -> BatchState:
+    if target not in BATCH_TRANSITIONS.get(current, []):
+        raise InvalidStateTransitionError(f"Invalid batch transition from {current} to {target}")
+    return target
+
+
+def transition_image_state(current: ImageState, target: ImageState) -> ImageState:
+    if target not in IMAGE_TRANSITIONS.get(current, []):
+        raise InvalidStateTransitionError(f"Invalid image transition from {current} to {target}")
+    return target
+
+
+def transition_item_state(current: ItemState, target: ItemState) -> ItemState:
+    if target not in ITEM_TRANSITIONS.get(current, []):
+        raise InvalidStateTransitionError(f"Invalid item transition from {current} to {target}")
+    return target
+
+
+def is_batch_terminal(state: BatchState) -> bool:
+    return state in BATCH_TERMINAL_STATES
+
+
+def is_image_terminal(state: ImageState) -> bool:
+    return state in IMAGE_TERMINAL_STATES
+
+
+def is_item_terminal(state: ItemState) -> bool:
+    return state in ITEM_TERMINAL_STATES

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -88,6 +88,14 @@ class Settings(BaseSettings):
     problem_selection_recency_weight: float = Field(default=1.0, ge=0)
     problem_selection_min_age_days: int = Field(default=3, ge=0)
 
+    # Bulk ingestion configuration
+    bulk_ingestion_max_images: int = Field(default=50, ge=1)
+    bulk_ingestion_max_image_bytes: int = Field(default=10 * 1024 * 1024, ge=1)
+    bulk_ingestion_max_items: int = Field(default=200, ge=1)
+    bulk_ingestion_batch_ttl_seconds: int = Field(default=86400, ge=1)
+    bulk_ingestion_extraction_concurrency: int = Field(default=3, ge=1)
+    bulk_ingestion_item_lease_timeout_seconds: int = Field(default=120, ge=1)
+
     # Teacher password configuration
     teacher_password_default: str = Field(default="default-teacher-password")
 

--- a/backend/tests/domain/test_bulk_ingestion_state.py
+++ b/backend/tests/domain/test_bulk_ingestion_state.py
@@ -1,0 +1,114 @@
+import pytest
+
+from app.domain.ingestion import (
+    BatchState,
+    ImageState,
+    ItemState,
+    transition_batch_state,
+    transition_image_state,
+    transition_item_state,
+    is_batch_terminal,
+    is_image_terminal,
+    is_item_terminal,
+)
+from app.domain.state import InvalidStateTransitionError
+
+
+class TestBatchStateTransitions:
+    def test_active_to_completed(self):
+        assert transition_batch_state(BatchState.ACTIVE, BatchState.COMPLETED) == BatchState.COMPLETED
+
+    def test_active_to_expired(self):
+        assert transition_batch_state(BatchState.ACTIVE, BatchState.EXPIRED) == BatchState.EXPIRED
+
+    def test_active_to_deleted(self):
+        assert transition_batch_state(BatchState.ACTIVE, BatchState.DELETED) == BatchState.DELETED
+
+    def test_terminal_batch_states_reject_transitions(self):
+        for source in (BatchState.COMPLETED, BatchState.EXPIRED, BatchState.DELETED):
+            for target in BatchState:
+                with pytest.raises(InvalidStateTransitionError):
+                    transition_batch_state(source, target)
+
+    def test_batch_terminal_states(self):
+        assert is_batch_terminal(BatchState.COMPLETED) is True
+        assert is_batch_terminal(BatchState.EXPIRED) is True
+        assert is_batch_terminal(BatchState.DELETED) is True
+        assert is_batch_terminal(BatchState.ACTIVE) is False
+
+
+class TestImageStateTransitions:
+    def test_uploaded_to_detecting(self):
+        assert transition_image_state(ImageState.UPLOADED, ImageState.DETECTING) == ImageState.DETECTING
+
+    def test_detecting_to_ready(self):
+        assert transition_image_state(ImageState.DETECTING, ImageState.READY) == ImageState.READY
+
+    def test_detecting_to_detect_failed(self):
+        assert transition_image_state(ImageState.DETECTING, ImageState.DETECT_FAILED) == ImageState.DETECT_FAILED
+
+    def test_detect_failed_to_detecting(self):
+        assert transition_image_state(ImageState.DETECT_FAILED, ImageState.DETECTING) == ImageState.DETECTING
+
+    def test_detect_failed_to_ready(self):
+        assert transition_image_state(ImageState.DETECT_FAILED, ImageState.READY) == ImageState.READY
+
+    def test_ready_to_committed(self):
+        assert transition_image_state(ImageState.READY, ImageState.COMMITTED) == ImageState.COMMITTED
+
+    def test_committed_to_deleted(self):
+        assert transition_image_state(ImageState.COMMITTED, ImageState.DELETED) == ImageState.DELETED
+
+    def test_invalid_image_transitions(self):
+        with pytest.raises(InvalidStateTransitionError):
+            transition_image_state(ImageState.UPLOADED, ImageState.READY)
+        with pytest.raises(InvalidStateTransitionError):
+            transition_image_state(ImageState.READY, ImageState.UPLOADED)
+        with pytest.raises(InvalidStateTransitionError):
+            transition_image_state(ImageState.DELETED, ImageState.UPLOADED)
+
+    def test_image_terminal_states(self):
+        assert is_image_terminal(ImageState.DELETED) is True
+        assert is_image_terminal(ImageState.UPLOADED) is False
+
+
+class TestItemStateTransitions:
+    def test_queued_to_extracting(self):
+        assert transition_item_state(ItemState.QUEUED, ItemState.EXTRACTING) == ItemState.EXTRACTING
+
+    def test_extracting_to_ready(self):
+        assert transition_item_state(ItemState.EXTRACTING, ItemState.READY) == ItemState.READY
+
+    def test_extracting_to_failed(self):
+        assert transition_item_state(ItemState.EXTRACTING, ItemState.FAILED) == ItemState.FAILED
+
+    def test_failed_to_queued(self):
+        assert transition_item_state(ItemState.FAILED, ItemState.QUEUED) == ItemState.QUEUED
+
+    def test_ready_to_submitted(self):
+        assert transition_item_state(ItemState.READY, ItemState.SUBMITTED) == ItemState.SUBMITTED
+
+    def test_ready_to_submit_failed(self):
+        assert transition_item_state(ItemState.READY, ItemState.SUBMIT_FAILED) == ItemState.SUBMIT_FAILED
+
+    def test_submit_failed_to_queued(self):
+        assert transition_item_state(ItemState.SUBMIT_FAILED, ItemState.QUEUED) == ItemState.QUEUED
+
+    def test_deleted_item_is_terminal(self):
+        assert transition_item_state(ItemState.READY, ItemState.DELETED) == ItemState.DELETED
+        for source in (ItemState.DELETED, ItemState.SUBMITTED):
+            for target in ItemState:
+                with pytest.raises(InvalidStateTransitionError):
+                    transition_item_state(source, target)
+
+    def test_invalid_item_transitions(self):
+        with pytest.raises(InvalidStateTransitionError):
+            transition_item_state(ItemState.QUEUED, ItemState.SUBMITTED)
+        with pytest.raises(InvalidStateTransitionError):
+            transition_item_state(ItemState.SUBMITTED, ItemState.QUEUED)
+
+    def test_item_terminal_states(self):
+        assert is_item_terminal(ItemState.SUBMITTED) is True
+        assert is_item_terminal(ItemState.DELETED) is True
+        assert is_item_terminal(ItemState.READY) is False
+        assert is_item_terminal(ItemState.SUBMIT_FAILED) is False

--- a/backend/tests/infrastructure/test_config.py
+++ b/backend/tests/infrastructure/test_config.py
@@ -1,3 +1,6 @@
+import pytest
+from pydantic import ValidationError
+
 from app.infrastructure.config.settings import Settings
 from pydantic_settings import SettingsConfigDict
 
@@ -58,6 +61,12 @@ def test_settings_load_from_environment(monkeypatch) -> None:
     monkeypatch.setenv("SESSION_COOKIE_NAME", "cookie")
     monkeypatch.setenv("SESSION_SECURE", "true")
     monkeypatch.setenv("SESSION_SAMESITE", "strict")
+    monkeypatch.setenv("BULK_INGESTION_MAX_IMAGES", "10")
+    monkeypatch.setenv("BULK_INGESTION_MAX_IMAGE_BYTES", "5242880")
+    monkeypatch.setenv("BULK_INGESTION_MAX_ITEMS", "50")
+    monkeypatch.setenv("BULK_INGESTION_BATCH_TTL_SECONDS", "7200")
+    monkeypatch.setenv("BULK_INGESTION_EXTRACTION_CONCURRENCY", "2")
+    monkeypatch.setenv("BULK_INGESTION_ITEM_LEASE_TIMEOUT_SECONDS", "60")
 
     settings = _IsolatedSettings()
 
@@ -112,6 +121,12 @@ def test_settings_load_from_environment(monkeypatch) -> None:
     assert settings.session_cookie_name == "cookie"
     assert settings.session_secure is True
     assert settings.session_samesite == "strict"
+    assert settings.bulk_ingestion_max_images == 10
+    assert settings.bulk_ingestion_max_image_bytes == 5242880
+    assert settings.bulk_ingestion_max_items == 50
+    assert settings.bulk_ingestion_batch_ttl_seconds == 7200
+    assert settings.bulk_ingestion_extraction_concurrency == 2
+    assert settings.bulk_ingestion_item_lease_timeout_seconds == 60
 
 
 def test_settings_defaults_when_environment_missing(monkeypatch) -> None:
@@ -167,6 +182,12 @@ def test_settings_defaults_when_environment_missing(monkeypatch) -> None:
         "SESSION_COOKIE_NAME",
         "SESSION_SECURE",
         "SESSION_SAMESITE",
+        "BULK_INGESTION_MAX_IMAGES",
+        "BULK_INGESTION_MAX_IMAGE_BYTES",
+        "BULK_INGESTION_MAX_ITEMS",
+        "BULK_INGESTION_BATCH_TTL_SECONDS",
+        "BULK_INGESTION_EXTRACTION_CONCURRENCY",
+        "BULK_INGESTION_ITEM_LEASE_TIMEOUT_SECONDS",
     ]:
         monkeypatch.delenv(key, raising=False)
 
@@ -211,3 +232,15 @@ def test_settings_defaults_when_environment_missing(monkeypatch) -> None:
     assert settings.solution_task_timeout_minutes == 10
     assert settings.solution_max_retries == 3
     assert settings.session_samesite == "lax"
+    assert settings.bulk_ingestion_max_images == 50
+    assert settings.bulk_ingestion_max_image_bytes == 10 * 1024 * 1024
+    assert settings.bulk_ingestion_max_items == 200
+    assert settings.bulk_ingestion_batch_ttl_seconds == 86400
+    assert settings.bulk_ingestion_extraction_concurrency == 3
+    assert settings.bulk_ingestion_item_lease_timeout_seconds == 120
+
+
+def test_settings_reject_invalid_bulk_ingestion_values(monkeypatch) -> None:
+    monkeypatch.setenv("BULK_INGESTION_MAX_IMAGES", "0")
+    with pytest.raises(ValidationError):
+        _IsolatedSettings()


### PR DESCRIPTION
## Summary

Defines the backend domain model for server-backed bulk ingestion batches: batch, image, and item lifecycle states; valid state-transition helpers; terminal-state checks; and configurable limits/TTL/concurrency settings.

## Linked Issue

Closes #359

## Issue Alignment

This PR implements the issue by:

- Adding `BatchState`, `ImageState`, and `ItemState` enums under `backend/app/domain/ingestion/`.
- Adding explicit transition maps and `transition_*_state` helpers that raise `InvalidStateTransitionError` for invalid moves.
- Adding `is_*_terminal` helpers covering terminal states (`completed`, `expired`, `deleted` for batches; `deleted` for images; `submitted`/`deleted` for items).
- Adding bulk-ingestion settings to the existing `Settings` class:
  - `bulk_ingestion_max_images` (default 50)
  - `bulk_ingestion_max_image_bytes` (default 10 MiB)
  - `bulk_ingestion_max_items` (default 200)
  - `bulk_ingestion_batch_ttl_seconds` (default 86400)
  - `bulk_ingestion_extraction_concurrency` (default 3)
  - `bulk_ingestion_item_lease_timeout_seconds` (default 120)
- Adding domain and config tests covering valid/invalid transitions, terminal states, defaults, environment overrides, and invalid-value rejection.

Scope covered:

- Domain states and transition helpers.
- Terminal-state helpers.
- Bulk-ingestion configuration.
- Required tests.

Out of scope / intentionally not included:

- Database collections or indexes.
- API endpoints.
- VLM detection/extraction/submit logic.
- Frontend work.
- Long-term archival.

## Implementation Notes

- New bulk-ingestion domain code lives in `backend/app/domain/ingestion/state.py`, matching the issue’s suggested location.
- Reused the existing `InvalidStateTransitionError` from `app.domain.state` to keep error handling consistent with preview/exam state transitions.
- Kept state machines minimal but aligned with downstream workflow expectations (upload → detect → commit → extract → submit).
- Configuration uses the existing Pydantic-Settings `Settings` class so env-var overrides work automatically.

## Tests

Commands run:

- `cd backend && uv run --extra dev pytest tests/domain tests/infrastructure` — **297 passed**

Automated tests added or updated:

- `backend/tests/domain/test_bulk_ingestion_state.py` — covers batch/image/item valid and invalid transitions and terminal states.
- `backend/tests/infrastructure/test_config.py` — covers env overrides, defaults, and invalid value rejection for the new bulk-ingestion settings.

Manual verification:

- Confirmed the new config names and defaults are documented above and match the PR description.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
