### PR TITLE
Add server-backed batch persistence and temporary media cleanup foundation

### DIFF
--- a/backend/app/infrastructure/ingestion/__init__.py
+++ b/backend/app/infrastructure/ingestion/__init__.py
@@ -1,1 +1,46 @@
 """Ingestion infrastructure namespace."""
+
+from .cleanup import cleanup_batch_media, run_batch_cleanup
+from .documents import (
+    build_batch_document,
+    build_image_document,
+    build_item_document,
+    build_source_image,
+    new_image_id,
+    new_item_id,
+)
+from .repository import (
+    INGESTION_BATCHES_COLLECTION,
+    BATCH_INDEXES,
+    add_items_for_image,
+    add_source_image,
+    create_batch,
+    ensure_batch_indexes,
+    find_cleanup_candidates,
+    get_active_batch_for_user,
+    get_batch,
+    is_batch_expired,
+    mark_batch_cleaned,
+)
+
+__all__ = [
+    "INGESTION_BATCHES_COLLECTION",
+    "BATCH_INDEXES",
+    "add_items_for_image",
+    "add_source_image",
+    "build_batch_document",
+    "build_image_document",
+    "build_item_document",
+    "build_source_image",
+    "cleanup_batch_media",
+    "create_batch",
+    "ensure_batch_indexes",
+    "find_cleanup_candidates",
+    "get_active_batch_for_user",
+    "get_batch",
+    "is_batch_expired",
+    "mark_batch_cleaned",
+    "new_image_id",
+    "new_item_id",
+    "run_batch_cleanup",
+]

--- a/backend/app/infrastructure/ingestion/cleanup.py
+++ b/backend/app/infrastructure/ingestion/cleanup.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Any
+
+from botocore.exceptions import ClientError
+
+from app.infrastructure.storage.mongo import Document
+from app.infrastructure.storage.s3 import StorageObjectNotFoundError
+
+from .repository import INGESTION_BATCHES_COLLECTION, find_cleanup_candidates, mark_batch_cleaned
+
+
+def _delete_media(storage: Any, bucket: str | None, key: str | None) -> None:
+    if not bucket or not key:
+        return
+    try:
+        storage.delete_object(bucket, key)
+    except StorageObjectNotFoundError:
+        return
+    except ClientError:
+        return
+
+
+async def cleanup_batch_media(storage: Any, batch: Document) -> None:
+    """Delete all temporary source images and item crops for a batch.
+
+    Missing objects are ignored so the cleanup remains idempotent.
+    """
+    for image in batch.get("images", []):
+        source_image = image.get("sourceImage") or {}
+        _delete_media(storage, source_image.get("bucket"), source_image.get("objectKey"))
+
+    for item in batch.get("items", []):
+        crop = item.get("crop") or {}
+        _delete_media(storage, crop.get("bucket"), crop.get("objectKey"))
+
+
+async def run_batch_cleanup(
+    database: Any,
+    storage: Any,
+    *,
+    now: Any | None = None,
+) -> int:
+    """Find and clean expired/completed batches. Returns number cleaned."""
+    candidates = await find_cleanup_candidates(database, now=now)
+    cleaned = 0
+    for batch in candidates:
+        await cleanup_batch_media(storage, batch)
+        await mark_batch_cleaned(database, batch["_id"], now=now)
+        cleaned += 1
+    return cleaned
+
+
+__all__ = [
+    "INGESTION_BATCHES_COLLECTION",
+    "cleanup_batch_media",
+    "find_cleanup_candidates",
+    "run_batch_cleanup",
+]

--- a/backend/app/infrastructure/ingestion/cleanup.py
+++ b/backend/app/infrastructure/ingestion/cleanup.py
@@ -17,8 +17,11 @@ def _delete_media(storage: Any, bucket: str | None, key: str | None) -> None:
         storage.delete_object(bucket, key)
     except StorageObjectNotFoundError:
         return
-    except ClientError:
-        return
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code")
+        if error_code in {"404", "NoSuchKey", "NotFound"}:
+            return
+        raise
 
 
 async def cleanup_batch_media(storage: Any, batch: Document) -> None:

--- a/backend/app/infrastructure/ingestion/documents.py
+++ b/backend/app/infrastructure/ingestion/documents.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import uuid4
+
+from bson import ObjectId
+
+from app.domain.ingestion import BatchState, ImageState, ItemState
+
+
+def new_image_id() -> str:
+    return str(uuid4())
+
+
+def new_item_id() -> str:
+    return str(uuid4())
+
+
+def build_source_image(
+    *,
+    bucket: str,
+    object_key: str,
+    content_type: str,
+    size_bytes: int,
+    sha256: str,
+    uploaded_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "bucket": bucket,
+        "objectKey": object_key,
+        "contentType": content_type,
+        "sizeBytes": size_bytes,
+        "sha256": sha256,
+        "uploadedAt": uploaded_at,
+    }
+
+
+def build_image_document(
+    *,
+    image_id: str,
+    source_image: dict[str, Any],
+    order: int,
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "imageId": image_id,
+        "status": ImageState.UPLOADED.value,
+        "order": order,
+        "sourceImage": source_image,
+        "subject": None,
+        "boxes": [],
+        "detection": {
+            "model": None,
+            "rawProviderResponse": None,
+            "failureCode": None,
+            "failureMessage": None,
+        },
+        "committedAt": None,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def build_item_document(
+    *,
+    item_id: str,
+    batch_id: ObjectId,
+    image_id: str,
+    order: int,
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "itemId": item_id,
+        "imageId": image_id,
+        "batchId": batch_id,
+        "status": ItemState.QUEUED.value,
+        "order": order,
+        "draft": {
+            "text": None,
+            "problemType": None,
+            "graphDsl": None,
+            "correctAnswer": None,
+            "tags": [],
+            "subject": None,
+        },
+        "extraction": {
+            "success": None,
+            "model": None,
+            "rawText": None,
+            "rawProblemType": None,
+            "rawGraphDsl": None,
+            "rawProviderResponse": None,
+            "failureCode": None,
+            "failureMessage": None,
+            "requestStartedAt": None,
+            "requestFinishedAt": None,
+        },
+        "retryCount": 0,
+        "submit": {
+            "submittedProblemId": None,
+            "success": None,
+            "failureCode": None,
+            "failureMessage": None,
+        },
+        "origin": {
+            "batchId": str(batch_id),
+            "imageId": image_id,
+            "itemId": item_id,
+        },
+        "crop": None,
+        "leaseUntil": None,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def build_batch_document(
+    *,
+    batch_id: ObjectId,
+    user_id: Any,
+    expires_at: datetime,
+    now: datetime,
+) -> dict[str, Any]:
+    return {
+        "_id": batch_id,
+        "userId": user_id,
+        "status": BatchState.ACTIVE.value,
+        "images": [],
+        "items": [],
+        "createdAt": now,
+        "updatedAt": now,
+        "expiresAt": expires_at,
+    }

--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from bson import ObjectId
+from pymongo import ASCENDING
+
+from app.domain.ingestion import BatchState, ImageState
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.storage.mongo import Document
+
+from .documents import (
+    build_batch_document,
+    build_image_document,
+    build_item_document,
+    new_image_id,
+    new_item_id,
+)
+
+INGESTION_BATCHES_COLLECTION = "ingestion_batches"
+
+BATCH_INDEXES = [
+    {
+        "keys": [("userId", ASCENDING), ("status", ASCENDING), ("expiresAt", ASCENDING)],
+        "name": "batch_user_status_expiry",
+    },
+    {
+        "keys": [("status", ASCENDING), ("expiresAt", ASCENDING)],
+        "name": "batch_cleanup",
+    },
+    {
+        "keys": [("items.itemId", ASCENDING)],
+        "name": "batch_item_id",
+    },
+    {
+        "keys": [("items.origin.batchId", ASCENDING), ("items.origin.itemId", ASCENDING)],
+        "name": "batch_item_origin",
+    },
+]
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _collection(database: Any) -> Any:
+    return database[INGESTION_BATCHES_COLLECTION]
+
+
+def _object_id(value: str | ObjectId) -> ObjectId:
+    return ObjectId(value) if isinstance(value, str) else value
+
+
+def is_batch_expired(batch: Document, *, now: datetime | None = None) -> bool:
+    expires_at = batch.get("expiresAt")
+    if not isinstance(expires_at, datetime):
+        return False
+    return expires_at < (now or _now())
+
+
+async def create_batch(
+    database: Any,
+    user_id: Any,
+    settings: Settings,
+    *,
+    now: datetime | None = None,
+) -> Document:
+    current = now or _now()
+    ttl_seconds = settings.bulk_ingestion_batch_ttl_seconds
+    batch_id = ObjectId()
+    document = build_batch_document(
+        batch_id=batch_id,
+        user_id=user_id,
+        expires_at=current + timedelta(seconds=ttl_seconds),
+        now=current,
+    )
+    await _collection(database).insert_one(document)
+    return document
+
+
+async def get_batch(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+) -> Document | None:
+    return await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+
+
+async def get_active_batch_for_user(
+    database: Any,
+    user_id: Any,
+    *,
+    now: datetime | None = None,
+) -> Document | None:
+    current = now or _now()
+    return await _collection(database).find_one(
+        {
+            "userId": user_id,
+            "status": BatchState.ACTIVE.value,
+            "expiresAt": {"$gt": current},
+        }
+    )
+
+
+async def add_source_image(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    source_image: dict[str, Any],
+    *,
+    order: int,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    current = now or _now()
+    image_id = new_image_id()
+    image_document = build_image_document(
+        image_id=image_id,
+        source_image=source_image,
+        order=order,
+        now=current,
+    )
+
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    images.append(image_document)
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "updatedAt": current}},
+    )
+    return image_document
+
+
+async def add_items_for_image(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    item_count: int,
+    *,
+    starting_order: int,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    current = now or _now()
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    new_items: list[dict[str, Any]] = []
+    for offset in range(item_count):
+        item_id = new_item_id()
+        item_document = build_item_document(
+            item_id=item_id,
+            batch_id=batch["_id"],
+            image_id=image_id,
+            order=starting_order + offset,
+            now=current,
+        )
+        items.append(item_document)
+        new_items.append(item_document)
+
+    images = list(batch.get("images", []))
+    for image in images:
+        if image.get("imageId") == image_id:
+            image["status"] = ImageState.COMMITTED.value
+            image["committedAt"] = current
+            image["updatedAt"] = current
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "items": items, "updatedAt": current}},
+    )
+    return new_items
+
+
+async def find_cleanup_candidates(
+    database: Any,
+    *,
+    now: datetime | None = None,
+) -> list[Document]:
+    current = now or _now()
+    query = {
+        "$or": [
+            {"status": BatchState.EXPIRED.value},
+            {"status": BatchState.COMPLETED.value},
+            {
+                "status": BatchState.ACTIVE.value,
+                "expiresAt": {"$lte": current},
+            },
+        ]
+    }
+    cursor = _collection(database).find(query)
+    return await cursor.to_list(length=None)
+
+
+async def mark_batch_cleaned(
+    database: Any,
+    batch_id: str | ObjectId,
+    *,
+    now: datetime | None = None,
+) -> None:
+    current = now or _now()
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id)},
+        {"$set": {"status": BatchState.DELETED.value, "updatedAt": current}},
+    )
+
+
+async def ensure_batch_indexes(database: Any) -> None:
+    collection = _collection(database)
+    create_index = getattr(collection, "create_index", None)
+    if not callable(create_index):
+        return
+    for index in BATCH_INDEXES:
+        await create_index(index["keys"], name=index["name"])

--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -96,11 +96,17 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
     except AttributeError:
         existing_collections = set()
 
+    from app.infrastructure.ingestion.repository import (
+        INGESTION_BATCHES_COLLECTION,
+        ensure_batch_indexes,
+    )
+
     for collection_name in (
         SOLUTION_GENERATION_TASKS_COLLECTION,
         CANONICAL_SOLUTIONS_COLLECTION,
         COACHING_CONVERSATIONS_COLLECTION,
         FOLDERS_COLLECTION,
+        INGESTION_BATCHES_COLLECTION,
     ):
         if collection_name not in existing_collections and hasattr(database, "create_collection"):
             await database.create_collection(collection_name)
@@ -130,6 +136,8 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
             name="user_parent_folder_unique",
             collation={"locale": "en", "strength": 2},  # case-insensitive
         )
+
+    await ensure_batch_indexes(database)
 
 
 @asynccontextmanager

--- a/backend/tests/infrastructure/test_ingestion_persistence.py
+++ b/backend/tests/infrastructure/test_ingestion_persistence.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 from bson import ObjectId
+from botocore.exceptions import ClientError
 
 from app.domain.ingestion import BatchState, ImageState, ItemState
 from app.infrastructure.config.settings import Settings
@@ -153,6 +154,16 @@ class StrictStorage(FakeStorage):
         if (bucket, key) not in self._objects:
             raise StorageObjectNotFoundError(key)
         super().delete_object(bucket, key)
+
+
+class AccessDeniedStorage(FakeStorage):
+    """Simulates a non-missing object-store failure so cleanup does not swallow real errors."""
+
+    def delete_object(self, bucket: str, key: str) -> None:
+        raise ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "Access denied"}},
+            "DeleteObject",
+        )
 
 
 @pytest.fixture
@@ -408,6 +419,37 @@ async def test_cleanup_ignores_missing_media(
     loaded = await get_batch(database, batch["_id"], user_id)
     assert loaded is not None
     assert loaded["status"] == BatchState.DELETED.value
+
+
+@pytest.mark.asyncio
+async def test_cleanup_re_raises_non_missing_object_store_errors(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    storage = AccessDeniedStorage()
+    batch = await create_batch(database, user_id, settings)
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/denied.png",
+        content_type="image/png",
+        size_bytes=10,
+        sha256="sha",
+        uploaded_at=datetime.now(UTC),
+    )
+    await add_source_image(database, batch["_id"], user_id, source_image, order=0)
+    await database["ingestion_batches"].update_one(
+        {"_id": batch["_id"]},
+        {"$set": {"status": BatchState.EXPIRED.value}},
+    )
+
+    with pytest.raises(ClientError):
+        await run_batch_cleanup(database, storage)
+
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert loaded["status"] == BatchState.EXPIRED.value
 
 
 @pytest.mark.asyncio

--- a/backend/tests/infrastructure/test_ingestion_persistence.py
+++ b/backend/tests/infrastructure/test_ingestion_persistence.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from bson import ObjectId
+
+from app.domain.ingestion import BatchState, ImageState, ItemState
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.ingestion import (
+    add_items_for_image,
+    add_source_image,
+    build_source_image,
+    cleanup_batch_media,
+    create_batch,
+    find_cleanup_candidates,
+    get_active_batch_for_user,
+    get_batch,
+    is_batch_expired,
+    mark_batch_cleaned,
+    run_batch_cleanup,
+)
+from app.infrastructure.storage.s3 import StorageObjectNotFoundError
+
+
+class FakeInsertOneResult:
+    def __init__(self, inserted_id: ObjectId) -> None:
+        self.inserted_id = inserted_id
+
+
+class FakeUpdateResult:
+    def __init__(self, modified_count: int) -> None:
+        self.modified_count = modified_count
+
+
+class FakeCursor:
+    def __init__(self, documents: list[dict[str, Any]]) -> None:
+        self._documents = [deepcopy(document) for document in documents]
+
+    async def to_list(self, length: int | None = None) -> list[dict[str, Any]]:
+        documents = self._documents
+        if length is not None:
+            documents = documents[:length]
+        return [deepcopy(document) for document in documents]
+
+
+def _matches(document: dict[str, Any], query: dict[str, Any]) -> bool:
+    for key, expected in query.items():
+        if key == "$or":
+            return any(_matches(document, subquery) for subquery in expected)
+        actual = document.get(key)
+        if isinstance(expected, dict):
+            for op, value in expected.items():
+                if op == "$in":
+                    if actual not in value:
+                        return False
+                elif op == "$gt":
+                    if actual is None or actual <= value:
+                        return False
+                elif op == "$gte":
+                    if actual is None or actual < value:
+                        return False
+                elif op == "$lt":
+                    if actual is None or actual >= value:
+                        return False
+                elif op == "$lte":
+                    if actual is None or actual > value:
+                        return False
+            continue
+        if isinstance(actual, list):
+            if expected not in actual:
+                return False
+            continue
+        if actual != expected:
+            return False
+    return True
+
+
+class FakeCollection:
+    def __init__(self) -> None:
+        self._documents: list[dict[str, Any]] = []
+
+    async def insert_one(self, document: dict[str, Any]) -> FakeInsertOneResult:
+        stored = deepcopy(document)
+        if "_id" not in stored:
+            stored["_id"] = ObjectId()
+        self._documents.append(stored)
+        return FakeInsertOneResult(stored["_id"])
+
+    async def find_one(self, query: dict[str, Any]) -> dict[str, Any] | None:
+        for document in self._documents:
+            if _matches(document, query):
+                return deepcopy(document)
+        return None
+
+    def find(self, query: dict[str, Any]) -> FakeCursor:
+        return FakeCursor([document for document in self._documents if _matches(document, query)])
+
+    async def update_one(
+        self,
+        query: dict[str, Any],
+        update: dict[str, Any],
+    ) -> FakeUpdateResult:
+        for document in self._documents:
+            if not _matches(document, query):
+                continue
+            for key, value in update.get("$set", {}).items():
+                document[key] = deepcopy(value)
+            return FakeUpdateResult(1)
+        return FakeUpdateResult(0)
+
+
+class FakeDatabase:
+    def __init__(self) -> None:
+        self._collections: dict[str, FakeCollection] = {}
+
+    def __getitem__(self, name: str) -> FakeCollection:
+        return self._collections.setdefault(name, FakeCollection())
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self._objects: dict[tuple[str, str], bytes] = {}
+
+    def seed(self, bucket: str, key: str, payload: bytes) -> None:
+        self._objects[(bucket, key)] = payload
+
+    def put_object(
+        self,
+        bucket: str,
+        key: str,
+        payload: bytes,
+        content_type: str | None = None,
+    ) -> None:
+        self._objects[(bucket, key)] = payload
+
+    def get_object(self, bucket: str, key: str) -> bytes:
+        payload = self._objects.get((bucket, key))
+        if payload is None:
+            raise StorageObjectNotFoundError(key)
+        return payload
+
+    def delete_object(self, bucket: str, key: str) -> None:
+        self._objects.pop((bucket, key), None)
+
+
+class StrictStorage(FakeStorage):
+    """Raises when deleting a missing object so cleanup exception handling is exercised."""
+
+    def delete_object(self, bucket: str, key: str) -> None:
+        if (bucket, key) not in self._objects:
+            raise StorageObjectNotFoundError(key)
+        super().delete_object(bucket, key)
+
+
+@pytest.fixture
+def database() -> FakeDatabase:
+    return FakeDatabase()
+
+
+@pytest.fixture
+def storage() -> FakeStorage:
+    return FakeStorage()
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(bulk_ingestion_batch_ttl_seconds=3600)
+
+
+@pytest.fixture
+def user_id() -> ObjectId:
+    return ObjectId()
+
+
+@pytest.mark.asyncio
+async def test_create_batch_persists_and_loads(
+    database: FakeDatabase,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    batch = await create_batch(database, user_id, settings)
+
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert loaded["userId"] == user_id
+    assert loaded["status"] == BatchState.ACTIVE.value
+    assert loaded["images"] == []
+    assert loaded["items"] == []
+    assert loaded["expiresAt"] > loaded["createdAt"]
+
+
+@pytest.mark.asyncio
+async def test_get_active_batch_for_user_returns_unexpired_active(
+    database: FakeDatabase,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    now = datetime.now(UTC)
+    await create_batch(database, user_id, settings, now=now)
+
+    active = await get_active_batch_for_user(database, user_id, now=now)
+    assert active is not None
+    assert active["status"] == BatchState.ACTIVE.value
+
+
+@pytest.mark.asyncio
+async def test_get_active_batch_for_user_ignores_expired(
+    database: FakeDatabase,
+    user_id: ObjectId,
+) -> None:
+    now = datetime.now(UTC)
+    short_settings = Settings(bulk_ingestion_batch_ttl_seconds=1)
+    await create_batch(database, user_id, short_settings, now=now)
+
+    active = await get_active_batch_for_user(database, user_id, now=now + timedelta(seconds=2))
+    assert active is None
+
+
+@pytest.mark.asyncio
+async def test_add_source_image_round_trips(
+    database: FakeDatabase,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    batch = await create_batch(database, user_id, settings)
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/img.png",
+        content_type="image/png",
+        size_bytes=42,
+        sha256="sha",
+        uploaded_at=datetime.now(UTC),
+    )
+
+    image = await add_source_image(
+        database,
+        batch["_id"],
+        user_id,
+        source_image,
+        order=0,
+    )
+
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert len(loaded["images"]) == 1
+    stored_image = loaded["images"][0]
+    assert stored_image["imageId"] == image["imageId"]
+    assert stored_image["status"] == ImageState.UPLOADED.value
+    assert stored_image["sourceImage"] == source_image
+    assert stored_image["detection"]["failureCode"] is None
+
+
+@pytest.mark.asyncio
+async def test_add_items_for_image_commits_image_and_creates_items(
+    database: FakeDatabase,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    batch = await create_batch(database, user_id, settings)
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/img.png",
+        content_type="image/png",
+        size_bytes=42,
+        sha256="sha",
+        uploaded_at=datetime.now(UTC),
+    )
+    image = await add_source_image(database, batch["_id"], user_id, source_image, order=0)
+
+    items = await add_items_for_image(
+        database,
+        batch["_id"],
+        user_id,
+        image["imageId"],
+        item_count=2,
+        starting_order=0,
+    )
+
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert len(loaded["images"]) == 1
+    assert loaded["images"][0]["status"] == ImageState.COMMITTED.value
+    assert loaded["images"][0]["committedAt"] is not None
+    assert len(loaded["items"]) == 2
+    for index, item in enumerate(loaded["items"]):
+        assert item["itemId"] == items[index]["itemId"]
+        assert item["imageId"] == image["imageId"]
+        assert item["status"] == ItemState.QUEUED.value
+        assert item["draft"] == {
+            "text": None,
+            "problemType": None,
+            "graphDsl": None,
+            "correctAnswer": None,
+            "tags": [],
+            "subject": None,
+        }
+        assert item["extraction"]["failureCode"] is None
+        assert item["retryCount"] == 0
+        assert item["submit"]["submittedProblemId"] is None
+        assert item["origin"]["batchId"] == str(batch["_id"])
+        assert item["origin"]["itemId"] == item["itemId"]
+
+
+@pytest.mark.asyncio
+async def test_find_cleanup_candidates_includes_expired_and_completed(
+    database: FakeDatabase,
+    user_id: ObjectId,
+) -> None:
+    now = datetime.now(UTC)
+    short_settings = Settings(bulk_ingestion_batch_ttl_seconds=1)
+
+    expired_active = await create_batch(database, user_id, short_settings, now=now)
+    completed = await create_batch(database, user_id, Settings(bulk_ingestion_batch_ttl_seconds=3600), now=now)
+    await database["ingestion_batches"].update_one(
+        {"_id": completed["_id"]},
+        {"$set": {"status": BatchState.COMPLETED.value}},
+    )
+    expired_terminal = await create_batch(database, user_id, short_settings, now=now)
+    await database["ingestion_batches"].update_one(
+        {"_id": expired_terminal["_id"]},
+        {"$set": {"status": BatchState.EXPIRED.value}},
+    )
+    fresh = await create_batch(database, user_id, Settings(bulk_ingestion_batch_ttl_seconds=3600), now=now)
+
+    candidates = await find_cleanup_candidates(database, now=now + timedelta(seconds=2))
+    candidate_ids = {candidate["_id"] for candidate in candidates}
+
+    assert expired_active["_id"] in candidate_ids
+    assert completed["_id"] in candidate_ids
+    assert expired_terminal["_id"] in candidate_ids
+    assert fresh["_id"] not in candidate_ids
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_source_and_crop_media(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    batch = await create_batch(database, user_id, settings)
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/source.png",
+        content_type="image/png",
+        size_bytes=10,
+        sha256="sha",
+        uploaded_at=datetime.now(UTC),
+    )
+    image = await add_source_image(database, batch["_id"], user_id, source_image, order=0)
+    items = await add_items_for_image(
+        database, batch["_id"], user_id, image["imageId"], item_count=1, starting_order=0
+    )
+
+    crop_key = "users/u/crop.png"
+    items[0]["crop"] = {"bucket": "media", "objectKey": crop_key}
+    await database["ingestion_batches"].update_one(
+        {"_id": batch["_id"]},
+        {"$set": {"items": items}},
+    )
+    storage.seed("media", source_image["objectKey"], b"source")
+    storage.seed("media", crop_key, b"crop")
+    await database["ingestion_batches"].update_one(
+        {"_id": batch["_id"]},
+        {"$set": {"status": BatchState.EXPIRED.value}},
+    )
+
+    cleaned = await run_batch_cleanup(database, storage)
+
+    assert cleaned == 1
+    with pytest.raises(StorageObjectNotFoundError):
+        storage.get_object("media", source_image["objectKey"])
+    with pytest.raises(StorageObjectNotFoundError):
+        storage.get_object("media", crop_key)
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert loaded["status"] == BatchState.DELETED.value
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ignores_missing_media(
+    database: FakeDatabase,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    storage = StrictStorage()
+    batch = await create_batch(database, user_id, settings)
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/missing.png",
+        content_type="image/png",
+        size_bytes=10,
+        sha256="sha",
+        uploaded_at=datetime.now(UTC),
+    )
+    await add_source_image(database, batch["_id"], user_id, source_image, order=0)
+    await database["ingestion_batches"].update_one(
+        {"_id": batch["_id"]},
+        {"$set": {"status": BatchState.EXPIRED.value}},
+    )
+
+    cleaned = await run_batch_cleanup(database, storage)
+
+    assert cleaned == 1
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert loaded["status"] == BatchState.DELETED.value
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_touch_unrelated_media(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    batch = await create_batch(database, user_id, settings)
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/source.png",
+        content_type="image/png",
+        size_bytes=10,
+        sha256="sha",
+        uploaded_at=datetime.now(UTC),
+    )
+    await add_source_image(database, batch["_id"], user_id, source_image, order=0)
+    await database["ingestion_batches"].update_one(
+        {"_id": batch["_id"]},
+        {"$set": {"status": BatchState.EXPIRED.value}},
+    )
+    storage.seed("media", "users/u/other.png", b"other")
+    storage.seed("media", source_image["objectKey"], b"source")
+
+    await run_batch_cleanup(database, storage)
+
+    assert storage.get_object("media", "users/u/other.png") == b"other"
+
+
+@pytest.mark.asyncio
+async def test_is_batch_expired(
+    database: FakeDatabase,
+    user_id: ObjectId,
+) -> None:
+    now = datetime.now(UTC)
+    batch = await create_batch(database, user_id, Settings(bulk_ingestion_batch_ttl_seconds=1), now=now)
+
+    assert is_batch_expired(batch, now=now + timedelta(seconds=2)) is True
+    assert is_batch_expired(batch, now=now) is False
+
+
+@pytest.mark.asyncio
+async def test_mark_batch_cleaned(
+    database: FakeDatabase,
+    user_id: ObjectId,
+    settings: Settings,
+) -> None:
+    batch = await create_batch(database, user_id, settings)
+    await mark_batch_cleaned(database, batch["_id"])
+
+    loaded = await get_batch(database, batch["_id"], user_id)
+    assert loaded is not None
+    assert loaded["status"] == BatchState.DELETED.value

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -7,6 +7,10 @@ from typing import Any, cast
 import pytest
 
 from app.infrastructure.config.settings import Settings
+from app.infrastructure.ingestion.repository import (
+    BATCH_INDEXES,
+    INGESTION_BATCHES_COLLECTION,
+)
 from app.infrastructure.storage.mongo import (
     AsyncMongoClientFactory,
     CANONICAL_SOLUTIONS_COLLECTION,
@@ -138,6 +142,7 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
         CANONICAL_SOLUTIONS_COLLECTION,
         COACHING_CONVERSATIONS_COLLECTION,
         FOLDERS_COLLECTION,
+        INGESTION_BATCHES_COLLECTION,
     ]
     assert database[TAGS_COLLECTION].index_calls == [
         {
@@ -160,4 +165,8 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
                 "collation": {"locale": "en", "strength": 2},
             },
         }
+    ]
+    assert database[INGESTION_BATCHES_COLLECTION].index_calls == [
+        {"keys": list(index["keys"]), "kwargs": {"name": index["name"]}}
+        for index in BATCH_INDEXES
     ]


### PR DESCRIPTION
## Summary

Adds persistence support for temporary bulk ingestion batches, including batch/image/item document builders, a small repository for owner-scoped batch lookup and cleanup discovery, indexes, and an idempotent cleanup service that removes temporary source images and item crops.

## Linked Issue

Closes #360

## Issue Alignment

This PR implements the issue by:

- Adding `ingestion_batches` as a new Mongo collection (no extension of `ingestion_previews`).
- Adding document builders under `backend/app/infrastructure/ingestion/` for:
  - batches (ownership, status, expiry)
  - images (stable `imageId`, source image reference, detection failure metadata, boxes, committed state)
  - items (stable `itemId`, draft, extraction failure/retry metadata, submit outcome, crop reference, lease, origin metadata)
- Adding repository helpers for:
  - creating a user-owned batch
  - loading a batch with ownership enforcement
  - fetching the active unexpired batch for a user
  - adding source images
  - committing image boxes into items
  - discovering expired/completed cleanup candidates
  - marking a batch cleaned
- Adding cleanup service logic that deletes temporary media and is safe when objects are already missing.
- Adding required indexes for ownership lookup, expiry cleanup, item lookup, and item origin lookup.
- Adding persistence and cleanup tests.

Scope covered:

- `ingestion_batches` persistence structures.
- Stable image/item IDs.
- Origin metadata for idempotent submit lookup.
- Indexes.
- Repository/helper functions.
- Cleanup service.
- Required tests.

Out of scope / intentionally not included:

- User-facing API endpoints.
- VLM detection/extraction/submit logic.
- Frontend UI.
- Long-term archival.
- Scheduled cleanup trigger.

## Implementation Notes

- New code lives under `backend/app/infrastructure/ingestion/` as suggested.
- Documents are plain dicts built by small builder functions so they serialize directly to Mongo.
- Image and item IDs are UUID4 strings, separate from Mongo `_id`, to give downstream extraction and submit paths stable references.
- Item `origin` includes `batchId`, `imageId`, and `itemId` to support future idempotent submit lookups.
- Cleanup is idempotent: missing S3 objects are ignored, and a cleaned batch is moved to `deleted` status so it is not re-selected as a candidate.
- Indexes are created through `ensure_database_setup` alongside existing collection/index setup.

## Tests

Commands run:

- `cd backend && uv run --extra dev pytest tests/infrastructure tests/domain` — **308 passed**

Automated tests added or updated:

- `backend/tests/infrastructure/test_ingestion_persistence.py` — covers create/load, active batch lookup, image and item round-tripping, cleanup candidate discovery, cleanup media deletion, missing-media safety, unrelated-media preservation, expiry checks, and batch cleaned marking.
- `backend/tests/infrastructure/test_mongo.py` — updated to assert the new `ingestion_batches` collection and its indexes are created.

Manual verification:

- Confirmed cleanup only deletes media referenced by the batch being cleaned.
- Confirmed cleanup completes without error when referenced objects are already missing.

## Deviations From Issue Plan

None.

## Follow-Up Work

- Scheduling/triggering cleanup is left for a later issue if the repo adds a scheduler.
