### PR TITLE
Implement detection, box editing, and image commit APIs

### DIFF
--- a/backend/app/domain/ingestion/__init__.py
+++ b/backend/app/domain/ingestion/__init__.py
@@ -1,5 +1,6 @@
 """Ingestion domain namespace."""
 
+from .boxes import InvalidBoxError, validate_boxes
 from .state import (
     BatchState,
     ImageState,
@@ -34,4 +35,6 @@ __all__ = [
     "is_batch_terminal",
     "is_image_terminal",
     "is_item_terminal",
+    "InvalidBoxError",
+    "validate_boxes",
 ]

--- a/backend/app/domain/ingestion/boxes.py
+++ b/backend/app/domain/ingestion/boxes.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class InvalidBoxError(ValueError):
+    pass
+
+
+def validate_boxes(
+    boxes: list[dict[str, Any]],
+    image_width: int | None,
+    image_height: int | None,
+) -> list[dict[str, Any]]:
+    """Validate and normalize box payloads.
+
+    Boxes must have positive width/height. If image dimensions are provided,
+    every box must fit inside the image bounds.
+    """
+    validated: list[dict[str, Any]] = []
+    for index, box in enumerate(boxes):
+        try:
+            x = float(box["x"])
+            y = float(box["y"])
+            width = float(box["width"])
+            height = float(box["height"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise InvalidBoxError(f"Box {index} is missing numeric coordinates") from exc
+
+        if width <= 0 or height <= 0:
+            raise InvalidBoxError(f"Box {index} must have positive width and height")
+
+        if image_width is not None and image_height is not None:
+            if x < 0 or y < 0 or x + width > image_width or y + height > image_height:
+                raise InvalidBoxError(f"Box {index} exceeds image bounds")
+
+        validated.append({"x": x, "y": y, "width": width, "height": height})
+    return validated

--- a/backend/app/infrastructure/ingestion/documents.py
+++ b/backend/app/infrastructure/ingestion/documents.py
@@ -25,6 +25,8 @@ def build_source_image(
     size_bytes: int,
     sha256: str,
     uploaded_at: datetime,
+    width: int | None = None,
+    height: int | None = None,
 ) -> dict[str, Any]:
     return {
         "bucket": bucket,
@@ -33,6 +35,8 @@ def build_source_image(
         "sizeBytes": size_bytes,
         "sha256": sha256,
         "uploadedAt": uploaded_at,
+        "width": width,
+        "height": height,
     }
 
 

--- a/backend/app/infrastructure/ingestion/image_size.py
+++ b/backend/app/infrastructure/ingestion/image_size.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+def get_image_size(image_bytes: bytes) -> tuple[int, int] | None:
+    """Return (width, height) for PNG or JPEG bytes without external deps."""
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n") and len(image_bytes) >= 24:
+        width = int.from_bytes(image_bytes[16:20], "big")
+        height = int.from_bytes(image_bytes[20:24], "big")
+        return width, height
+
+    if image_bytes.startswith(b"\xff\xd8"):
+        offset = 2
+        while offset + 4 < len(image_bytes):
+            if image_bytes[offset] != 0xFF:
+                return None
+            marker = image_bytes[offset + 1]
+            if marker in (0xD9, 0x00):
+                offset += 2
+                continue
+            if marker in (0xD8,):
+                offset += 2
+                continue
+            length = int.from_bytes(image_bytes[offset + 2 : offset + 4], "big")
+            if marker in (
+                0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+                0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF,
+            ):
+                if offset + 9 < len(image_bytes):
+                    height = int.from_bytes(image_bytes[offset + 5 : offset + 7], "big")
+                    width = int.from_bytes(image_bytes[offset + 7 : offset + 9], "big")
+                    return width, height
+                return None
+            offset += 2 + length
+
+    return None

--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -6,7 +6,7 @@ from typing import Any
 from bson import ObjectId
 from pymongo import ASCENDING
 
-from app.domain.ingestion import BatchState, ImageState
+from app.domain.ingestion import BatchState, ImageState, ItemState
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import Document
 
@@ -180,6 +180,233 @@ async def add_items_for_image(
     await _collection(database).update_one(
         {"_id": _object_id(batch_id), "userId": user_id},
         {"$set": {"images": images, "items": items, "updatedAt": current}},
+    )
+    return new_items
+
+
+async def start_image_detection(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    *,
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    for image in images:
+        if image.get("imageId") == image_id:
+            image["status"] = ImageState.DETECTING.value
+            image["updatedAt"] = now
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "updatedAt": now}},
+    )
+
+
+async def save_image_detection_success(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    *,
+    subject: str,
+    boxes: list[dict[str, Any]],
+    model: str,
+    raw_provider_response: dict[str, Any] | None,
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    for image in images:
+        if image.get("imageId") == image_id:
+            image["status"] = ImageState.READY.value
+            image["subject"] = subject
+            image["boxes"] = list(boxes)
+            image["detection"] = {
+                "model": model,
+                "rawProviderResponse": raw_provider_response,
+                "failureCode": None,
+                "failureMessage": None,
+            }
+            image["updatedAt"] = now
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "updatedAt": now}},
+    )
+
+
+async def save_image_detection_failure(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    *,
+    failure_code: str,
+    failure_message: str,
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    for image in images:
+        if image.get("imageId") == image_id:
+            image["status"] = ImageState.DETECT_FAILED.value
+            image["detection"] = {
+                "model": None,
+                "rawProviderResponse": None,
+                "failureCode": failure_code,
+                "failureMessage": failure_message,
+            }
+            image["updatedAt"] = now
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "updatedAt": now}},
+    )
+
+
+async def save_image_boxes_and_subject(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    *,
+    subject: str | None,
+    boxes: list[dict[str, Any]],
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    for image in images:
+        if image.get("imageId") == image_id:
+            image["status"] = ImageState.READY.value
+            if subject is not None:
+                image["subject"] = subject
+            image["boxes"] = list(boxes)
+            image["updatedAt"] = now
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "updatedAt": now}},
+    )
+
+
+async def delete_batch_image(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    *,
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    for image in images:
+        if image.get("imageId") == image_id:
+            image["status"] = ImageState.DELETED.value
+            image["updatedAt"] = now
+            break
+
+    items = list(batch.get("items", []))
+    for item in items:
+        if item.get("imageId") == image_id:
+            item["status"] = ItemState.DELETED.value
+            item["updatedAt"] = now
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "items": items, "updatedAt": now}},
+    )
+
+
+async def commit_image_boxes(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    image_id: str,
+    *,
+    now: datetime,
+) -> list[dict[str, Any]]:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    images = list(batch.get("images", []))
+    target_image = None
+    for image in images:
+        if image.get("imageId") == image_id:
+            target_image = image
+            break
+    if target_image is None:
+        raise ValueError("Image not found")
+
+    if target_image["status"] == ImageState.COMMITTED.value:
+        return [
+            item for item in batch.get("items", [])
+            if item.get("imageId") == image_id and item.get("status") != ItemState.DELETED.value
+        ]
+
+    existing_items = [
+        item for item in batch.get("items", [])
+        if item.get("status") != ItemState.DELETED.value
+    ]
+    next_order = max((item["order"] for item in existing_items), default=-1) + 1
+
+    new_items: list[dict[str, Any]] = []
+    for offset, _box in enumerate(target_image.get("boxes", [])):
+        item_id = new_item_id()
+        item_document = build_item_document(
+            item_id=item_id,
+            batch_id=batch["_id"],
+            image_id=image_id,
+            order=next_order + offset,
+            now=now,
+        )
+        new_items.append(item_document)
+
+    items = list(batch.get("items", []))
+    items.extend(new_items)
+
+    target_image["status"] = ImageState.COMMITTED.value
+    target_image["committedAt"] = now
+    target_image["updatedAt"] = now
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"images": images, "items": items, "updatedAt": now}},
     )
     return new_items
 

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import mimetypes
 from datetime import UTC, datetime
 from pathlib import Path
@@ -10,6 +11,8 @@ from fastapi import APIRouter, Depends, File, UploadFile
 from pydantic import BaseModel
 
 import base64
+
+logger = logging.getLogger(__name__)
 
 from app.domain.ingestion import (
     BatchState,
@@ -352,6 +355,7 @@ async def detect_image_boxes(
             source_image["bucket"], source_image["objectKey"]
         )
     except Exception as exc:
+        logger.exception("Unexpected storage read failure during detection")
         await save_image_detection_failure(
             database,
             batch_id,
@@ -392,6 +396,7 @@ async def detect_image_boxes(
             now=datetime.now(UTC),
         )
     except Exception as exc:
+        logger.exception("Unexpected error during box detection")
         await save_image_detection_failure(
             database,
             batch_id,

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -9,20 +9,38 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, File, UploadFile
 from pydantic import BaseModel
 
-from app.domain.ingestion import BatchState
+import base64
+
+from app.domain.ingestion import (
+    BatchState,
+    ImageState,
+    InvalidBoxError,
+    ItemState,
+    transition_image_state,
+    validate_boxes,
+)
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.ingestion.documents import build_source_image
+from app.infrastructure.ingestion.image_size import get_image_size
 from app.infrastructure.ingestion.repository import (
     add_source_image,
+    commit_image_boxes,
     create_batch as create_batch_repo,
+    delete_batch_image,
     get_active_batch_for_user,
     get_batch,
     is_batch_expired,
+    save_image_boxes_and_subject,
+    save_image_detection_failure,
+    save_image_detection_success,
+    start_image_detection,
 )
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import S3StorageAdapter
+from app.infrastructure.vlm.base_client import BaseVLMError
 from app.presentation.deps import (
     DatabaseDependency,
+    HelperVLMDependency,
     get_app_settings,
     get_current_user,
     get_s3_storage,
@@ -109,6 +127,8 @@ def _serialize_source_image(source_image: dict[str, Any]) -> dict[str, Any]:
         "contentType": source_image.get("contentType"),
         "sizeBytes": source_image.get("sizeBytes"),
         "sha256": source_image.get("sha256"),
+        "width": source_image.get("width"),
+        "height": source_image.get("height"),
         "uploadedAt": source_image.get("uploadedAt"),
     }
 
@@ -154,18 +174,38 @@ def _serialize_item(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def serialize_batch(batch: Document) -> dict[str, Any]:
+    images = [
+        image for image in batch.get("images", [])
+        if image.get("status") != ImageState.DELETED.value
+    ]
+    items = [
+        item for item in batch.get("items", [])
+        if item.get("status") != ItemState.DELETED.value
+    ]
     return {
         "batch": {
             "id": str(batch["_id"]),
             "userId": str(batch["userId"]),
             "status": batch["status"],
-            "images": [_serialize_image(image) for image in batch.get("images", [])],
-            "items": [_serialize_item(item) for item in batch.get("items", [])],
+            "images": [_serialize_image(image) for image in images],
+            "items": [_serialize_item(item) for item in items],
             "createdAt": batch["createdAt"],
             "updatedAt": batch["updatedAt"],
             "expiresAt": batch["expiresAt"],
         }
     }
+
+
+def _find_image_or_404(batch: Document, image_id: str) -> dict[str, Any]:
+    for image in batch.get("images", []):
+        if image.get("imageId") == image_id:
+            return image
+    raise ApiError(404, "NOT_FOUND", "Image not found")
+
+
+class SaveBoxesRequest(BaseModel):
+    subject: str | None = None
+    boxes: list[dict[str, Any]]
 
 
 async def _load_owned_batch(
@@ -257,6 +297,7 @@ async def upload_batch_images(
         )
         s3_storage.put_object(settings.s3_bucket, object_key, image_bytes, content_type)
 
+        width, height = get_image_size(image_bytes) or (None, None)
         source_image = build_source_image(
             bucket=settings.s3_bucket,
             object_key=object_key,
@@ -264,6 +305,8 @@ async def upload_batch_images(
             size_bytes=len(image_bytes),
             sha256=hashlib.sha256(image_bytes).hexdigest(),
             uploaded_at=now,
+            width=width,
+            height=height,
         )
         await add_source_image(
             database,
@@ -273,6 +316,187 @@ async def upload_batch_images(
             order=existing_count + offset,
             now=now,
         )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch))
+
+
+@router.post("/{batch_id}/images/{image_id}/detect", response_model=BatchResponse)
+async def detect_image_boxes(
+    batch_id: str,
+    image_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+    s3_storage: StorageDependency,
+    vlm: HelperVLMDependency,
+) -> BatchResponse:
+    batch = await _load_owned_batch(database, batch_id, user["_id"])
+    image = _find_image_or_404(batch, image_id)
+
+    current_state = ImageState(image["status"])
+    try:
+        transition_image_state(current_state, ImageState.DETECTING)
+    except Exception as exc:
+        raise ApiError(
+            409, "INVALID_IMAGE_STATE", f"Image cannot be detected: {exc}"
+        ) from exc
+    await start_image_detection(
+        database, batch_id, user["_id"], image_id, now=datetime.now(UTC)
+    )
+
+    source_image = image.get("sourceImage") or {}
+    try:
+        image_bytes = s3_storage.get_object(
+            source_image["bucket"], source_image["objectKey"]
+        )
+    except Exception as exc:
+        await save_image_detection_failure(
+            database,
+            batch_id,
+            user["_id"],
+            image_id,
+            failure_code="storage-read-failed",
+            failure_message=str(exc),
+            now=datetime.now(UTC),
+        )
+        updated_batch = await get_batch(database, batch_id, user["_id"])
+        if updated_batch is None:
+            raise ApiError(404, "NOT_FOUND", "Batch not found")
+        return BatchResponse(**serialize_batch(updated_batch))
+
+    try:
+        result = await vlm.detect_problem_boxes(
+            image_base64=base64.b64encode(image_bytes).decode()
+        )
+        await save_image_detection_success(
+            database,
+            batch_id,
+            user["_id"],
+            image_id,
+            subject=result.subject,
+            boxes=[box.model_dump() for box in result.boxes],
+            model=result.model,
+            raw_provider_response=result.raw_provider_response,
+            now=datetime.now(UTC),
+        )
+    except BaseVLMError as exc:
+        await save_image_detection_failure(
+            database,
+            batch_id,
+            user["_id"],
+            image_id,
+            failure_code=exc.code,
+            failure_message=exc.args[0],
+            now=datetime.now(UTC),
+        )
+    except Exception as exc:
+        await save_image_detection_failure(
+            database,
+            batch_id,
+            user["_id"],
+            image_id,
+            failure_code="detection-failed",
+            failure_message=str(exc),
+            now=datetime.now(UTC),
+        )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch))
+
+
+@router.patch("/{batch_id}/images/{image_id}", response_model=BatchResponse)
+async def save_image_boxes(
+    batch_id: str,
+    image_id: str,
+    request: SaveBoxesRequest,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    batch = await _load_owned_batch(database, batch_id, user["_id"])
+    image = _find_image_or_404(batch, image_id)
+
+    if image["status"] == ImageState.COMMITTED.value:
+        raise ApiError(409, "IMAGE_ALREADY_COMMITTED", "Image has already been committed")
+    if image["status"] == ImageState.DELETED.value:
+        raise ApiError(409, "IMAGE_DELETED", "Image has been deleted")
+
+    source_image = image.get("sourceImage") or {}
+    try:
+        validated_boxes = validate_boxes(
+            request.boxes,
+            source_image.get("width"),
+            source_image.get("height"),
+        )
+    except InvalidBoxError as exc:
+        raise ApiError(400, "INVALID_BOXES", str(exc)) from exc
+
+    await save_image_boxes_and_subject(
+        database,
+        batch_id,
+        user["_id"],
+        image_id,
+        subject=request.subject,
+        boxes=validated_boxes,
+        now=datetime.now(UTC),
+    )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch))
+
+
+@router.delete("/{batch_id}/images/{image_id}", response_model=BatchResponse)
+async def delete_image(
+    batch_id: str,
+    image_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    await _load_owned_batch(database, batch_id, user["_id"])
+    await delete_batch_image(
+        database,
+        batch_id,
+        user["_id"],
+        image_id,
+        now=datetime.now(UTC),
+    )
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch))
+
+
+@router.post("/{batch_id}/images/{image_id}/commit", response_model=BatchResponse)
+async def commit_image(
+    batch_id: str,
+    image_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    batch = await _load_owned_batch(database, batch_id, user["_id"])
+    image = _find_image_or_404(batch, image_id)
+
+    if image["status"] == ImageState.COMMITTED.value:
+        return BatchResponse(**serialize_batch(batch))
+    if image["status"] != ImageState.READY.value:
+        raise ApiError(
+            409,
+            "IMAGE_NOT_READY",
+            "Image must be ready before committing",
+        )
+
+    await commit_image_boxes(
+        database,
+        batch_id,
+        user["_id"],
+        image_id,
+        now=datetime.now(UTC),
+    )
 
     updated_batch = await get_batch(database, batch_id, user["_id"])
     if updated_batch is None:

--- a/backend/app/presentation/deps.py
+++ b/backend/app/presentation/deps.py
@@ -181,4 +181,5 @@ async def get_grading_vlm_client(
 
 
 StorageDependency = Annotated[S3StorageAdapter, Depends(get_s3_storage)]
+HelperVLMDependency = Annotated[VLMClient, Depends(create_helper_vlm_client)]
 GradingVLMDependency = Annotated[VLMClient, Depends(get_grading_vlm_client)]

--- a/backend/app/presentation/schemas.py
+++ b/backend/app/presentation/schemas.py
@@ -18,4 +18,6 @@ class SourceImagePayload(BaseModel):
     contentType: str | None = None
     sizeBytes: int | None = None
     sha256: str | None = None
+    width: int | None = None
+    height: int | None = None
     uploadedAt: datetime | None = None

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -14,8 +14,14 @@ from httpx import ASGITransport, AsyncClient
 
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
+from app.infrastructure.vlm.client import DetectionResult, ProblemBox
 from app.main import create_app
-from app.presentation.deps import get_app_settings, get_database, get_s3_storage
+from app.presentation.deps import (
+    create_helper_vlm_client,
+    get_app_settings,
+    get_database,
+    get_s3_storage,
+)
 from tests.api.conftest import FakeDatabase
 
 
@@ -47,6 +53,29 @@ class FakeStorage:
         self.objects[(bucket, object_key)] = payload
 
 
+class FakeHelperVLMClient:
+    def __init__(self, model: str = "fake-helper-vlm") -> None:
+        self._model = model
+        self.responses: list[Any] = []
+        self.calls: list[dict[str, Any]] = []
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def detect_problem_boxes(
+        self,
+        *,
+        image_url: str | None = None,
+        image_base64: str | None = None,
+    ) -> DetectionResult:
+        self.calls.append({"image_url": image_url, "image_base64": image_base64})
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
 def make_png_bytes() -> bytes:
     payload = base64.b64decode(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9iAAAAAASUVORK5CYII="
@@ -56,6 +85,28 @@ def make_png_bytes() -> bytes:
 
 def make_oversize_png_bytes(size: int) -> bytes:
     return b"\x89PNG\r\n\x1a\n" + b"\x00" * size
+
+
+def make_detection_result(
+    *,
+    subject: str = "math",
+    boxes: list[ProblemBox] | None = None,
+    model: str = "fake-helper-vlm",
+) -> DetectionResult:
+    boxes = boxes or []
+    raw = {
+        "subject": subject,
+        "boxes": [box.model_dump() for box in boxes],
+        "providerMetadata": {"provider": "fake"},
+    }
+    return DetectionResult(
+        request_type="problem-box-detection",
+        model=model,
+        subject=subject,
+        boxes=boxes,
+        provider_metadata=raw["providerMetadata"],
+        raw_provider_response=raw,
+    )
 
 
 async def register_and_login(
@@ -83,6 +134,24 @@ async def register_and_login(
     return user
 
 
+async def create_batch_with_image(
+    client: AsyncClient,
+    image_bytes: bytes | None = None,
+) -> tuple[str, str]:
+    create_response = await client.post("/api/v1/ingestion-batches")
+    assert create_response.status_code == 201
+    batch_id = create_response.json()["batch"]["id"]
+
+    image_bytes = image_bytes or make_png_bytes()
+    upload_response = await client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("test.png", image_bytes, "image/png")},
+    )
+    assert upload_response.status_code == 201
+    image_id = upload_response.json()["batch"]["images"][0]["imageId"]
+    return batch_id, image_id
+
+
 @pytest_asyncio.fixture
 async def bulk_app() -> AsyncIterator[FastAPI]:
     application = create_app()
@@ -100,12 +169,16 @@ async def bulk_app() -> AsyncIterator[FastAPI]:
         bulk_ingestion_batch_ttl_seconds=3600,
     )
 
+    helper_vlm = FakeHelperVLMClient(model=settings.helper_vlm_model)
+
     application.state.fake_database = database
     application.state.fake_storage = storage
+    application.state.fake_helper_vlm = helper_vlm
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_app_settings] = lambda: settings
     application.dependency_overrides[get_s3_storage] = lambda: storage
+    application.dependency_overrides[create_helper_vlm_client] = lambda: helper_vlm
 
     yield application
 
@@ -124,6 +197,11 @@ async def authenticated_bulk_client(
 ) -> AsyncIterator[AsyncClient]:
     await register_and_login(bulk_client, bulk_app, username="student1")
     yield bulk_client
+
+
+@pytest_asyncio.fixture
+async def helper_vlm(bulk_app: FastAPI) -> FakeHelperVLMClient:
+    return bulk_app.state.fake_helper_vlm
 
 
 @pytest.mark.asyncio
@@ -366,5 +444,391 @@ async def test_batch_routes_require_authentication(
     response = await bulk_client.post(
         f"/api/v1/ingestion-batches/{ObjectId()}/images",
         files={"images": ("test.png", make_png_bytes(), "image/png")},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_detect_success_creates_boxes_and_subject(
+    authenticated_bulk_client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[
+                ProblemBox(x=0, y=0, width=1, height=1),
+            ],
+        )
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+
+    assert response.status_code == 200
+    batch = response.json()["batch"]
+    assert len(batch["images"]) == 1
+    image = batch["images"][0]
+    assert image["imageId"] == image_id
+    assert image["status"] == "ready"
+    assert image["subject"] == "math"
+    assert len(image["boxes"]) == 1
+    assert image["boxes"][0] == {"x": 0.0, "y": 0.0, "width": 1.0, "height": 1.0}
+    assert image["detection"]["model"] == "fake-helper-vlm"
+    assert image["sourceImage"]["width"] == 1
+    assert image["sourceImage"]["height"] == 1
+
+
+@pytest.mark.asyncio
+async def test_detect_failure_and_retry_preserves_other_images(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    image_bytes = make_png_bytes()
+    upload_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files=[
+            ("images", ("first.png", image_bytes, "image/png")),
+            ("images", ("second.png", image_bytes, "image/png")),
+        ],
+    )
+    assert upload_response.status_code == 201
+    first_image_id = upload_response.json()["batch"]["images"][0]["imageId"]
+    second_image_id = upload_response.json()["batch"]["images"][1]["imageId"]
+
+    helper_vlm.responses.append(Exception("detection failed"))
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="english",
+            boxes=[ProblemBox(x=0, y=0, width=1, height=1)],
+        )
+    )
+
+    first_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{first_image_id}/detect"
+    )
+    assert first_response.status_code == 200
+    assert first_response.json()["batch"]["images"][0]["status"] == "detect-failed"
+
+    second_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{second_image_id}/detect"
+    )
+    assert second_response.status_code == 200
+    assert second_response.json()["batch"]["images"][1]["status"] == "ready"
+    assert second_response.json()["batch"]["images"][1]["subject"] == "english"
+
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[
+                ProblemBox(x=0, y=0, width=1, height=1),
+                ProblemBox(x=0, y=0, width=1, height=1),
+            ],
+        )
+    )
+    retry_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{first_image_id}/detect"
+    )
+    assert retry_response.status_code == 200
+    batch = retry_response.json()["batch"]
+    assert batch["images"][0]["status"] == "ready"
+    assert batch["images"][0]["subject"] == "math"
+    assert len(batch["images"][0]["boxes"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_manual_box_entry_after_detection_failure(
+    authenticated_bulk_client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    helper_vlm.responses.append(Exception("detection failed"))
+
+    detect_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+    assert detect_response.status_code == 200
+    assert detect_response.json()["batch"]["images"][0]["status"] == "detect-failed"
+
+    save_response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={
+            "subject": "math",
+            "boxes": [{"x": 0, "y": 0, "width": 1, "height": 1}],
+        },
+    )
+    assert save_response.status_code == 200
+    image = save_response.json()["batch"]["images"][0]
+    assert image["status"] == "ready"
+    assert image["subject"] == "math"
+    assert len(image["boxes"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_save_boxes_persists_edits(
+    authenticated_bulk_client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[
+                ProblemBox(x=0, y=0, width=1, height=1),
+            ],
+        )
+    )
+    await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+
+    save_response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={
+            "subject": "english",
+            "boxes": [
+                {"x": 0, "y": 0, "width": 1, "height": 1},
+                {"x": 0, "y": 0, "width": 1, "height": 1},
+            ],
+        },
+    )
+    assert save_response.status_code == 200
+    image = save_response.json()["batch"]["images"][0]
+    assert image["subject"] == "english"
+    assert len(image["boxes"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_subject_override_persists(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={"subject": "english", "boxes": []},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["batch"]["images"][0]["subject"] == "english"
+
+
+@pytest.mark.asyncio
+async def test_invalid_box_zero_area_rejected(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={"boxes": [{"x": 0, "y": 0, "width": 0, "height": 1}]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_BOXES"
+
+
+@pytest.mark.asyncio
+async def test_invalid_box_outside_bounds_rejected(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={"boxes": [{"x": 0, "y": 0, "width": 2, "height": 1}]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_BOXES"
+
+
+@pytest.mark.asyncio
+async def test_commit_zero_boxes_creates_no_items(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+
+    save_response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={"subject": "math", "boxes": []},
+    )
+    assert save_response.status_code == 200
+
+    commit_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+    assert commit_response.status_code == 200
+    batch = commit_response.json()["batch"]
+    assert batch["images"][0]["status"] == "committed"
+    assert batch["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_commit_creates_items_in_reading_order(
+    authenticated_bulk_client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[
+                ProblemBox(x=0, y=0, width=1, height=1),
+                ProblemBox(x=0, y=0, width=1, height=1),
+            ],
+        )
+    )
+    await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+
+    commit_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+    assert commit_response.status_code == 200
+    batch = commit_response.json()["batch"]
+    assert len(batch["items"]) == 2
+    assert batch["items"][0]["order"] == 0
+    assert batch["items"][1]["order"] == 1
+    assert batch["items"][0]["imageId"] == image_id
+
+
+@pytest.mark.asyncio
+async def test_commit_is_idempotent(
+    authenticated_bulk_client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[ProblemBox(x=0, y=0, width=1, height=1)],
+        )
+    )
+    await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+
+    first_commit = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+    assert first_commit.status_code == 200
+    assert len(first_commit.json()["batch"]["items"]) == 1
+
+    second_commit = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+    assert second_commit.status_code == 200
+    assert len(second_commit.json()["batch"]["items"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_commit_rejects_unready_image(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "IMAGE_NOT_READY"
+
+
+@pytest.mark.asyncio
+async def test_patch_rejects_committed_image(
+    authenticated_bulk_client: AsyncClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={"subject": "math", "boxes": [{"x": 0, "y": 0, "width": 1, "height": 1}]},
+    )
+    await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}",
+        json={"boxes": [{"x": 0, "y": 0, "width": 1, "height": 1}]},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "IMAGE_ALREADY_COMMITTED"
+
+
+@pytest.mark.asyncio
+async def test_delete_image_removes_image_and_items(
+    authenticated_bulk_client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, image_id = await create_batch_with_image(authenticated_bulk_client)
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[ProblemBox(x=0, y=0, width=1, height=1)],
+        )
+    )
+    await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+    await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+
+    delete_response = await authenticated_bulk_client.delete(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}"
+    )
+    assert delete_response.status_code == 200
+    batch = delete_response.json()["batch"]
+    assert batch["images"] == []
+    assert batch["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_detect_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{ObjectId()}/images/image-1/detect"
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_save_boxes_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.patch(
+        f"/api/v1/ingestion-batches/{ObjectId()}/images/image-1",
+        json={"boxes": []},
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_commit_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{ObjectId()}/images/image-1/commit"
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_delete_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.delete(
+        f"/api/v1/ingestion-batches/{ObjectId()}/images/image-1"
     )
     assert response.status_code == 401

--- a/backend/tests/domain/test_bulk_ingestion_boxes.py
+++ b/backend/tests/domain/test_bulk_ingestion_boxes.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domain.ingestion import InvalidBoxError, validate_boxes
+
+
+def test_validate_boxes_accepts_valid_boxes() -> None:
+    boxes = [{"x": 10, "y": 20, "width": 30, "height": 40}]
+    assert validate_boxes(boxes, 100, 100) == [
+        {"x": 10.0, "y": 20.0, "width": 30.0, "height": 40.0}
+    ]
+
+
+def test_validate_boxes_rejects_zero_width() -> None:
+    with pytest.raises(InvalidBoxError):
+        validate_boxes([{"x": 0, "y": 0, "width": 0, "height": 10}], 100, 100)
+
+
+def test_validate_boxes_rejects_zero_height() -> None:
+    with pytest.raises(InvalidBoxError):
+        validate_boxes([{"x": 0, "y": 0, "width": 10, "height": 0}], 100, 100)
+
+
+def test_validate_boxes_rejects_negative_coordinate() -> None:
+    with pytest.raises(InvalidBoxError):
+        validate_boxes([{"x": -1, "y": 0, "width": 10, "height": 10}], 100, 100)
+
+
+def test_validate_boxes_rejects_box_exceeding_width() -> None:
+    with pytest.raises(InvalidBoxError):
+        validate_boxes([{"x": 50, "y": 0, "width": 60, "height": 10}], 100, 100)
+
+
+def test_validate_boxes_rejects_box_exceeding_height() -> None:
+    with pytest.raises(InvalidBoxError):
+        validate_boxes([{"x": 0, "y": 90, "width": 10, "height": 20}], 100, 100)
+
+
+def test_validate_boxes_skips_bounds_when_dimensions_missing() -> None:
+    boxes = [{"x": 0, "y": 0, "width": 10, "height": 10}]
+    assert validate_boxes(boxes, None, None) == [
+        {"x": 0.0, "y": 0.0, "width": 10.0, "height": 10.0}
+    ]


### PR DESCRIPTION
## Summary

This PR implements the backend box-review gate for bulk ingestion: detection, manual box editing, subject override, image skip/delete, and committing boxes into extraction items.

## Linked Issue

Closes #363

## Issue Alignment

This PR implements the issue by:

- Adding `POST /api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect` to run/retry Helper VLM problem-box detection.
- Persisting detection success (boxes, subject, model, raw response) and failure (code, message) metadata per image.
- Adding `PATCH /api/v1/ingestion-batches/{batch_id}/images/{image_id}` to save edited/manual boxes and subject overrides.
- Validating boxes have positive area and fit within parsed image bounds.
- Adding `DELETE /api/v1/ingestion-batches/{batch_id}/images/{image_id}` to skip/delete an image and mark its committed items deleted.
- Adding `POST /api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit` to create extraction items idempotently, preserving deterministic order.
- Storing parsed PNG/JPEG width/height in `sourceImage` on upload.

Scope covered:

- Detection start/retry, persistence, box editing, subject override, validation, image delete/skip, and commit.
- API and unit tests as required by the issue.

Out of scope / intentionally not included:

- Extraction execution (#364).
- Frontend box editor (#368).
- Split/merge boxes, polygon/rotated boxes, per-box confidence filtering, manual reading-order editing.

## Implementation Notes

- `app/infrastructure/ingestion/image_size.py` parses PNG IHDR and JPEG SOF markers without adding dependencies.
- `app/domain/ingestion/boxes.py` provides `validate_boxes` used by both the API and unit tests.
- Repository functions in `app/infrastructure/ingestion/repository.py` mutate batch images/items arrays and write them back atomically.
- The detect endpoint sets the image state to `detecting`, calls the Helper VLM with base64 image bytes, and records success or failure.
- Commit is idempotent: repeating commit for the same already-committed image returns the existing items without creating duplicates.
- Deleted images and items are filtered from serialized batch responses.

## Tests

Commands run:

- `cd backend && uv run --extra dev pytest tests/api tests/domain` — **440 passed**
- `cd backend && uv run --extra dev pytest tests/api tests/integration tests/infrastructure tests/domain` — **579 passed**

Automated tests added or updated:

- `tests/api/test_bulk_ingestion.py`: 17 new API tests covering detection success/failure/retry, manual boxes, subject override, invalid boxes, zero-box commit, commit order/idempotency, committed-image mutation guard, delete/skip, and auth.
- `tests/domain/test_bulk_ingestion_boxes.py`: 7 unit tests for box validation.

Manual verification:

- Confirmed failed detection on one image does not block detection on another image in the same batch.

## Deviations From Issue Plan

None.

## Follow-Up Work

- #364: extraction orchestration, crop generation, and retry.
- #368: frontend upload/detection/box-review UI.
