### PR TITLE
Implement batch intake and image upload APIs

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,6 +16,7 @@ from app.presentation.auth import router as auth_router
 from app.presentation.exams import router as exams_router
 from app.presentation.errors import ApiError, api_error_handler, validation_error_handler
 from app.presentation.folders import router as folders_router
+from app.presentation.bulk_ingestion import router as bulk_ingestion_router
 from app.presentation.ingestion import router as ingestion_router
 from app.presentation.media import router as media_router
 from app.presentation.problems import router as problems_router
@@ -76,6 +77,7 @@ def create_app() -> FastAPI:
     api_v1_router = APIRouter(prefix="/api/v1")
     api_v1_router.include_router(auth_router)
     api_v1_router.include_router(ingestion_router)
+    api_v1_router.include_router(bulk_ingestion_router)
     api_v1_router.include_router(problems_router)
     api_v1_router.include_router(exams_router)
     api_v1_router.include_router(media_router)

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -5,7 +5,6 @@ import mimetypes
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
-from uuid import uuid4
 
 from fastapi import APIRouter, Depends, File, UploadFile
 from pydantic import BaseModel
@@ -101,11 +100,6 @@ def _guess_extension(upload: UploadFile) -> str:
         if guessed:
             return guessed
     return ".bin"
-
-
-def _build_batch_image_key(user_id: str, extension: str) -> str:
-    suffix = extension.lstrip(".") or "bin"
-    return f"users/{user_id}/ingestion/batches/{uuid4()}.{suffix}"
 
 
 def _serialize_source_image(source_image: dict[str, Any]) -> dict[str, Any]:
@@ -258,7 +252,9 @@ async def upload_batch_images(
         image_bytes, content_type = await _validate_image_upload(
             image, settings.bulk_ingestion_max_image_bytes
         )
-        object_key = _build_batch_image_key(str(user["_id"]), _guess_extension(image))
+        object_key = s3_storage.build_object_key(
+            str(user["_id"]), _guess_extension(image), category="ingestion/batches"
+        )
         s3_storage.put_object(settings.s3_bucket, object_key, image_bytes, content_type)
 
         source_image = build_source_image(

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import hashlib
+import mimetypes
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Annotated, Any
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, File, UploadFile
+from pydantic import BaseModel
+
+from app.domain.ingestion import BatchState
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.ingestion.documents import build_source_image
+from app.infrastructure.ingestion.repository import (
+    add_source_image,
+    create_batch as create_batch_repo,
+    get_active_batch_for_user,
+    get_batch,
+    is_batch_expired,
+)
+from app.infrastructure.storage.mongo import Document
+from app.infrastructure.storage.s3 import S3StorageAdapter
+from app.presentation.deps import (
+    DatabaseDependency,
+    get_app_settings,
+    get_current_user,
+    get_s3_storage,
+)
+from app.presentation.errors import ApiError
+from app.presentation.helpers import parse_object_id
+from app.presentation.schemas import SourceImagePayload
+
+router = APIRouter(prefix="/ingestion-batches", tags=["bulk-ingestion"])
+
+CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
+StorageDependency = Annotated[S3StorageAdapter, Depends(get_s3_storage)]
+SettingsDependency = Annotated[Settings, Depends(get_app_settings)]
+
+
+class DetectionResponse(BaseModel):
+    model: str | None
+    rawProviderResponse: Any | None
+    failureCode: str | None
+    failureMessage: str | None
+
+
+class ImageResponse(BaseModel):
+    imageId: str
+    status: str
+    order: int
+    sourceImage: SourceImagePayload
+    subject: str | None
+    boxes: list[dict[str, Any]]
+    detection: DetectionResponse
+    committedAt: datetime | None
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class ItemResponse(BaseModel):
+    itemId: str
+    imageId: str
+    batchId: str
+    status: str
+    order: int
+    draft: dict[str, Any]
+    extraction: dict[str, Any]
+    retryCount: int
+    submit: dict[str, Any]
+    origin: dict[str, Any]
+    crop: dict[str, Any] | None
+    leaseUntil: datetime | None
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class BatchPayload(BaseModel):
+    id: str
+    userId: str
+    status: str
+    images: list[ImageResponse]
+    items: list[ItemResponse]
+    createdAt: datetime
+    updatedAt: datetime
+    expiresAt: datetime
+
+
+class BatchResponse(BaseModel):
+    batch: BatchPayload
+
+
+def _guess_extension(upload: UploadFile) -> str:
+    if upload.filename:
+        suffix = Path(upload.filename).suffix
+        if suffix:
+            return suffix
+    if upload.content_type:
+        guessed = mimetypes.guess_extension(upload.content_type)
+        if guessed:
+            return guessed
+    return ".bin"
+
+
+def _build_batch_image_key(user_id: str, extension: str) -> str:
+    suffix = extension.lstrip(".") or "bin"
+    return f"users/{user_id}/ingestion/batches/{uuid4()}.{suffix}"
+
+
+def _serialize_source_image(source_image: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "bucket": source_image["bucket"],
+        "objectKey": source_image["objectKey"],
+        "contentType": source_image.get("contentType"),
+        "sizeBytes": source_image.get("sizeBytes"),
+        "sha256": source_image.get("sha256"),
+        "uploadedAt": source_image.get("uploadedAt"),
+    }
+
+
+def _serialize_image(image: dict[str, Any]) -> dict[str, Any]:
+    detection = image.get("detection") or {}
+    return {
+        "imageId": image["imageId"],
+        "status": image["status"],
+        "order": image["order"],
+        "sourceImage": _serialize_source_image(image.get("sourceImage") or {}),
+        "subject": image.get("subject"),
+        "boxes": list(image.get("boxes", [])),
+        "detection": {
+            "model": detection.get("model"),
+            "rawProviderResponse": detection.get("rawProviderResponse"),
+            "failureCode": detection.get("failureCode"),
+            "failureMessage": detection.get("failureMessage"),
+        },
+        "committedAt": image.get("committedAt"),
+        "createdAt": image["createdAt"],
+        "updatedAt": image["updatedAt"],
+    }
+
+
+def _serialize_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "itemId": item["itemId"],
+        "imageId": item["imageId"],
+        "batchId": str(item["batchId"]),
+        "status": item["status"],
+        "order": item["order"],
+        "draft": dict(item.get("draft", {})),
+        "extraction": dict(item.get("extraction", {})),
+        "retryCount": item.get("retryCount", 0),
+        "submit": dict(item.get("submit", {})),
+        "origin": dict(item.get("origin", {})),
+        "crop": item.get("crop"),
+        "leaseUntil": item.get("leaseUntil"),
+        "createdAt": item["createdAt"],
+        "updatedAt": item["updatedAt"],
+    }
+
+
+def serialize_batch(batch: Document) -> dict[str, Any]:
+    return {
+        "batch": {
+            "id": str(batch["_id"]),
+            "userId": str(batch["userId"]),
+            "status": batch["status"],
+            "images": [_serialize_image(image) for image in batch.get("images", [])],
+            "items": [_serialize_item(item) for item in batch.get("items", [])],
+            "createdAt": batch["createdAt"],
+            "updatedAt": batch["updatedAt"],
+            "expiresAt": batch["expiresAt"],
+        }
+    }
+
+
+async def _load_owned_batch(
+    database: Any,
+    batch_id: str,
+    user_id: Any,
+) -> Document:
+    parse_object_id(batch_id, resource_name="Batch")
+    batch = await get_batch(database, batch_id, user_id)
+    if batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    if is_batch_expired(batch):
+        raise ApiError(409, "BATCH_EXPIRED", "Batch has expired")
+    if batch["status"] != BatchState.ACTIVE.value:
+        raise ApiError(409, "INVALID_BATCH_STATE", "Batch is not active")
+    return batch
+
+
+async def _validate_image_upload(
+    image: UploadFile,
+    max_image_bytes: int,
+) -> tuple[bytes, str]:
+    content_type = image.content_type or ""
+    if not content_type.startswith("image/"):
+        raise ApiError(400, "INVALID_IMAGE", "Uploaded file must be an image")
+
+    image_bytes = await image.read()
+    if not image_bytes:
+        raise ApiError(400, "INVALID_IMAGE", "Uploaded image is empty")
+    if len(image_bytes) > max_image_bytes:
+        raise ApiError(
+            400,
+            "IMAGE_TOO_LARGE",
+            f"Image exceeds maximum size of {max_image_bytes} bytes",
+        )
+    return image_bytes, content_type
+
+
+@router.post("", response_model=BatchResponse, status_code=201)
+async def create_batch(
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+    settings: SettingsDependency,
+) -> BatchResponse:
+    batch = await create_batch_repo(database, user["_id"], settings)
+    return BatchResponse(**serialize_batch(batch))
+
+
+@router.get("/active", response_model=BatchResponse)
+async def get_active_batch(
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    batch = await get_active_batch_for_user(database, user["_id"])
+    if batch is None:
+        raise ApiError(404, "NOT_FOUND", "No active batch found")
+    return BatchResponse(**serialize_batch(batch))
+
+
+@router.post("/{batch_id}/images", response_model=BatchResponse, status_code=201)
+async def upload_batch_images(
+    batch_id: str,
+    images: Annotated[list[UploadFile], File(...)],
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+    settings: SettingsDependency,
+    s3_storage: StorageDependency,
+) -> BatchResponse:
+    batch = await _load_owned_batch(database, batch_id, user["_id"])
+
+    if not images:
+        raise ApiError(400, "INVALID_IMAGE", "No images provided")
+
+    existing_count = len(batch.get("images", []))
+    if existing_count + len(images) > settings.bulk_ingestion_max_images:
+        raise ApiError(
+            409,
+            "BATCH_IMAGE_LIMIT_EXCEEDED",
+            f"Batch cannot exceed {settings.bulk_ingestion_max_images} images",
+        )
+
+    now = datetime.now(UTC)
+    for offset, image in enumerate(images):
+        image_bytes, content_type = await _validate_image_upload(
+            image, settings.bulk_ingestion_max_image_bytes
+        )
+        object_key = _build_batch_image_key(str(user["_id"]), _guess_extension(image))
+        s3_storage.put_object(settings.s3_bucket, object_key, image_bytes, content_type)
+
+        source_image = build_source_image(
+            bucket=settings.s3_bucket,
+            object_key=object_key,
+            content_type=content_type,
+            size_bytes=len(image_bytes),
+            sha256=hashlib.sha256(image_bytes).hexdigest(),
+            uploaded_at=now,
+        )
+        await add_source_image(
+            database,
+            batch_id,
+            user["_id"],
+            source_image,
+            order=existing_count + offset,
+            now=now,
+        )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch))

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -383,6 +383,18 @@ def matches_query(document: dict[str, Any], query: dict[str, Any]) -> bool:
                                 break
                     if not matched:
                         return False
+                elif op == "$gt":
+                    if not any(c is not None and c > op_val for c in candidates):
+                        return False
+                elif op == "$gte":
+                    if not any(c is not None and c >= op_val for c in candidates):
+                        return False
+                elif op == "$lt":
+                    if not any(c is not None and c < op_val for c in candidates):
+                        return False
+                elif op == "$lte":
+                    if not any(c is not None and c <= op_val for c in candidates):
+                        return False
                 else:
                     return False
         else:

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import base64
+import io
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.storage.s3 import StorageObjectNotFoundError
+from app.main import create_app
+from app.presentation.deps import get_app_settings, get_database, get_s3_storage
+from tests.api.conftest import FakeDatabase
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self.objects: dict[tuple[str, str], bytes] = {}
+        self.put_calls: list[tuple[str, str, str | None, bytes]] = []
+        self.get_calls: list[tuple[str, str]] = []
+        self._counter = 0
+
+    def build_object_key(self, user_id: str, extension: str) -> str:
+        self._counter += 1
+        return f"users/{user_id}/ingestion/preview-{self._counter}{extension}"
+
+    def put_object(self, bucket: str, object_key: str, payload: bytes, content_type: str | None) -> None:
+        self.objects[(bucket, object_key)] = payload
+        self.put_calls.append((bucket, object_key, content_type, payload))
+
+    def get_object(self, bucket: str, object_key: str) -> bytes:
+        self.get_calls.append((bucket, object_key))
+        payload = self.objects.get((bucket, object_key))
+        if payload is None:
+            raise StorageObjectNotFoundError(object_key)
+        return payload
+
+    def seed(self, bucket: str, object_key: str, payload: bytes) -> None:
+        self.objects[(bucket, object_key)] = payload
+
+
+def make_png_bytes() -> bytes:
+    payload = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9iAAAAAASUVORK5CYII="
+    )
+    return io.BytesIO(payload).getvalue()
+
+
+def make_oversize_png_bytes(size: int) -> bytes:
+    return b"\x89PNG\r\n\x1a\n" + b"\x00" * size
+
+
+async def register_and_login(
+    client: AsyncClient,
+    app: FastAPI,
+    *,
+    username: str,
+    password: str = "secret",
+) -> dict[str, Any]:
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={"username": username, "password": password},
+    )
+    assert register_response.status_code == 201
+
+    login_response = await client.post(
+        "/api/v1/auth/login",
+        json={"username": username, "password": password},
+    )
+    assert login_response.status_code == 200
+
+    database: FakeDatabase = app.state.fake_database
+    user = await database["users"].find_one({"username": username})
+    assert user is not None
+    return user
+
+
+@pytest_asyncio.fixture
+async def bulk_app() -> AsyncIterator[FastAPI]:
+    application = create_app()
+    database = FakeDatabase()
+    storage = FakeStorage()
+    settings = Settings(
+        helper_vlm_model="gpt-4.1-mini",
+        helper_vlm_timeout_seconds=1.0,
+        math_ingestion_vlm_model="math-model",
+        math_ingestion_vlm_timeout_seconds=1.0,
+        english_ingestion_vlm_model="english-model",
+        english_ingestion_vlm_timeout_seconds=1.0,
+        bulk_ingestion_max_images=3,
+        bulk_ingestion_max_image_bytes=200,
+        bulk_ingestion_batch_ttl_seconds=3600,
+    )
+
+    application.state.fake_database = database
+    application.state.fake_storage = storage
+
+    application.dependency_overrides[get_database] = lambda: database
+    application.dependency_overrides[get_app_settings] = lambda: settings
+    application.dependency_overrides[get_s3_storage] = lambda: storage
+
+    yield application
+
+
+@pytest_asyncio.fixture
+async def bulk_client(bulk_app: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=bulk_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def authenticated_bulk_client(
+    bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> AsyncIterator[AsyncClient]:
+    await register_and_login(bulk_client, bulk_app, username="student1")
+    yield bulk_client
+
+
+@pytest.mark.asyncio
+async def test_create_batch_for_authenticated_user(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+
+    assert response.status_code == 201
+    body = response.json()["batch"]
+    assert body["status"] == "active"
+    assert "id" in body
+    assert "expiresAt" in body
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    stored = await database["ingestion_batches"].find_one({"_id": ObjectId(body["id"])})
+    assert stored is not None
+    assert stored["status"] == "active"
+
+
+@pytest.mark.asyncio
+async def test_get_active_batch_returns_existing_unexpired_batch(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.get("/api/v1/ingestion-batches/active")
+
+    assert response.status_code == 200
+    assert response.json()["batch"]["id"] == batch_id
+
+
+@pytest.mark.asyncio
+async def test_get_active_batch_returns_404_when_no_batch_exists(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    response = await authenticated_bulk_client.get("/api/v1/ingestion-batches/active")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_upload_valid_images_returns_batch_with_image_metadata(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    image_bytes = make_png_bytes()
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files=[
+            ("images", ("first.png", image_bytes, "image/png")),
+            ("images", ("second.png", image_bytes, "image/png")),
+        ],
+    )
+
+    assert response.status_code == 201
+    batch = response.json()["batch"]
+    assert len(batch["images"]) == 2
+    assert batch["images"][0]["order"] == 0
+    assert batch["images"][1]["order"] == 1
+    assert batch["images"][0]["sourceImage"]["contentType"] == "image/png"
+    assert batch["images"][0]["sourceImage"]["sizeBytes"] == len(image_bytes)
+    assert batch["images"][0]["status"] == "uploaded"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 2
+    assert storage.put_calls[0][3] == image_bytes
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_empty_image(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("empty.png", b"", "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_IMAGE"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_non_image_file(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("notes.txt", b"not-an-image", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_IMAGE"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_oversize_image(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("huge.png", make_oversize_png_bytes(500), "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "IMAGE_TOO_LARGE"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_exceeding_max_images(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+    image_bytes = make_png_bytes()
+
+    first_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files=[
+            ("images", ("a.png", image_bytes, "image/png")),
+            ("images", ("b.png", image_bytes, "image/png")),
+        ],
+    )
+    assert first_response.status_code == 201
+
+    second_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files=[
+            ("images", ("c.png", image_bytes, "image/png")),
+            ("images", ("d.png", image_bytes, "image/png")),
+        ],
+    )
+
+    assert second_response.status_code == 409
+    assert second_response.json()["error"]["code"] == "BATCH_IMAGE_LIMIT_EXCEEDED"
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_expired_batch(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    await database["ingestion_batches"].update_one(
+        {"_id": ObjectId(batch_id)},
+        {"$set": {"expiresAt": datetime.now(UTC) - timedelta(seconds=1)}},
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("test.png", make_png_bytes(), "image/png")},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "BATCH_EXPIRED"
+
+
+@pytest.mark.asyncio
+async def test_upload_enforces_ownership(
+    bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    owner = await register_and_login(bulk_client, bulk_app, username="owner")
+    create_response = await bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    await register_and_login(bulk_client, bulk_app, username="other")
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("test.png", make_png_bytes(), "image/png")},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    stored = await database["ingestion_batches"].find_one({"_id": ObjectId(batch_id)})
+    assert stored is not None
+    assert stored["userId"] == owner["_id"]
+
+
+@pytest.mark.asyncio
+async def test_get_active_batch_enforces_ownership(
+    bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    await register_and_login(bulk_client, bulk_app, username="owner")
+    await bulk_client.post("/api/v1/ingestion-batches")
+
+    await register_and_login(bulk_client, bulk_app, username="other")
+    response = await bulk_client.get("/api/v1/ingestion-batches/active")
+
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_batch_routes_require_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.post("/api/v1/ingestion-batches")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "UNAUTHENTICATED"
+
+    response = await bulk_client.get("/api/v1/ingestion-batches/active")
+    assert response.status_code == 401
+
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{ObjectId()}/images",
+        files={"images": ("test.png", make_png_bytes(), "image/png")},
+    )
+    assert response.status_code == 401

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -26,9 +26,11 @@ class FakeStorage:
         self.get_calls: list[tuple[str, str]] = []
         self._counter = 0
 
-    def build_object_key(self, user_id: str, extension: str) -> str:
+    def build_object_key(
+        self, user_id: str, extension: str, *, category: str = "images"
+    ) -> str:
         self._counter += 1
-        return f"users/{user_id}/ingestion/preview-{self._counter}{extension}"
+        return f"users/{user_id}/{category}/preview-{self._counter}{extension}"
 
     def put_object(self, bucket: str, object_key: str, payload: bytes, content_type: str | None) -> None:
         self.objects[(bucket, object_key)] = payload


### PR DESCRIPTION
## Summary

Implements the authenticated backend APIs for creating/resuming a bulk ingestion batch and uploading validated images into it. No VLM work is triggered by these endpoints.

## Linked Issue

Closes #362

## Issue Alignment

This PR implements the issue by:

- Adding `POST /api/v1/ingestion-batches` to create a new temporary batch for the current user.
- Adding `GET /api/v1/ingestion-batches/active` to resume the user's unexpired active batch.
- Adding `POST /api/v1/ingestion-batches/{batch_id}/images` to upload one or more images into a batch.
- Enforcing file type (`image/*`), non-empty image, per-image size limit, batch image count limit, batch expiry, and active-only state before any upload is accepted.
- Storing accepted source images as temporary S3 batch media and persisting their metadata through the existing batch repository.
- Returning batch/image metadata needed by the frontend, wrapped as `{ batch: ... }` to match existing API conventions.
- Enforcing ownership: cross-user batch access returns `404 Not Found`.

Scope covered:

- Batch creation and resume endpoints.
- Multi-image upload endpoint.
- Upload validation (type, empty, size, count, expiry, state).
- Temporary media storage and batch metadata persistence.
- Ownership and authentication enforcement.
- Required API tests.

Out of scope / intentionally not included:

- VLM detection (handled by #363).
- Box editing (handled by #363).
- Extraction (handled by #364).
- Submit (handled by #366).
- Frontend UI (handled by #367–#371).

## Implementation Notes

- New presentation module `app/presentation/bulk_ingestion.py` with router prefix `/ingestion-batches`.
- Reuses `app.infrastructure.ingestion.repository` and `app.infrastructure.ingestion.documents` from #360.
- Uses `S3StorageAdapter.put_object` directly with per-user batch object keys (`users/{user_id}/ingestion/batches/{uuid}.{ext}`).
- Validation rejects bad uploads before any S3 write or repository update, so no VLM call is made for invalid input.
- Extended the `tests/api/conftest.py` fake query matcher with `$gt`, `$gte`, `$lt`, and `$lte` so the active-batch lookup (`expiresAt: { $gt: now }`) works in API tests.

## Tests

Commands run:

- `cd backend && uv run --extra dev pytest tests/api tests/integration` — **239 passed**
- `cd backend && uv run --extra dev pytest tests/infrastructure tests/domain` — **316 passed**

Automated tests added or updated:

- `backend/tests/api/test_bulk_ingestion.py` — covers creating a batch, resuming an active batch, uploading valid images, rejecting empty/non-image/oversize/over-limit uploads, rejecting expired batches, and enforcing ownership and authentication.

Manual verification:

- Confirmed that invalid uploads return an error before any S3 storage or repository update occurs (verified via fake storage `put_calls` and database state assertions).

## Deviations From Issue Plan

None.

## Follow-Up Work

- Detection/box-review APIs (#363) will build on these endpoints.
