### PR TITLE
Evaluate and consolidate remaining isolated Mongo/S3 test fakes

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -90,7 +90,10 @@ class FakeCollection:
 
     def seed(self, *documents: dict[str, Any]) -> None:
         for doc in documents:
-            self._documents.append(deepcopy(doc))
+            stored = deepcopy(doc)
+            if "_id" not in stored:
+                stored["_id"] = ObjectId()
+            self._documents.append(stored)
 
     def find(
         self,
@@ -210,6 +213,9 @@ class FakeCollection:
         query: dict[str, Any],
         update: dict[str, Any],
         session: Any | None = None,
+        sort: Any | None = None,
+        return_document: Any | None = None,
+        **kwargs: Any,
     ) -> dict[str, Any] | None:
         for document in self._documents:
             if matches_query(document, query):

--- a/backend/tests/domain/test_coaching_service.py
+++ b/backend/tests/domain/test_coaching_service.py
@@ -1,5 +1,4 @@
 from datetime import datetime, UTC
-from copy import deepcopy
 
 import pytest
 from bson import ObjectId
@@ -7,74 +6,11 @@ from bson import ObjectId
 from app.domain.coaching.service import CoachingService, CoachingError
 from app.domain.models import CoachingConversation, CoachingMessage, CoachingRole
 from app.infrastructure.vlm.solution_coaching_client import CoachingVLMResult, SolutionCoachingVLMError
+from tests.conftest import FakeCollection, FakeDatabase
 
 
-class FakeDatabase:
-    def __init__(self):
-        self.cols = {
-            "exams": FakeCollection(),
-            "problems": FakeCollection(),
-            "canonical_solutions": FakeCollection(),
-            "practice_attempts": FakeCollection(),
-            "coaching_conversations": FakeCollection()
-        }
-
-    def __getitem__(self, name):
-        return self.cols[name]
-
-
-class FakeCollection:
-    def __init__(self):
-        self.docs = []
-
-    def seed(self, doc):
-        if "_id" not in doc:
-            doc["_id"] = ObjectId()
-        self.docs.append(deepcopy(doc))
-
-    async def count_documents(self, query):
-        return len([d for d in self.docs if self._match(d, query)])
-
-    async def find_one(self, query, sort=None):
-        docs = [d for d in self.docs if self._match(d, query)]
-        if not docs:
-            return None
-        if sort:
-            docs.sort(key=lambda x: x.get(sort[0][0], datetime.min), reverse=(sort[0][1] == -1))
-        return deepcopy(docs[0])
-
-    async def delete_one(self, query):
-        docs = [d for d in self.docs if not self._match(d, query)]
-        self.docs = docs
-
-    async def update_one(self, query, update, upsert=False):
-        doc = await self.find_one(query)
-        if doc:
-            for k, v in update.get("$set", {}).items():
-                doc[k] = v
-            # update in place
-            for i, d in enumerate(self.docs):
-                if self._match(d, query):
-                    self.docs[i] = doc
-                    break
-        elif upsert:
-            new_doc = deepcopy(query)
-            for k, v in update.get("$set", {}).items():
-                new_doc[k] = v
-            self.seed(new_doc)
-
-    def _match(self, doc, query):
-        for k, v in query.items():
-            if k == "items.problemId":
-                # mock logic for this specific query
-                if "items" in doc and any(v == item.get("problemId") for item in doc["items"]):
-                    continue
-                return False
-            if doc.get(k) != v:
-                return False
-        return True
-
-
+# VLM-specific test double; kept local because it models the coaching VLM client,
+# not Mongo/S3 storage shapes.
 class FakeCoachingVLMClient:
     def __init__(self):
         self.error_to_raise = None
@@ -101,14 +37,16 @@ async def test_get_conversation_not_found():
     conv = await service.get_conversation("prob1", "user1")
     assert conv is None
 
+
 @pytest.mark.asyncio
 async def test_clear_conversation():
     db = FakeDatabase()
     client = FakeCoachingVLMClient()
     service = CoachingService(db, vlm_client=client)
-    db.cols["coaching_conversations"].seed({"problem_id": "prob1", "user_id": "user1"})
+    db["coaching_conversations"].seed({"problem_id": "prob1", "user_id": "user1"})
     await service.clear_conversation("prob1", "user1")
     assert await service.get_conversation("prob1", "user1") is None
+
 
 @pytest.mark.asyncio
 async def test_send_message_active_exam_blocked():
@@ -119,7 +57,7 @@ async def test_send_message_active_exam_blocked():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["exams"].seed({
+    db["exams"].seed({
         "userId": user_id,
         "state": "in-progress",
         "items": [{"problemId": prob_id}]
@@ -128,6 +66,7 @@ async def test_send_message_active_exam_blocked():
     with pytest.raises(CoachingError) as exc:
         await service.send_message(str(prob_id), str(user_id), "hello")
     assert exc.value.code == "ACTIVE_EXAM_RESTRICTION"
+
 
 @pytest.mark.asyncio
 async def test_send_message_success():
@@ -138,8 +77,8 @@ async def test_send_message_success():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
-    db.cols["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
 
     conv = await service.send_message(str(prob_id), str(user_id), "help me")
 
@@ -154,6 +93,7 @@ async def test_send_message_success():
     assert req.problem_text == "prob text"
     assert req.canonical_steps_markdown == "steps"
 
+
 @pytest.mark.asyncio
 async def test_send_message_skipped_problem_no_attempt():
     db = FakeDatabase()
@@ -163,7 +103,7 @@ async def test_send_message_skipped_problem_no_attempt():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
     # no canonical solution
 
     conv = await service.send_message(str(prob_id), str(user_id), "help me")
@@ -171,6 +111,7 @@ async def test_send_message_skipped_problem_no_attempt():
 
     req = client.calls[0]
     assert req.canonical_steps_markdown == "No canonical steps available."
+
 
 @pytest.mark.asyncio
 async def test_send_message_cap_exceeded():
@@ -181,17 +122,18 @@ async def test_send_message_cap_exceeded():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False})
 
     # create a conversation with 20 messages
     messages = [{"role": "student", "content": "hello"}] * 20
-    db.cols["coaching_conversations"].seed({
+    db["coaching_conversations"].seed({
         "problem_id": str(prob_id), "user_id": str(user_id), "messages": messages
     })
 
     with pytest.raises(CoachingError) as exc:
         await service.send_message(str(prob_id), str(user_id), "hello")
     assert exc.value.code == "MESSAGE_CAP_EXCEEDED"
+
 
 @pytest.mark.asyncio
 async def test_send_message_vlm_failure():
@@ -203,12 +145,13 @@ async def test_send_message_vlm_failure():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False})
 
     with pytest.raises(CoachingError) as exc:
         await service.send_message(str(prob_id), str(user_id), "hello")
     assert exc.value.code == "VLM_FAILURE"
     assert exc.value.status_code == 503
+
 
 @pytest.mark.asyncio
 async def test_send_message_persists_reasoning_content():
@@ -226,8 +169,8 @@ async def test_send_message_persists_reasoning_content():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
-    db.cols["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
 
     conv = await service.send_message(str(prob_id), str(user_id), "help me")
 
@@ -235,6 +178,7 @@ async def test_send_message_persists_reasoning_content():
     assert conv.messages[1].role == CoachingRole.COACH
     assert conv.messages[1].content == "coach reply"
     assert conv.messages[1].reasoning_content == "step by step thinking"
+
 
 @pytest.mark.asyncio
 async def test_send_message_reasoning_content_none_when_absent():
@@ -251,9 +195,12 @@ async def test_send_message_reasoning_content_none_when_absent():
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
-    db.cols["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db["canonical_solutions"].seed({"problem_id": str(prob_id), "steps_markdown": "steps", "final_answer": "ans"})
 
     conv = await service.send_message(str(prob_id), str(user_id), "help me")
 
+    assert len(conv.messages) == 2
+    assert conv.messages[1].role == CoachingRole.COACH
+    assert conv.messages[1].content == "coach reply"
     assert conv.messages[1].reasoning_content is None

--- a/backend/tests/domain/test_observability.py
+++ b/backend/tests/domain/test_observability.py
@@ -125,7 +125,7 @@ async def test_send_message_logs_observability(caplog):
     prob_id = ObjectId()
     user_id = ObjectId()
 
-    db.cols["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
+    db["problems"].seed({"_id": prob_id, "userId": user_id, "isDeleted": False, "text": "prob text"})
 
     with caplog.at_level(logging.INFO):
         conv = await service.send_message(str(prob_id), str(user_id), "help me")

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -25,6 +25,9 @@ from app.infrastructure.storage.mongo import (
 )
 
 
+# These fakes stay local because they model database-level administration
+# (list_collection_names/create_collection) and index-call tracking, which are
+# shape-divergent from the shared Mongo/S3 fakes in tests/conftest.py.
 class FakeDatabase:
     def __init__(self, name: str) -> None:
         self.name = name

--- a/backend/tests/worker/test_solution_worker.py
+++ b/backend/tests/worker/test_solution_worker.py
@@ -1,7 +1,6 @@
 import asyncio
 from datetime import UTC, datetime, timedelta
 from typing import Any
-from copy import deepcopy
 from unittest.mock import patch
 
 import pytest
@@ -10,74 +9,11 @@ from bson import ObjectId
 from app.domain.models import SolutionGenerationStatus
 from app.infrastructure.vlm.solution_coaching_client import SolutionCoachingVLMError, SolutionVLMResult
 from app.infrastructure.worker.solution_worker import run_solution_worker, process_task
-
-class FakeCollection:
-    def __init__(self):
-        self._documents = []
-
-    def seed(self, document):
-        self._documents.append(document)
-
-    async def find_one(self, query):
-        for doc in self._documents:
-            if _matches(doc, query):
-                return deepcopy(doc)
-        return None
-
-    async def update_one(self, query, update):
-        for doc in self._documents:
-            if _matches(doc, query):
-                for k, v in update.get("$set", {}).items():
-                    doc[k] = v
-                return
-
-    async def update_many(self, query, update):
-        for doc in self._documents:
-            if _matches(doc, query):
-                for k, v in update.get("$set", {}).items():
-                    doc[k] = v
-
-    async def find_one_and_update(self, query, update, sort=None, return_document=None):
-        docs = [d for d in self._documents if _matches(d, query)]
-        if not docs:
-            return None
-        if sort:
-            docs.sort(key=lambda x: x.get(sort[0][0], 0))
-        
-        doc = docs[0]
-        for k, v in update.get("$set", {}).items():
-            doc[k] = v
-        return deepcopy(doc)
-
-    async def insert_one(self, doc):
-        d = deepcopy(doc)
-        if "_id" not in d: d["_id"] = ObjectId()
-        self._documents.append(d)
+from tests.conftest import FakeCollection, FakeDatabase, FakeStorage
 
 
-def _matches(document, query):
-    for key, value in query.items():
-        if key == "$or":
-            if not any(_matches(document, clause) for clause in value):
-                return False
-            continue
-
-        actual = document.get(key)
-        if isinstance(value, dict):
-            if "$in" in value and actual not in value["$in"]:
-                return False
-            if "$lt" in value and (actual is None or not (actual < value["$lt"])):
-                return False
-            if "$lte" in value and (actual is None or not (actual <= value["$lte"])):
-                return False
-            if "$exists" in value and (key in document) != value["$exists"]:
-                return False
-            continue
-
-        if actual != value:
-            return False
-    return True
-
+# VLM-specific test double; kept local because it models SolutionVLMClient behavior,
+# not Mongo/S3 storage shapes.
 class FakeSolutionVLMClient:
     def __init__(self):
         self.error_to_raise = None
@@ -100,9 +36,6 @@ class FakeSolutionVLMClient:
     async def aclose(self):
         self.closed = True
 
-class FakeStorage:
-    def get_object(self, bucket, key):
-        return b"image"
 
 @pytest.mark.asyncio
 async def test_process_task_success():
@@ -111,15 +44,16 @@ async def test_process_task_success():
     tasks_col = FakeCollection()
     solutions_col = FakeCollection()
     problems_col = FakeCollection()
-    
+
     problem_id = str(ObjectId())
     user_id = str(ObjectId())
     task_id = ObjectId()
-    
+
     problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    storage.seed("b", "k", b"image")
     task = {"_id": task_id, "problem_id": problem_id, "user_id": user_id, "status": "pending"}
     tasks_col.seed(task)
-    
+
     await process_task(task, client, storage, tasks_col, solutions_col, problems_col, 3)
 
     updated_task = await tasks_col.find_one({"_id": task_id})
@@ -127,6 +61,7 @@ async def test_process_task_success():
     assert len(solutions_col._documents) == 1
     assert len(client.calls) == 1
     assert not client.closed  # injected client must not be closed
+
 
 @pytest.mark.asyncio
 async def test_process_task_retry_and_fail():
@@ -136,12 +71,13 @@ async def test_process_task_retry_and_fail():
     tasks_col = FakeCollection()
     solutions_col = FakeCollection()
     problems_col = FakeCollection()
-    
+
     problem_id = str(ObjectId())
     task_id = ObjectId()
-    
+
     problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
-    
+    storage.seed("b", "k", b"image")
+
     # 1. First failure -> pending
     task = {"_id": task_id, "problem_id": problem_id, "user_id": "u", "status": "pending", "retry_count": 0}
     tasks_col.seed(task)
@@ -151,7 +87,7 @@ async def test_process_task_retry_and_fail():
     assert updated["retry_count"] == 1
     assert updated["updated_at"] <= updated["process_after"]
     assert updated["process_after"] - updated["updated_at"] == timedelta(seconds=30)
-    
+
     # 2. Fourth failure -> failed
     task["retry_count"] = 3
     await process_task(task, client, storage, tasks_col, solutions_col, problems_col, 3)
@@ -160,8 +96,9 @@ async def test_process_task_retry_and_fail():
     assert updated["retry_count"] == 4
     assert not client.closed  # injected client must not be closed
 
+
 @pytest.mark.asyncio
-async def test_run_worker_stuck_task_recovery():
+async def test_run_worker_stuck_task_recovery(monkeypatch):
     class FakeSettings:
         solution_worker_poll_interval_seconds = 0.01
         solution_task_timeout_minutes = 10
@@ -181,21 +118,13 @@ async def test_run_worker_stuck_task_recovery():
         s3_secret_key = "s"
 
     from app.infrastructure.config import settings
-    settings.get_settings = lambda: FakeSettings()
-
-    class FakeDatabase:
-        def __init__(self):
-            self.cols = {"solution_generation_tasks": FakeCollection(), "canonical_solutions": FakeCollection(), "problems": FakeCollection()}
-        def __getitem__(self, k):
-            return self.cols[k]
-        def get_collection(self, k):
-            return self.cols[k]
+    monkeypatch.setattr(settings, "get_settings", lambda: FakeSettings())
 
     db = FakeDatabase()
     now = datetime.now(UTC)
 
     stuck_task = {"_id": ObjectId(), "problem_id": str(ObjectId()), "user_id": str(ObjectId()), "status": "generating", "updated_at": now - timedelta(minutes=15)}
-    db.cols["solution_generation_tasks"].seed(stuck_task)
+    db["solution_generation_tasks"].seed(stuck_task)
 
     stop_event = asyncio.Event()
 
@@ -208,12 +137,12 @@ async def test_run_worker_stuck_task_recovery():
 
     # After one loop, stuck task should be recovered to generating and then maybe processed if problem exists.
     # But since problem doesn't exist, it will be marked failed.
-    updated = await db.cols["solution_generation_tasks"].find_one({"_id": stuck_task["_id"]})
-    assert updated["status"] == "failed" # because it found the task, couldn't find problem
+    updated = await db["solution_generation_tasks"].find_one({"_id": stuck_task["_id"]})
+    assert updated["status"] == "failed"  # because it found the task, couldn't find problem
 
 
 @pytest.mark.asyncio
-async def test_run_worker_skips_pending_task_until_process_after() -> None:
+async def test_run_worker_skips_pending_task_until_process_after(monkeypatch) -> None:
     class FakeSettings:
         solution_worker_poll_interval_seconds = 0.01
         solution_task_timeout_minutes = 10
@@ -233,15 +162,7 @@ async def test_run_worker_skips_pending_task_until_process_after() -> None:
         s3_secret_key = "s"
 
     from app.infrastructure.config import settings
-    settings.get_settings = lambda: FakeSettings()
-
-    class FakeDatabase:
-        def __init__(self):
-            self.cols = {"solution_generation_tasks": FakeCollection(), "canonical_solutions": FakeCollection(), "problems": FakeCollection()}
-        def __getitem__(self, k):
-            return self.cols[k]
-        def get_collection(self, k):
-            return self.cols[k]
+    monkeypatch.setattr(settings, "get_settings", lambda: FakeSettings())
 
     db = FakeDatabase()
     now = datetime.now(UTC)
@@ -253,7 +174,7 @@ async def test_run_worker_skips_pending_task_until_process_after() -> None:
         "updated_at": now,
         "process_after": now + timedelta(minutes=1),
     }
-    db.cols["solution_generation_tasks"].seed(pending_task)
+    db["solution_generation_tasks"].seed(pending_task)
 
     stop_event = asyncio.Event()
 
@@ -263,8 +184,9 @@ async def test_run_worker_skips_pending_task_until_process_after() -> None:
 
     await asyncio.gather(run_solution_worker(db, stop_event), stop_soon())
 
-    updated = await db.cols["solution_generation_tasks"].find_one({"_id": pending_task["_id"]})
+    updated = await db["solution_generation_tasks"].find_one({"_id": pending_task["_id"]})
     assert updated["status"] == "pending"
+
 
 @pytest.mark.asyncio
 async def test_process_task_no_image():
@@ -273,17 +195,17 @@ async def test_process_task_no_image():
     tasks_col = FakeCollection()
     solutions_col = FakeCollection()
     problems_col = FakeCollection()
-    
+
     problem_id = str(ObjectId())
     user_id = str(ObjectId())
     task_id = ObjectId()
-    
+
     problems_col.seed({"_id": ObjectId(problem_id), "text": "prob no image", "correctAnswer": {"display": "ans"}})
     task = {"_id": task_id, "problem_id": problem_id, "user_id": user_id, "status": "pending"}
     tasks_col.seed(task)
-    
+
     await process_task(task, client, storage, tasks_col, solutions_col, problems_col, 3)
-    
+
     updated_task = await tasks_col.find_one({"_id": task_id})
     assert updated_task["status"] == "ready"
     assert len(solutions_col._documents) == 1
@@ -306,6 +228,7 @@ async def test_process_task_closes_internal_client_on_success():
     task_id = ObjectId()
 
     problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    storage.seed("b", "k", b"image")
     task = {"_id": task_id, "problem_id": problem_id, "user_id": user_id, "status": "pending"}
     tasks_col.seed(task)
 
@@ -334,6 +257,7 @@ async def test_process_task_closes_internal_client_on_vlm_failure():
     task_id = ObjectId()
 
     problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    storage.seed("b", "k", b"image")
     task = {"_id": task_id, "problem_id": problem_id, "user_id": "u", "status": "pending", "retry_count": 3}
     tasks_col.seed(task)
 
@@ -362,6 +286,7 @@ async def test_process_task_closes_internal_client_on_unexpected_failure():
     task_id = ObjectId()
 
     problems_col.seed({"_id": ObjectId(problem_id), "text": "prob", "correctAnswer": {"display": "ans"}, "sourceImage": {"bucket": "b", "objectKey": "k"}})
+    storage.seed("b", "k", b"image")
     task = {"_id": task_id, "problem_id": problem_id, "user_id": "u", "status": "pending"}
     tasks_col.seed(task)
 


### PR DESCRIPTION
## Summary

This PR audits the remaining isolated Mongo/S3 test doubles and consolidates the ones whose shapes converge with the shared fakes introduced in #376.

## Linked Issue

Closes #379

## Issue Alignment

This PR implements the issue by:

- Migrating `tests/worker/test_solution_worker.py` to the shared `FakeCollection`, `FakeDatabase`, and `FakeStorage` from `tests/conftest.py`.
- Migrating `tests/domain/test_coaching_service.py` to the shared fakes.
- Leaving `tests/infrastructure/test_mongo.py` fakes local with a documented justification (they track database-level administration and index calls).
- Extending the shared fakes only where genuinely necessary (`seed` auto-assigns `_id`; `find_one_and_update` accepts common kwargs).
- Updating `tests/domain/test_observability.py` to use the new shared-shaped coaching fakes.

Scope covered:

- Audit and migration of the three named modules.
- Test-only changes; no production code changed.

Out of scope / intentionally not included:

- Production code changes.
- Refactoring unrelated test infrastructure.

## Implementation Notes

- `tests/worker/test_solution_worker.py` still keeps `FakeSolutionVLMClient` local because it models `SolutionVLMClient`, not storage shapes.
- `tests/domain/test_coaching_service.py` keeps `FakeCoachingVLMClient` local for the same reason.
- `tests/infrastructure/test_mongo.py` keeps its local `FakeDatabase`/`FakeCollection` because they record `created_collections` and `index_calls`, which are divergent responsibilities.
- Worker tests now use `monkeypatch` so the `settings.get_settings` override is restored after each test, fixing a cross-test isolation leak that surfaced after the migration.

## Tests

Command run:

- `cd backend && uv run --extra dev pytest tests/worker tests/infrastructure tests/domain tests/api tests/integration` — **563 passed**

No new tests were added because the change is a test-infrastructure refactor; the existing suites prove behavior is preserved.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
