### PR TITLE
feat(bulk-ingestion): implement extraction orchestration, crop generation, and retry

### DIFF
--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -95,6 +95,8 @@ class Settings(BaseSettings):
     bulk_ingestion_batch_ttl_seconds: int = Field(default=86400, ge=1)
     bulk_ingestion_extraction_concurrency: int = Field(default=3, ge=1)
     bulk_ingestion_item_lease_timeout_seconds: int = Field(default=120, ge=1)
+    bulk_ingestion_extraction_poll_interval_seconds: float = Field(default=5.0, gt=0)
+    bulk_ingestion_extraction_worker_enabled: bool = Field(default=True)
 
     # Teacher password configuration
     teacher_password_default: str = Field(default="default-teacher-password")

--- a/backend/app/infrastructure/ingestion/crop.py
+++ b/backend/app/infrastructure/ingestion/crop.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import io
+from typing import Any
+
+from PIL import Image
+
+
+def _content_type_from_format(image_format: str | None) -> str:
+    if image_format == "JPEG":
+        return "image/jpeg"
+    if image_format == "PNG":
+        return "image/png"
+    return "image/png"
+
+
+def crop_image_to_box(
+    image_bytes: bytes,
+    box: dict[str, Any],
+) -> tuple[bytes, str, int, int]:
+    """Crop a region from image bytes and return the crop bytes, content type, width, height."""
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        image_format = img.format
+        img_width, img_height = img.size
+
+        x = max(0, int(box["x"]))
+        y = max(0, int(box["y"]))
+        right = min(img_width, int(box["x"] + box["width"]))
+        bottom = min(img_height, int(box["y"] + box["height"]))
+
+        if right <= x or bottom <= y:
+            raise ValueError("Crop box has no area after clamping")
+
+        cropped = img.crop((x, y, right, bottom))
+        content_type = _content_type_from_format(image_format)
+
+        output_format = image_format if image_format in {"PNG", "JPEG"} else "PNG"
+        buffer = io.BytesIO()
+        cropped.save(buffer, format=output_format)
+        return buffer.getvalue(), content_type, cropped.width, cropped.height

--- a/backend/app/infrastructure/ingestion/documents.py
+++ b/backend/app/infrastructure/ingestion/documents.py
@@ -40,6 +40,27 @@ def build_source_image(
     }
 
 
+def build_crop_image(
+    *,
+    bucket: str,
+    object_key: str,
+    content_type: str,
+    size_bytes: int,
+    width: int,
+    height: int,
+    uploaded_at: datetime,
+) -> dict[str, Any]:
+    return {
+        "bucket": bucket,
+        "objectKey": object_key,
+        "contentType": content_type,
+        "sizeBytes": size_bytes,
+        "width": width,
+        "height": height,
+        "uploadedAt": uploaded_at,
+    }
+
+
 def build_image_document(
     *,
     image_id: str,
@@ -73,6 +94,7 @@ def build_item_document(
     image_id: str,
     order: int,
     now: datetime,
+    box: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     return {
         "itemId": item_id,
@@ -80,6 +102,7 @@ def build_item_document(
         "batchId": batch_id,
         "status": ItemState.QUEUED.value,
         "order": order,
+        "box": box,
         "draft": {
             "text": None,
             "problemType": None,

--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from bson import ObjectId
-from pymongo import ASCENDING
+from pymongo import ASCENDING, ReturnDocument
 
 from app.domain.ingestion import BatchState, ImageState, ItemState
 from app.infrastructure.config.settings import Settings
@@ -386,7 +386,7 @@ async def commit_image_boxes(
     next_order = max((item["order"] for item in existing_items), default=-1) + 1
 
     new_items: list[dict[str, Any]] = []
-    for offset, _box in enumerate(target_image.get("boxes", [])):
+    for offset, box in enumerate(target_image.get("boxes", [])):
         item_id = new_item_id()
         item_document = build_item_document(
             item_id=item_id,
@@ -394,6 +394,7 @@ async def commit_image_boxes(
             image_id=image_id,
             order=next_order + offset,
             now=now,
+            box=box,
         )
         new_items.append(item_document)
 
@@ -409,6 +410,158 @@ async def commit_image_boxes(
         {"$set": {"images": images, "items": items, "updatedAt": now}},
     )
     return new_items
+
+
+async def claim_item(
+    database: Any,
+    batch_id: str | ObjectId,
+    item_id: str,
+    user_id: Any,
+    *,
+    lease_timeout_seconds: int,
+    now: datetime,
+) -> dict[str, Any] | None:
+    """Atomically claim an item for extraction. Returns the updated item or None."""
+    lease_until = now + timedelta(seconds=lease_timeout_seconds)
+    result = await _collection(database).find_one_and_update(
+        {
+            "_id": _object_id(batch_id),
+            "userId": user_id,
+            "items": {
+                "$elemMatch": {
+                    "itemId": item_id,
+                    "status": {"$in": [ItemState.QUEUED.value, ItemState.EXTRACTING.value]},
+                    "$or": [
+                        {"leaseUntil": None},
+                        {"leaseUntil": {"$lte": now}},
+                    ],
+                }
+            },
+        },
+        {
+            "$set": {
+                "items.$.status": ItemState.EXTRACTING.value,
+                "items.$.leaseUntil": lease_until,
+                "items.$.updatedAt": now,
+                "items.$.extraction.requestStartedAt": now,
+                "updatedAt": now,
+            },
+            "$inc": {"items.$.retryCount": 1},
+        },
+        return_document=ReturnDocument.AFTER,
+    )
+    if result is None:
+        return None
+    for item in result.get("items", []):
+        if item.get("itemId") == item_id:
+            return item
+    return None
+
+
+async def save_item_extraction_success(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    item_id: str,
+    *,
+    crop: dict[str, Any],
+    draft: dict[str, Any],
+    extraction: dict[str, Any],
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    for item in items:
+        if item.get("itemId") == item_id:
+            item["status"] = ItemState.READY.value
+            item["crop"] = crop
+            item["draft"] = draft
+            item["extraction"] = extraction
+            item["leaseUntil"] = None
+            item["updatedAt"] = now
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"items": items, "updatedAt": now}},
+    )
+
+
+async def save_item_extraction_failure(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    item_id: str,
+    *,
+    extraction: dict[str, Any],
+    now: datetime,
+) -> None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    for item in items:
+        if item.get("itemId") == item_id:
+            item["status"] = ItemState.FAILED.value
+            item["extraction"] = extraction
+            item["leaseUntil"] = None
+            item["updatedAt"] = now
+            break
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"items": items, "updatedAt": now}},
+    )
+
+
+async def reset_item_for_retry(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    item_id: str,
+    *,
+    now: datetime,
+) -> bool:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    changed = False
+    for item in items:
+        if item.get("itemId") != item_id:
+            continue
+        status = item.get("status")
+        lease_until = item.get("leaseUntil")
+        if status == ItemState.FAILED.value or (
+            status == ItemState.EXTRACTING.value
+            and isinstance(lease_until, datetime)
+            and lease_until <= now
+        ):
+            item["status"] = ItemState.QUEUED.value
+            item["leaseUntil"] = None
+            item["updatedAt"] = now
+            changed = True
+        break
+
+    if not changed:
+        return False
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"items": items, "updatedAt": now}},
+    )
+    return True
 
 
 async def find_cleanup_candidates(

--- a/backend/app/infrastructure/worker/extraction_worker.py
+++ b/backend/app/infrastructure/worker/extraction_worker.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from app.domain.ingestion import BatchState, ItemState
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.ingestion.crop import crop_image_to_box
+from app.infrastructure.ingestion.documents import build_crop_image
+from app.infrastructure.ingestion.repository import (
+    INGESTION_BATCHES_COLLECTION,
+    claim_item,
+    save_item_extraction_failure,
+    save_item_extraction_success,
+)
+from app.infrastructure.storage.s3 import S3StorageAdapter
+from app.infrastructure.vlm.base_client import BaseVLMError
+from app.infrastructure.vlm.client import VLMClient
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _find_image(batch: dict[str, Any], image_id: str) -> dict[str, Any] | None:
+    for image in batch.get("images", []):
+        if image.get("imageId") == image_id:
+            return image
+    return None
+
+
+def _content_type_extension(content_type: str) -> str:
+    if content_type == "image/jpeg":
+        return ".jpg"
+    return ".png"
+
+
+def _is_item_claimable(item: dict[str, Any], now: datetime) -> bool:
+    status = item.get("status")
+    if status == ItemState.QUEUED.value:
+        return True
+    if status == ItemState.EXTRACTING.value:
+        lease_until = item.get("leaseUntil")
+        if lease_until is None or (isinstance(lease_until, datetime) and lease_until <= now):
+            return True
+    return False
+
+
+async def _select_client(
+    subject: str,
+    math_client: VLMClient,
+    english_client: VLMClient,
+) -> VLMClient:
+    if subject == "math":
+        return math_client
+    if subject == "english":
+        return english_client
+    raise ValueError(f"Unsupported subject: {subject}")
+
+
+async def process_item(
+    item: dict[str, Any],
+    batch: dict[str, Any],
+    database: Any,
+    storage: S3StorageAdapter,
+    math_client: VLMClient,
+    english_client: VLMClient,
+    settings: Settings,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Crop, extract, and persist results for a single claimed item."""
+    current = now or _utc_now()
+    batch_id = batch["_id"]
+    user_id = batch["userId"]
+    item_id = item["itemId"]
+    image_id = item["imageId"]
+
+    image = _find_image(batch, image_id)
+    if image is None:
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": None,
+                "failureCode": "source-image-missing",
+                "failureMessage": "Source image not found in batch",
+                "requestStartedAt": current,
+                "requestFinishedAt": current,
+            },
+            now=current,
+        )
+        return
+
+    source_image = image.get("sourceImage") or {}
+    subject = image.get("subject")
+    if not subject:
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": None,
+                "failureCode": "missing-subject",
+                "failureMessage": "Image subject is not set",
+                "requestStartedAt": current,
+                "requestFinishedAt": current,
+            },
+            now=current,
+        )
+        return
+
+    box = item.get("box")
+    if not box:
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": None,
+                "failureCode": "missing-box",
+                "failureMessage": "Item has no crop box",
+                "requestStartedAt": current,
+                "requestFinishedAt": current,
+            },
+            now=current,
+        )
+        return
+
+    try:
+        source_bytes = storage.get_object(source_image["bucket"], source_image["objectKey"])
+    except Exception as exc:
+        logger.exception("Failed to load source image for extraction")
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": None,
+                "failureCode": "storage-read-failed",
+                "failureMessage": str(exc),
+                "requestStartedAt": current,
+                "requestFinishedAt": current,
+            },
+            now=current,
+        )
+        return
+
+    try:
+        crop_bytes, crop_content_type, crop_width, crop_height = crop_image_to_box(source_bytes, box)
+    except Exception as exc:
+        logger.exception("Failed to crop source image")
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": None,
+                "failureCode": "crop-failed",
+                "failureMessage": str(exc),
+                "requestStartedAt": current,
+                "requestFinishedAt": current,
+            },
+            now=current,
+        )
+        return
+
+    crop_extension = _content_type_extension(crop_content_type)
+    crop_object_key = storage.build_object_key(
+        str(user_id), crop_extension, category="ingestion/crops"
+    )
+    storage.put_object(settings.s3_bucket, crop_object_key, crop_bytes, crop_content_type)
+    crop_meta = build_crop_image(
+        bucket=settings.s3_bucket,
+        object_key=crop_object_key,
+        content_type=crop_content_type,
+        size_bytes=len(crop_bytes),
+        width=crop_width,
+        height=crop_height,
+        uploaded_at=current,
+    )
+
+    try:
+        client = await _select_client(subject, math_client, english_client)
+        result = await client.extract(image_base64=base64.b64encode(crop_bytes).decode())
+    except BaseVLMError as exc:
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": exc.raw_provider_response,
+                "failureCode": exc.code,
+                "failureMessage": exc.args[0],
+                "requestStartedAt": current,
+                "requestFinishedAt": _utc_now(),
+            },
+            now=_utc_now(),
+        )
+        return
+    except Exception as exc:
+        logger.exception("Unexpected extraction failure")
+        await save_item_extraction_failure(
+            database,
+            batch_id,
+            user_id,
+            item_id,
+            extraction={
+                "success": False,
+                "model": None,
+                "rawText": None,
+                "rawProblemType": None,
+                "rawGraphDsl": None,
+                "rawProviderResponse": None,
+                "failureCode": "extraction-failed",
+                "failureMessage": str(exc),
+                "requestStartedAt": current,
+                "requestFinishedAt": _utc_now(),
+            },
+            now=_utc_now(),
+        )
+        return
+
+    finished_at = _utc_now()
+    await save_item_extraction_success(
+        database,
+        batch_id,
+        user_id,
+        item_id,
+        crop=crop_meta,
+        draft={
+            "text": result.text,
+            "problemType": result.problem_type,
+            "graphDsl": result.graph_dsl,
+            "correctAnswer": None,
+            "tags": [],
+            "subject": subject,
+        },
+        extraction={
+            "success": True,
+            "model": result.model,
+            "rawText": result.text,
+            "rawProblemType": result.problem_type,
+            "rawGraphDsl": result.graph_dsl,
+            "rawProviderResponse": result.raw_provider_response,
+            "failureCode": None,
+            "failureMessage": None,
+            "requestStartedAt": current,
+            "requestFinishedAt": finished_at,
+        },
+        now=finished_at,
+    )
+
+
+async def claim_next_item(
+    database: Any,
+    settings: Settings,
+    *,
+    now: datetime | None = None,
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
+    """Find and atomically claim the next available item across active batches."""
+    current = now or _utc_now()
+    cursor = database[INGESTION_BATCHES_COLLECTION].find(
+        {
+            "status": BatchState.ACTIVE.value,
+            "items.status": {"$in": [ItemState.QUEUED.value, ItemState.EXTRACTING.value]},
+        }
+    )
+    batches = await cursor.to_list(length=None)
+    for batch in batches:
+        batch_user_id = batch.get("userId")
+        for item in batch.get("items", []):
+            if not _is_item_claimable(item, current):
+                continue
+            claimed = await claim_item(
+                database,
+                batch["_id"],
+                item["itemId"],
+                batch_user_id,
+                lease_timeout_seconds=settings.bulk_ingestion_item_lease_timeout_seconds,
+                now=current,
+            )
+            if claimed is not None:
+                return batch, claimed
+    return None
+
+
+async def run_extraction_worker(
+    database: Any,
+    storage: S3StorageAdapter,
+    settings: Settings,
+    math_client: VLMClient,
+    english_client: VLMClient,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Loop claiming and processing extraction items up to configured concurrency."""
+    poll_interval = getattr(settings, "bulk_ingestion_extraction_poll_interval_seconds", 5)
+
+    logger.info("Extraction worker started")
+
+    while True:
+        if stop_event and stop_event.is_set():
+            break
+
+        tasks: list[asyncio.Task[Any]] = []
+        for _ in range(settings.bulk_ingestion_extraction_concurrency):
+            claimed = await claim_next_item(database, settings, now=_utc_now())
+            if claimed is None:
+                break
+            batch, item = claimed
+            task = asyncio.create_task(
+                process_item(
+                    item,
+                    batch,
+                    database,
+                    storage,
+                    math_client,
+                    english_client,
+                    settings,
+                )
+            )
+            tasks.append(task)
+
+        if not tasks:
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait() if stop_event else asyncio.sleep(poll_interval),
+                    timeout=poll_interval,
+                )
+            except asyncio.TimeoutError:
+                continue
+            break
+
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                logger.exception("Extraction task failed")

--- a/backend/app/infrastructure/worker/extraction_worker.py
+++ b/backend/app/infrastructure/worker/extraction_worker.py
@@ -27,6 +27,28 @@ def _utc_now() -> datetime:
     return datetime.now(UTC)
 
 
+def _failed_extraction(
+    code: str,
+    message: str,
+    started_at: datetime,
+    finished_at: datetime,
+    *,
+    raw_provider_response: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "success": False,
+        "model": None,
+        "rawText": None,
+        "rawProblemType": None,
+        "rawGraphDsl": None,
+        "rawProviderResponse": raw_provider_response,
+        "failureCode": code,
+        "failureMessage": message,
+        "requestStartedAt": started_at,
+        "requestFinishedAt": finished_at,
+    }
+
+
 def _find_image(batch: dict[str, Any], image_id: str) -> dict[str, Any] | None:
     for image in batch.get("images", []):
         if image.get("imageId") == image_id:
@@ -88,18 +110,12 @@ async def process_item(
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": None,
-                "failureCode": "source-image-missing",
-                "failureMessage": "Source image not found in batch",
-                "requestStartedAt": current,
-                "requestFinishedAt": current,
-            },
+            extraction=_failed_extraction(
+                "source-image-missing",
+                "Source image not found in batch",
+                current,
+                current,
+            ),
             now=current,
         )
         return
@@ -112,18 +128,12 @@ async def process_item(
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": None,
-                "failureCode": "missing-subject",
-                "failureMessage": "Image subject is not set",
-                "requestStartedAt": current,
-                "requestFinishedAt": current,
-            },
+            extraction=_failed_extraction(
+                "missing-subject",
+                "Image subject is not set",
+                current,
+                current,
+            ),
             now=current,
         )
         return
@@ -135,18 +145,12 @@ async def process_item(
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": None,
-                "failureCode": "missing-box",
-                "failureMessage": "Item has no crop box",
-                "requestStartedAt": current,
-                "requestFinishedAt": current,
-            },
+            extraction=_failed_extraction(
+                "missing-box",
+                "Item has no crop box",
+                current,
+                current,
+            ),
             now=current,
         )
         return
@@ -160,18 +164,12 @@ async def process_item(
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": None,
-                "failureCode": "storage-read-failed",
-                "failureMessage": str(exc),
-                "requestStartedAt": current,
-                "requestFinishedAt": current,
-            },
+            extraction=_failed_extraction(
+                "storage-read-failed",
+                str(exc),
+                current,
+                current,
+            ),
             now=current,
         )
         return
@@ -185,18 +183,12 @@ async def process_item(
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": None,
-                "failureCode": "crop-failed",
-                "failureMessage": str(exc),
-                "requestStartedAt": current,
-                "requestFinishedAt": current,
-            },
+            extraction=_failed_extraction(
+                "crop-failed",
+                str(exc),
+                current,
+                current,
+            ),
             now=current,
         )
         return
@@ -220,46 +212,37 @@ async def process_item(
         client = await _select_client(subject, math_client, english_client)
         result = await client.extract(image_base64=base64.b64encode(crop_bytes).decode())
     except BaseVLMError as exc:
+        finished_at = _utc_now()
         await save_item_extraction_failure(
             database,
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": exc.raw_provider_response,
-                "failureCode": exc.code,
-                "failureMessage": exc.args[0],
-                "requestStartedAt": current,
-                "requestFinishedAt": _utc_now(),
-            },
-            now=_utc_now(),
+            extraction=_failed_extraction(
+                exc.code,
+                exc.args[0],
+                current,
+                finished_at,
+                raw_provider_response=exc.raw_provider_response,
+            ),
+            now=finished_at,
         )
         return
     except Exception as exc:
         logger.exception("Unexpected extraction failure")
+        finished_at = _utc_now()
         await save_item_extraction_failure(
             database,
             batch_id,
             user_id,
             item_id,
-            extraction={
-                "success": False,
-                "model": None,
-                "rawText": None,
-                "rawProblemType": None,
-                "rawGraphDsl": None,
-                "rawProviderResponse": None,
-                "failureCode": "extraction-failed",
-                "failureMessage": str(exc),
-                "requestStartedAt": current,
-                "requestFinishedAt": _utc_now(),
-            },
-            now=_utc_now(),
+            extraction=_failed_extraction(
+                "extraction-failed",
+                str(exc),
+                current,
+                finished_at,
+            ),
+            now=finished_at,
         )
         return
 
@@ -364,14 +347,15 @@ async def run_extraction_worker(
             tasks.append(task)
 
         if not tasks:
-            try:
-                await asyncio.wait_for(
-                    stop_event.wait() if stop_event else asyncio.sleep(poll_interval),
-                    timeout=poll_interval,
-                )
-            except asyncio.TimeoutError:
-                continue
-            break
+            # No work available: sleep for the poll interval, or exit when asked.
+            if stop_event:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
+                except asyncio.TimeoutError:
+                    continue
+                break
+            await asyncio.sleep(poll_interval)
+            continue
 
         results = await asyncio.gather(*tasks, return_exceptions=True)
         for result in results:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
-from typing import cast
+from typing import Any, cast
 
 from fastapi import APIRouter, FastAPI
 from fastapi.exceptions import RequestValidationError
@@ -9,7 +9,11 @@ from starlette.types import ExceptionHandler
 
 from app.infrastructure.config.settings import get_settings
 from app.infrastructure.storage.mongo import ensure_database_setup, get_database
+from app.infrastructure.storage.s3 import S3StorageAdapter
 from app.observability import configure_logging
+from app.infrastructure.vlm.client import VLMClient
+from app.infrastructure.vlm.prompts import ENGLISH_EXTRACTION_SYSTEM_PROMPT
+from app.infrastructure.worker.extraction_worker import run_extraction_worker
 from app.infrastructure.worker.solution_worker import run_solution_worker
 from app.presentation.solution_generation import backfill_solution_generation_tasks
 from app.presentation.auth import router as auth_router
@@ -38,25 +42,75 @@ async def _run_worker_with_logging(database, stop_event):
         raise
 
 
+async def _run_extraction_worker_with_logging(database, storage, settings, stop_event):
+    math_client: VLMClient | None = None
+    english_client: VLMClient | None = None
+    try:
+        math_client = VLMClient(
+            endpoint=settings.math_ingestion_vlm_endpoint,
+            model=settings.math_ingestion_vlm_model,
+            api_key=settings.math_ingestion_vlm_api_key,
+            timeout_seconds=settings.math_ingestion_vlm_timeout_seconds,
+        )
+        english_client = VLMClient(
+            endpoint=settings.english_ingestion_vlm_endpoint,
+            model=settings.english_ingestion_vlm_model,
+            api_key=settings.english_ingestion_vlm_api_key,
+            timeout_seconds=settings.english_ingestion_vlm_timeout_seconds,
+            extraction_system_prompt=ENGLISH_EXTRACTION_SYSTEM_PROMPT,
+        )
+        await run_extraction_worker(
+            database,
+            storage,
+            settings,
+            math_client,
+            english_client,
+            stop_event,
+        )
+    except Exception:
+        logger.exception("Extraction worker crashed")
+        raise
+    finally:
+        if math_client is not None:
+            await math_client.aclose()
+        if english_client is not None:
+            await english_client.aclose()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     database = get_database()
     await ensure_database_setup(database)
     await backfill_solution_generation_tasks(database)
     
-    # Start worker
+    settings = get_settings()
+    storage = S3StorageAdapter(settings=settings)
+
+    # Start workers
     stop_event = asyncio.Event()
-    worker_task = asyncio.create_task(_run_worker_with_logging(database, stop_event))
+    worker_tasks: list[asyncio.Task[Any]] = [
+        asyncio.create_task(_run_worker_with_logging(database, stop_event)),
+    ]
+    if settings.bulk_ingestion_extraction_worker_enabled:
+        worker_tasks.append(
+            asyncio.create_task(
+                _run_extraction_worker_with_logging(database, storage, settings, stop_event)
+            )
+        )
     
     yield
     
-    # Stop worker
+    # Stop workers
     stop_event.set()
-    try:
-        # Give it a short time to shut down
-        await asyncio.wait_for(worker_task, timeout=5.0)
-    except asyncio.TimeoutError:
-        worker_task.cancel()
+    for task in worker_tasks:
+        try:
+            await asyncio.wait_for(task, timeout=5.0)
+        except asyncio.TimeoutError:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
 def create_app() -> FastAPI:

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -523,6 +523,8 @@ async def start_extraction(
     database: DatabaseDependency,
     user: CurrentUserDependency,
 ) -> dict[str, Any]:
+    # The global worker polls the database for queued items; this endpoint only
+    # confirms the batch is actionable and tells the client to start polling.
     await _load_owned_batch(database, batch_id, user["_id"])
     return {"batchId": batch_id, "status": "extracting"}
 

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -33,6 +33,7 @@ from app.infrastructure.ingestion.repository import (
     get_active_batch_for_user,
     get_batch,
     is_batch_expired,
+    reset_item_for_retry,
     save_image_boxes_and_subject,
     save_image_detection_failure,
     save_image_detection_success,
@@ -502,6 +503,51 @@ async def commit_image(
         image_id,
         now=datetime.now(UTC),
     )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch))
+
+
+def _find_item_or_404(batch: Document, item_id: str) -> dict[str, Any]:
+    for item in batch.get("items", []):
+        if item.get("itemId") == item_id:
+            return item
+    raise ApiError(404, "NOT_FOUND", "Item not found")
+
+
+@router.post("/{batch_id}/extract", status_code=202)
+async def start_extraction(
+    batch_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> dict[str, Any]:
+    await _load_owned_batch(database, batch_id, user["_id"])
+    return {"batchId": batch_id, "status": "extracting"}
+
+
+@router.post("/{batch_id}/items/{item_id}/retry", response_model=BatchResponse)
+async def retry_item(
+    batch_id: str,
+    item_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    await _load_owned_batch(database, batch_id, user["_id"])
+    retried = await reset_item_for_retry(
+        database,
+        batch_id,
+        user["_id"],
+        item_id,
+        now=datetime.now(UTC),
+    )
+    if not retried:
+        raise ApiError(
+            409,
+            "ITEM_NOT_RETRYABLE",
+            "Item is not in a failed or stalled state",
+        )
 
     updated_batch = await get_batch(database, batch_id, user["_id"])
     if updated_batch is None:

--- a/backend/app/presentation/deps.py
+++ b/backend/app/presentation/deps.py
@@ -182,4 +182,6 @@ async def get_grading_vlm_client(
 
 StorageDependency = Annotated[S3StorageAdapter, Depends(get_s3_storage)]
 HelperVLMDependency = Annotated[VLMClient, Depends(create_helper_vlm_client)]
+MathIngestionVLMDependency = Annotated[VLMClient, Depends(create_math_ingestion_vlm_client)]
+EnglishIngestionVLMDependency = Annotated[VLMClient, Depends(create_english_ingestion_vlm_client)]
 GradingVLMDependency = Annotated[VLMClient, Depends(get_grading_vlm_client)]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pymongo>=4.8.0,<5.0.0",
   "uvicorn>=0.30.0,<1.0.0",
   "python-multipart>=0.0.9",
+  "pillow>=10.0.0,<11.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -14,7 +14,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
-from app.infrastructure.vlm.client import DetectionResult, ProblemBox
+from app.infrastructure.vlm.client import DetectionResult, ExtractionResult, ProblemBox
 from app.main import create_app
 from app.presentation.deps import (
     create_helper_vlm_client,
@@ -76,6 +76,33 @@ class FakeHelperVLMClient:
         return response
 
 
+class FakeIngestionVLMClient:
+    def __init__(self, model: str = "fake-ingestion-vlm") -> None:
+        self._model = model
+        self.responses: list[Any] = []
+        self.calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def extract(
+        self,
+        *,
+        image_url: str | None = None,
+        image_base64: str | None = None,
+    ) -> ExtractionResult:
+        self.calls.append({"image_url": image_url, "image_base64": image_base64})
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
 def make_png_bytes() -> bytes:
     payload = base64.b64decode(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9l9iAAAAAASUVORK5CYII="
@@ -85,6 +112,37 @@ def make_png_bytes() -> bytes:
 
 def make_oversize_png_bytes(size: int) -> bytes:
     return b"\x89PNG\r\n\x1a\n" + b"\x00" * size
+
+
+def make_valid_png_bytes(*, width: int = 10, height: int = 10) -> bytes:
+    from PIL import Image
+    buffer = io.BytesIO()
+    Image.new("RGB", (width, height), color="black").save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def make_extraction_result(
+    *,
+    text: str = "What is 2+2?",
+    problem_type: str = "short-answer",
+    graph_dsl: str | None = None,
+    model: str = "fake-ingestion-vlm",
+) -> ExtractionResult:
+    raw = {
+        "text": text,
+        "problemType": problem_type,
+        "graphDsl": graph_dsl,
+        "providerMetadata": {"provider": "fake"},
+    }
+    return ExtractionResult(
+        request_type="ingestion",
+        model=model,
+        text=text,
+        problem_type=problem_type,
+        graph_dsl=graph_dsl,
+        provider_metadata=raw["providerMetadata"],
+        raw_provider_response=raw,
+    )
 
 
 def make_detection_result(
@@ -134,6 +192,32 @@ async def register_and_login(
     return user
 
 
+async def create_committed_item(
+    client: AsyncClient,
+    helper_vlm: FakeHelperVLMClient,
+    *,
+    subject: str = "math",
+) -> tuple[str, str, str]:
+    batch_id, image_id = await create_batch_with_image(client, image_bytes=make_valid_png_bytes())
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject=subject,
+            boxes=[ProblemBox(x=0, y=0, width=1, height=1)],
+        )
+    )
+    detect_response = await client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+    assert detect_response.status_code == 200
+
+    commit_response = await client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+    assert commit_response.status_code == 200
+    item_id = commit_response.json()["batch"]["items"][0]["itemId"]
+    return batch_id, image_id, item_id
+
+
 async def create_batch_with_image(
     client: AsyncClient,
     image_bytes: bytes | None = None,
@@ -167,13 +251,19 @@ async def bulk_app() -> AsyncIterator[FastAPI]:
         bulk_ingestion_max_images=3,
         bulk_ingestion_max_image_bytes=200,
         bulk_ingestion_batch_ttl_seconds=3600,
+        bulk_ingestion_extraction_worker_enabled=False,
+        bulk_ingestion_extraction_poll_interval_seconds=3600,
     )
 
     helper_vlm = FakeHelperVLMClient(model=settings.helper_vlm_model)
+    math_vlm = FakeIngestionVLMClient(model=settings.math_ingestion_vlm_model)
+    english_vlm = FakeIngestionVLMClient(model=settings.english_ingestion_vlm_model)
 
     application.state.fake_database = database
     application.state.fake_storage = storage
     application.state.fake_helper_vlm = helper_vlm
+    application.state.fake_math_ingestion_vlm = math_vlm
+    application.state.fake_english_ingestion_vlm = english_vlm
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_app_settings] = lambda: settings
@@ -202,6 +292,16 @@ async def authenticated_bulk_client(
 @pytest_asyncio.fixture
 async def helper_vlm(bulk_app: FastAPI) -> FakeHelperVLMClient:
     return bulk_app.state.fake_helper_vlm
+
+
+@pytest_asyncio.fixture
+async def math_ingestion_vlm(bulk_app: FastAPI) -> FakeIngestionVLMClient:
+    return bulk_app.state.fake_math_ingestion_vlm
+
+
+@pytest_asyncio.fixture
+async def english_ingestion_vlm(bulk_app: FastAPI) -> FakeIngestionVLMClient:
+    return bulk_app.state.fake_english_ingestion_vlm
 
 
 @pytest.mark.asyncio
@@ -830,5 +930,149 @@ async def test_delete_requires_authentication(
 ) -> None:
     response = await bulk_client.delete(
         f"/api/v1/ingestion-batches/{ObjectId()}/images/image-1"
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_start_extraction_returns_202(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, _image_id, _item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/extract"
+    )
+
+    assert response.status_code == 202
+    assert response.json()["batchId"] == batch_id
+
+
+@pytest.mark.asyncio
+async def test_extraction_populates_draft_after_worker_runs(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm, subject="math"
+    )
+
+    extract_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/extract"
+    )
+    assert extract_response.status_code == 202
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    storage: FakeStorage = bulk_app.state.fake_storage
+    batch = await database["ingestion_batches"].find_one({"_id": ObjectId(batch_id)})
+    assert batch is not None
+    item = batch["items"][0]
+
+    math_ingestion_vlm.responses.append(
+        make_extraction_result(text="Extracted math text", model="math-model")
+    )
+
+    from app.infrastructure.worker.extraction_worker import process_item
+    from app.infrastructure.config.settings import Settings as AppSettings
+
+    settings = AppSettings(s3_bucket="learnloop-media")
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_ingestion_vlm,
+        bulk_app.state.fake_english_ingestion_vlm,
+        settings,
+    )
+
+    active_response = await authenticated_bulk_client.get("/api/v1/ingestion-batches/active")
+    assert active_response.status_code == 200
+    items = active_response.json()["batch"]["items"]
+    assert len(items) == 1
+    assert items[0]["itemId"] == item_id
+    assert items[0]["status"] == "ready"
+    assert items[0]["draft"]["text"] == "Extracted math text"
+    assert items[0]["extraction"]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_retry_item_resets_failed_item(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm
+    )
+    database: FakeDatabase = bulk_app.state.fake_database
+    await database["ingestion_batches"].update_one(
+        {"_id": ObjectId(batch_id), "items.itemId": item_id},
+        {
+            "$set": {
+                "items.$.status": "failed",
+                "items.$.leaseUntil": None,
+            }
+        },
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/retry"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["batch"]["items"][0]["status"] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_retry_item_rejects_active_item(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm
+    )
+    database: FakeDatabase = bulk_app.state.fake_database
+    await database["ingestion_batches"].update_one(
+        {"_id": ObjectId(batch_id), "items.itemId": item_id},
+        {
+            "$set": {
+                "items.$.status": "extracting",
+                "items.$.leaseUntil": datetime.now(UTC) + timedelta(seconds=60),
+            }
+        },
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/retry"
+    )
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "ITEM_NOT_RETRYABLE"
+
+
+@pytest.mark.asyncio
+async def test_extract_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{ObjectId()}/extract"
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_retry_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{ObjectId()}/items/item-1/retry"
     )
     assert response.status_code == 401

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -166,10 +166,18 @@ class FakeCollection:
             if isinstance(update, list):
                 for stage in update:
                     for key, expr in stage.get("$set", {}).items():
-                        target_doc[key] = _eval_pipeline_expr(expr, target_doc)
+                        resolved_key = self._resolve_positional_key(
+                            target_doc, query, key
+                        )
+                        _set_nested(
+                            target_doc, resolved_key, _eval_pipeline_expr(expr, target_doc)
+                        )
             else:
                 for key, value in update.get("$set", {}).items():
-                    _set_nested(target_doc, key, deepcopy(value))
+                    resolved_key = self._resolve_positional_key(
+                        target_doc, query, key
+                    )
+                    _set_nested(target_doc, resolved_key, deepcopy(value))
             return FakeUpdateResult(1)
 
         if upsert:
@@ -221,9 +229,60 @@ class FakeCollection:
             if matches_query(document, query):
                 original_document = deepcopy(document)
                 for key, value in update.get("$set", {}).items():
-                    _set_nested(document, key, deepcopy(value))
+                    resolved_key = self._resolve_positional_key(document, query, key)
+                    _set_nested(document, resolved_key, deepcopy(value))
+                for key, value in update.get("$inc", {}).items():
+                    resolved_key = self._resolve_positional_key(document, query, key)
+                    _inc_nested(document, resolved_key, value)
+                if return_document:
+                    return deepcopy(document)
                 return original_document
         return None
+
+    def _resolve_positional_key(
+        self,
+        document: dict[str, Any],
+        query: dict[str, Any],
+        key: str,
+    ) -> str:
+        if ".$." not in key:
+            return key
+        array_path = key.split(".$.")[0]
+        index = self._resolve_array_index(document, query, array_path)
+        return key.replace(".$.", f".{index}.", 1)
+
+    def _resolve_array_index(
+        self,
+        document: dict[str, Any],
+        query: dict[str, Any],
+        array_path: str,
+    ) -> int:
+        spec = query.get(array_path)
+        if isinstance(spec, dict) and "$elemMatch" in spec:
+            elem_match = spec["$elemMatch"]
+            array_values = get_nested_values(document, array_path.split("."))
+            for arr in array_values:
+                if isinstance(arr, list):
+                    for index, item in enumerate(arr):
+                        if matches_query(item, elem_match):
+                            return index
+            return 0
+
+        elem_query: dict[str, Any] = {}
+        prefix = f"{array_path}."
+        for query_key, query_value in query.items():
+            if query_key.startswith(prefix):
+                field = query_key[len(prefix) :]
+                elem_query[field] = query_value
+        if not elem_query:
+            return 0
+        array_values = get_nested_values(document, array_path.split("."))
+        for arr in array_values:
+            if isinstance(arr, list):
+                for index, item in enumerate(arr):
+                    if matches_query(item, elem_query):
+                        return index
+        return 0
 
     async def delete_one(self, query: dict[str, Any], session: Any | None = None) -> FakeDeleteResult:
         if self._delete_one_error is not None:
@@ -327,9 +386,11 @@ class FakeStorage:
         self.delete_calls: list[tuple[str, str]] = []
         self._counter = 0
 
-    def build_object_key(self, user_id: str, extension: str) -> str:
+    def build_object_key(
+        self, user_id: str, extension: str, *, category: str = "images"
+    ) -> str:
         self._counter += 1
-        return f"users/{user_id}/ingestion/preview-{self._counter}{extension}"
+        return f"users/{user_id}/{category}/preview-{self._counter}{extension}"
 
     def put_object(self, bucket: str, object_key: str, payload: bytes, content_type: str | None) -> None:
         self._objects[(bucket, object_key)] = payload
@@ -380,6 +441,18 @@ def matches_query(document: dict[str, Any], query: dict[str, Any]) -> bool:
         candidates = get_nested_values(document, parts)
 
         if isinstance(value, dict) and any(k.startswith("$") for k in value.keys()):
+            if "$elemMatch" in value:
+                matched = False
+                for candidate in candidates:
+                    if isinstance(candidate, list) and any(
+                        matches_query(item, value["$elemMatch"]) for item in candidate
+                    ):
+                        matched = True
+                        break
+                if not matched:
+                    return False
+                continue
+
             for op, op_val in value.items():
                 if op == "$options":
                     continue
@@ -460,10 +533,28 @@ def _set_nested(document: dict[str, Any], path: str, value: Any) -> None:
     parts = path.split(".")
     target = document
     for part in parts[:-1]:
-        if part not in target or not isinstance(target[part], dict):
+        if part.isdigit():
+            target = target[int(part)]
+        elif part in target and isinstance(target[part], list):
+            target = target[part]
+        elif part not in target or not isinstance(target[part], dict):
             target[part] = {}
-        target = target[part]
+            target = target[part]
+        else:
+            target = target[part]
     target[parts[-1]] = value
+
+
+def _inc_nested(document: dict[str, Any], path: str, value: Any) -> None:
+    parts = path.split(".")
+    target = document
+    for part in parts[:-1]:
+        if part.isdigit():
+            target = target[int(part)]
+        else:
+            target = target[part]
+    current = target.get(parts[-1], 0)
+    target[parts[-1]] = current + value
 
 
 def _eval_pipeline_expr(expr: Any, doc: dict[str, Any]) -> Any:

--- a/backend/tests/worker/test_extraction_worker.py
+++ b/backend/tests/worker/test_extraction_worker.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+import io
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from bson import ObjectId
+
+from app.domain.ingestion import ImageState, ItemState
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.ingestion.documents import (
+    build_batch_document,
+    build_image_document,
+    build_item_document,
+    build_source_image,
+)
+from app.infrastructure.ingestion.repository import (
+    claim_item,
+    get_batch,
+    reset_item_for_retry,
+)
+from app.infrastructure.vlm.client import ExtractionResult
+from app.infrastructure.worker.extraction_worker import (
+    _is_item_claimable,
+    claim_next_item,
+    process_item,
+)
+from tests.conftest import FakeDatabase, FakeStorage
+
+
+class FakeIngestionVLMClient:
+    def __init__(self, model: str = "fake-ingestion-vlm") -> None:
+        self._model = model
+        self.responses: list[Any] = []
+        self.calls: list[dict[str, Any]] = []
+        self.closed = False
+
+    @property
+    def model(self) -> str:
+        return self._model
+
+    async def extract(
+        self,
+        *,
+        image_url: str | None = None,
+        image_base64: str | None = None,
+    ) -> ExtractionResult:
+        self.calls.append({"image_url": image_url, "image_base64": image_base64})
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def make_png_bytes() -> bytes:
+    from PIL import Image
+    buffer = io.BytesIO()
+    Image.new("RGB", (10, 10), color="black").save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def make_extraction_result(
+    *,
+    text: str = "What is 2+2?",
+    problem_type: str = "short-answer",
+    graph_dsl: str | None = None,
+    model: str = "fake-ingestion-vlm",
+) -> ExtractionResult:
+    raw = {
+        "text": text,
+        "problemType": problem_type,
+        "graphDsl": graph_dsl,
+        "providerMetadata": {"provider": "fake"},
+    }
+    return ExtractionResult(
+        request_type="ingestion",
+        model=model,
+        text=text,
+        problem_type=problem_type,
+        graph_dsl=graph_dsl,
+        provider_metadata=raw["providerMetadata"],
+        raw_provider_response=raw,
+    )
+
+
+def _seed_batch_with_committed_item(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    *,
+    subject: str = "math",
+    box: dict[str, Any] | None = None,
+    item_status: str = ItemState.QUEUED.value,
+    lease_until: datetime | None = None,
+    retry_count: int = 0,
+) -> tuple[ObjectId, ObjectId, str, str]:
+    user_id = ObjectId()
+    batch_id = ObjectId()
+    image_id = "image-1"
+    item_id = "item-1"
+    now = datetime.now(UTC)
+
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/source.png",
+        content_type="image/png",
+        size_bytes=len(make_png_bytes()),
+        sha256="sha",
+        uploaded_at=now,
+        width=10,
+        height=10,
+    )
+    image = build_image_document(
+        image_id=image_id,
+        source_image=source_image,
+        order=0,
+        now=now,
+    )
+    image["status"] = ImageState.COMMITTED.value
+    image["subject"] = subject
+    image["boxes"] = [box] if box else []
+    image["committedAt"] = now
+
+    item = build_item_document(
+        item_id=item_id,
+        batch_id=batch_id,
+        image_id=image_id,
+        order=0,
+        now=now,
+        box=box,
+    )
+    item["status"] = item_status
+    item["leaseUntil"] = lease_until
+    item["retryCount"] = retry_count
+
+    batch = build_batch_document(
+        batch_id=batch_id,
+        user_id=user_id,
+        expires_at=now + timedelta(hours=1),
+        now=now,
+    )
+    batch["images"] = [image]
+    batch["items"] = [item]
+
+    database.seed("ingestion_batches", [batch])
+    storage.seed("media", "users/u/source.png", make_png_bytes())
+    return batch_id, user_id, image_id, item_id
+
+
+@pytest.fixture
+def database() -> FakeDatabase:
+    return FakeDatabase()
+
+
+@pytest.fixture
+def storage() -> FakeStorage:
+    return FakeStorage()
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        s3_bucket="media",
+        bulk_ingestion_item_lease_timeout_seconds=60,
+        bulk_ingestion_extraction_concurrency=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_item_claimable_queued() -> None:
+    assert _is_item_claimable({"status": ItemState.QUEUED.value}, datetime.now(UTC)) is True
+
+
+@pytest.mark.asyncio
+async def test_is_item_claimable_extracting_with_expired_lease() -> None:
+    now = datetime.now(UTC)
+    assert (
+        _is_item_claimable(
+            {"status": ItemState.EXTRACTING.value, "leaseUntil": now - timedelta(seconds=1)},
+            now,
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_is_item_claimable_not_ready() -> None:
+    now = datetime.now(UTC)
+    assert _is_item_claimable({"status": ItemState.READY.value}, now) is False
+    assert (
+        _is_item_claimable(
+            {"status": ItemState.EXTRACTING.value, "leaseUntil": now + timedelta(seconds=1)},
+            now,
+        )
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_claim_item_sets_extracting_and_lease(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    user_id = batch["userId"]
+    now = datetime.now(UTC)
+
+    claimed = await claim_item(
+        database,
+        batch_id,
+        item_id,
+        user_id,
+        lease_timeout_seconds=settings.bulk_ingestion_item_lease_timeout_seconds,
+        now=now,
+    )
+
+    assert claimed is not None
+    assert claimed["status"] == ItemState.EXTRACTING.value
+    assert claimed["retryCount"] == 1
+    assert claimed["leaseUntil"] > now
+
+    refreshed = await get_batch(database, batch_id, user_id)
+    stored_item = refreshed["items"][0]
+    assert stored_item["status"] == ItemState.EXTRACTING.value
+
+
+@pytest.mark.asyncio
+async def test_claim_item_returns_none_when_lease_active(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    now = datetime.now(UTC)
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.EXTRACTING.value,
+        lease_until=now + timedelta(seconds=30),
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    user_id = batch["userId"]
+
+    claimed = await claim_item(
+        database,
+        batch_id,
+        item_id,
+        user_id,
+        lease_timeout_seconds=settings.bulk_ingestion_item_lease_timeout_seconds,
+        now=now,
+    )
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_process_item_success_math(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+    math_client.responses.append(make_extraction_result(text="math problem", model="math-model"))
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    assert len(math_client.calls) == 1
+    assert len(english_client.calls) == 0
+    assert storage.put_calls[-1][0] == "media"
+    assert storage.put_calls[-1][1].startswith("users/") and "ingestion/crops" in storage.put_calls[-1][1]
+
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    stored_item = refreshed["items"][0]
+    assert stored_item["status"] == ItemState.READY.value
+    assert stored_item["draft"]["text"] == "math problem"
+    assert stored_item["draft"]["subject"] == "math"
+    assert stored_item["extraction"]["success"] is True
+    assert stored_item["extraction"]["model"] == "math-model"
+    assert stored_item["crop"] is not None
+    assert stored_item["leaseUntil"] is None
+
+
+@pytest.mark.asyncio
+async def test_process_item_routes_to_english_client(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="english",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+    english_client.responses.append(make_extraction_result(text="english problem", model="english-model"))
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    assert len(math_client.calls) == 0
+    assert len(english_client.calls) == 1
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    assert refreshed["items"][0]["extraction"]["model"] == "english-model"
+
+
+@pytest.mark.asyncio
+async def test_process_item_failure_isolated(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    math_client.responses.append(RuntimeError("boom"))
+    english_client = FakeIngestionVLMClient(model="english-model")
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    stored_item = refreshed["items"][0]
+    assert stored_item["status"] == ItemState.FAILED.value
+    assert stored_item["extraction"]["success"] is False
+    assert stored_item["extraction"]["failureCode"] == "extraction-failed"
+
+
+@pytest.mark.asyncio
+async def test_process_item_source_missing_marks_failed(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    # Remove the source object so storage read fails
+    storage._objects.clear()
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    stored_item = refreshed["items"][0]
+    assert stored_item["status"] == ItemState.FAILED.value
+    assert stored_item["extraction"]["failureCode"] == "storage-read-failed"
+
+
+@pytest.mark.asyncio
+async def test_reset_item_for_retry(
+    database: FakeDatabase,
+    storage: FakeStorage,
+) -> None:
+    now = datetime.now(UTC)
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.FAILED.value,
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    user_id = batch["userId"]
+
+    retried = await reset_item_for_retry(database, batch_id, user_id, item_id, now=now)
+
+    assert retried is True
+    refreshed = await get_batch(database, batch_id, user_id)
+    stored_item = refreshed["items"][0]
+    assert stored_item["status"] == ItemState.QUEUED.value
+    assert stored_item["leaseUntil"] is None
+
+
+@pytest.mark.asyncio
+async def test_reset_item_for_retry_stalled_extraction(
+    database: FakeDatabase,
+    storage: FakeStorage,
+) -> None:
+    now = datetime.now(UTC)
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.EXTRACTING.value,
+        lease_until=now - timedelta(seconds=1),
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    user_id = batch["userId"]
+
+    retried = await reset_item_for_retry(database, batch_id, user_id, item_id, now=now)
+
+    assert retried is True
+    refreshed = await get_batch(database, batch_id, user_id)
+    assert refreshed["items"][0]["status"] == ItemState.QUEUED.value
+
+
+@pytest.mark.asyncio
+async def test_reset_item_for_retry_rejects_active_extraction(
+    database: FakeDatabase,
+    storage: FakeStorage,
+) -> None:
+    now = datetime.now(UTC)
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.EXTRACTING.value,
+        lease_until=now + timedelta(seconds=30),
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    user_id = batch["userId"]
+
+    retried = await reset_item_for_retry(database, batch_id, user_id, item_id, now=now)
+
+    assert retried is False
+
+
+@pytest.mark.asyncio
+async def test_claim_next_item_respects_active_lease(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    now = datetime.now(UTC)
+    batch_id, _user_id, _image_id, _item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.EXTRACTING.value,
+        lease_until=now + timedelta(seconds=30),
+    )
+
+    claimed = await claim_next_item(database, settings, now=now)
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_claim_next_item_recovers_expired_lease(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    now = datetime.now(UTC)
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.EXTRACTING.value,
+        lease_until=now - timedelta(seconds=1),
+    )
+
+    claimed = await claim_next_item(database, settings, now=now)
+
+    assert claimed is not None
+    _batch, item = claimed
+    assert item["itemId"] == item_id
+    assert item["status"] == ItemState.EXTRACTING.value
+
+
+@pytest.mark.asyncio
+async def test_claim_next_item_skips_completed_items(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    _batch_id, _user_id, _image_id, _item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.READY.value,
+    )
+
+    claimed = await claim_next_item(database, settings, now=datetime.now(UTC))
+
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_process_item_completed_item_not_reextracted(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, _item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+        item_status=ItemState.READY.value,
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+
+    # process_item does not guard status itself; claim_item does. Calling it directly on a
+    # ready item would re-extract, so this test documents that completed items must be
+    # filtered by the claim layer.
+    claimed = await claim_next_item(database, settings, now=datetime.now(UTC))
+    assert claimed is None
+    assert len(math_client.calls) == 0

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,149 +1,149 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.*"
 
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
 ]
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53" },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
 name = "anyio"
 version = "4.13.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
 name = "bcrypt"
 version = "4.3.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/5d/6d7433e0f3cd46ce0b43cd65e1db465ea024dbb8216fb2404e919c2ad77b/bcrypt-4.3.0.tar.gz", hash = "sha256:3a3fd2204178b6d2adcf09cb4f6426ffef54762577a7c9b54c159008cb288c18", size = 25697, upload-time = "2025-02-28T01:24:09.174Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/11/22/5ada0b9af72b60cbc4c9a399fdde4af0feaa609d27eb0adc61607997a3fa/bcrypt-4.3.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d", size = 498019, upload-time = "2025-02-28T01:23:05.838Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/b8/8c/252a1edc598dc1ce57905be173328eda073083826955ee3c97c7ff5ba584/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b", size = 279174, upload-time = "2025-02-28T01:23:07.274Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/29/5b/4547d5c49b85f0337c13929f2ccbe08b7283069eea3550a457914fc078aa/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e", size = 283870, upload-time = "2025-02-28T01:23:09.151Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/be/21/7dbaf3fa1745cb63f776bb046e481fbababd7d344c5324eab47f5ca92dd2/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59", size = 279601, upload-time = "2025-02-28T01:23:11.461Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/6d/64/e042fc8262e971347d9230d9abbe70d68b0a549acd8611c83cebd3eaec67/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753", size = 297660, upload-time = "2025-02-28T01:23:12.989Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/50/b8/6294eb84a3fef3b67c69b4470fcdd5326676806bf2519cda79331ab3c3a9/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761", size = 284083, upload-time = "2025-02-28T01:23:14.5Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/62/e6/baff635a4f2c42e8788fe1b1633911c38551ecca9a749d1052d296329da6/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb", size = 279237, upload-time = "2025-02-28T01:23:16.686Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/39/48/46f623f1b0c7dc2e5de0b8af5e6f5ac4cc26408ac33f3d424e5ad8da4a90/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d", size = 283737, upload-time = "2025-02-28T01:23:18.897Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/49/8b/70671c3ce9c0fca4a6cc3cc6ccbaa7e948875a2e62cbd146e04a4011899c/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f", size = 312741, upload-time = "2025-02-28T01:23:21.041Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/27/fb/910d3a1caa2d249b6040a5caf9f9866c52114d51523ac2fb47578a27faee/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732", size = 316472, upload-time = "2025-02-28T01:23:23.183Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/dc/cf/7cf3a05b66ce466cfb575dbbda39718d45a609daa78500f57fa9f36fa3c0/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef", size = 343606, upload-time = "2025-02-28T01:23:25.361Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/e3/b8/e970ecc6d7e355c0d892b7f733480f4aa8509f99b33e71550242cf0b7e63/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304", size = 362867, upload-time = "2025-02-28T01:23:26.875Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/a9/97/8d3118efd8354c555a3422d544163f40d9f236be5b96c714086463f11699/bcrypt-4.3.0-cp38-abi3-win32.whl", hash = "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51", size = 160589, upload-time = "2025-02-28T01:23:28.381Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/29/07/416f0b99f7f3997c69815365babbc2e8754181a4b1899d921b3c7d5b6f12/bcrypt-4.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62", size = 152794, upload-time = "2025-02-28T01:23:30.187Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/6e/c1/3fa0e9e4e0bfd3fd77eb8b52ec198fd6e1fd7e9402052e43f23483f956dd/bcrypt-4.3.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3", size = 498969, upload-time = "2025-02-28T01:23:31.945Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ce/d4/755ce19b6743394787fbd7dff6bf271b27ee9b5912a97242e3caf125885b/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24", size = 279158, upload-time = "2025-02-28T01:23:34.161Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/9b/5d/805ef1a749c965c46b28285dfb5cd272a7ed9fa971f970435a5133250182/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef", size = 284285, upload-time = "2025-02-28T01:23:35.765Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ab/2b/698580547a4a4988e415721b71eb45e80c879f0fb04a62da131f45987b96/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b", size = 279583, upload-time = "2025-02-28T01:23:38.021Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/f2/87/62e1e426418204db520f955ffd06f1efd389feca893dad7095bf35612eec/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676", size = 297896, upload-time = "2025-02-28T01:23:39.575Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/cb/c6/8fedca4c2ada1b6e889c52d2943b2f968d3427e5d65f595620ec4c06fa2f/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1", size = 284492, upload-time = "2025-02-28T01:23:40.901Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/4d/4d/c43332dcaaddb7710a8ff5269fcccba97ed3c85987ddaa808db084267b9a/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe", size = 279213, upload-time = "2025-02-28T01:23:42.653Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/dc/7f/1e36379e169a7df3a14a1c160a49b7b918600a6008de43ff20d479e6f4b5/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0", size = 284162, upload-time = "2025-02-28T01:23:43.964Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/1c/0a/644b2731194b0d7646f3210dc4d80c7fee3ecb3a1f791a6e0ae6bb8684e3/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f", size = 312856, upload-time = "2025-02-28T01:23:46.011Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/dc/62/2a871837c0bb6ab0c9a88bf54de0fc021a6a08832d4ea313ed92a669d437/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23", size = 316726, upload-time = "2025-02-28T01:23:47.575Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/0c/a1/9898ea3faac0b156d457fd73a3cb9c2855c6fd063e44b8522925cdd8ce46/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe", size = 343664, upload-time = "2025-02-28T01:23:49.059Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/4c/b1/1289e21d710496b88340369137cc4c5f6ee036401190ea116a7b4ae6d32a/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a839320bf27d474e52ef8cb16449bb2ce0ba03ca9f44daba6d93fa1d8828e48a", size = 275103, upload-time = "2025-02-28T01:24:00.764Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/94/41/19be9fe17e4ffc5d10b7b67f10e459fc4eee6ffe9056a88de511920cfd8d/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:bdc6a24e754a555d7316fa4774e64c6c3997d27ed2d1964d55920c7c227bc4ce", size = 280513, upload-time = "2025-02-28T01:24:02.243Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/aa/73/05687a9ef89edebdd8ad7474c16d8af685eb4591c3c38300bb6aad4f0076/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:55a935b8e9a1d2def0626c4269db3fcd26728cbff1e84f0341465c31c4ee56d8", size = 274685, upload-time = "2025-02-28T01:24:04.512Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/63/13/47bba97924ebe86a62ef83dc75b7c8a881d53c535f83e2c54c4bd701e05c/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:57967b7a28d855313a963aaea51bf6df89f833db4320da458e5b3c5ab6d4c938", size = 280110, upload-time = "2025-02-28T01:24:05.896Z" },
+    { url = "https://files.pythonhosted.org/packages/11/22/5ada0b9af72b60cbc4c9a399fdde4af0feaa609d27eb0adc61607997a3fa/bcrypt-4.3.0-cp38-abi3-macosx_10_12_universal2.whl", hash = "sha256:f81b0ed2639568bf14749112298f9e4e2b28853dab50a8b357e31798686a036d", size = 498019, upload-time = "2025-02-28T01:23:05.838Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8c/252a1edc598dc1ce57905be173328eda073083826955ee3c97c7ff5ba584/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:864f8f19adbe13b7de11ba15d85d4a428c7e2f344bac110f667676a0ff84924b", size = 279174, upload-time = "2025-02-28T01:23:07.274Z" },
+    { url = "https://files.pythonhosted.org/packages/29/5b/4547d5c49b85f0337c13929f2ccbe08b7283069eea3550a457914fc078aa/bcrypt-4.3.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e36506d001e93bffe59754397572f21bb5dc7c83f54454c990c74a468cd589e", size = 283870, upload-time = "2025-02-28T01:23:09.151Z" },
+    { url = "https://files.pythonhosted.org/packages/be/21/7dbaf3fa1745cb63f776bb046e481fbababd7d344c5324eab47f5ca92dd2/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:842d08d75d9fe9fb94b18b071090220697f9f184d4547179b60734846461ed59", size = 279601, upload-time = "2025-02-28T01:23:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/64/e042fc8262e971347d9230d9abbe70d68b0a549acd8611c83cebd3eaec67/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:7c03296b85cb87db865d91da79bf63d5609284fc0cab9472fdd8367bbd830753", size = 297660, upload-time = "2025-02-28T01:23:12.989Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/6294eb84a3fef3b67c69b4470fcdd5326676806bf2519cda79331ab3c3a9/bcrypt-4.3.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:62f26585e8b219cdc909b6a0069efc5e4267e25d4a3770a364ac58024f62a761", size = 284083, upload-time = "2025-02-28T01:23:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e6/baff635a4f2c42e8788fe1b1633911c38551ecca9a749d1052d296329da6/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:beeefe437218a65322fbd0069eb437e7c98137e08f22c4660ac2dc795c31f8bb", size = 279237, upload-time = "2025-02-28T01:23:16.686Z" },
+    { url = "https://files.pythonhosted.org/packages/39/48/46f623f1b0c7dc2e5de0b8af5e6f5ac4cc26408ac33f3d424e5ad8da4a90/bcrypt-4.3.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:97eea7408db3a5bcce4a55d13245ab3fa566e23b4c67cd227062bb49e26c585d", size = 283737, upload-time = "2025-02-28T01:23:18.897Z" },
+    { url = "https://files.pythonhosted.org/packages/49/8b/70671c3ce9c0fca4a6cc3cc6ccbaa7e948875a2e62cbd146e04a4011899c/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:191354ebfe305e84f344c5964c7cd5f924a3bfc5d405c75ad07f232b6dffb49f", size = 312741, upload-time = "2025-02-28T01:23:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/910d3a1caa2d249b6040a5caf9f9866c52114d51523ac2fb47578a27faee/bcrypt-4.3.0-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:41261d64150858eeb5ff43c753c4b216991e0ae16614a308a15d909503617732", size = 316472, upload-time = "2025-02-28T01:23:23.183Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/cf/7cf3a05b66ce466cfb575dbbda39718d45a609daa78500f57fa9f36fa3c0/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:33752b1ba962ee793fa2b6321404bf20011fe45b9afd2a842139de3011898fef", size = 343606, upload-time = "2025-02-28T01:23:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b8/e970ecc6d7e355c0d892b7f733480f4aa8509f99b33e71550242cf0b7e63/bcrypt-4.3.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:50e6e80a4bfd23a25f5c05b90167c19030cf9f87930f7cb2eacb99f45d1c3304", size = 362867, upload-time = "2025-02-28T01:23:26.875Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/97/8d3118efd8354c555a3422d544163f40d9f236be5b96c714086463f11699/bcrypt-4.3.0-cp38-abi3-win32.whl", hash = "sha256:67a561c4d9fb9465ec866177e7aebcad08fe23aaf6fbd692a6fab69088abfc51", size = 160589, upload-time = "2025-02-28T01:23:28.381Z" },
+    { url = "https://files.pythonhosted.org/packages/29/07/416f0b99f7f3997c69815365babbc2e8754181a4b1899d921b3c7d5b6f12/bcrypt-4.3.0-cp38-abi3-win_amd64.whl", hash = "sha256:584027857bc2843772114717a7490a37f68da563b3620f78a849bcb54dc11e62", size = 152794, upload-time = "2025-02-28T01:23:30.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c1/3fa0e9e4e0bfd3fd77eb8b52ec198fd6e1fd7e9402052e43f23483f956dd/bcrypt-4.3.0-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3efb1157edebfd9128e4e46e2ac1a64e0c1fe46fb023158a407c7892b0f8c3", size = 498969, upload-time = "2025-02-28T01:23:31.945Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d4/755ce19b6743394787fbd7dff6bf271b27ee9b5912a97242e3caf125885b/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08bacc884fd302b611226c01014eca277d48f0a05187666bca23aac0dad6fe24", size = 279158, upload-time = "2025-02-28T01:23:34.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5d/805ef1a749c965c46b28285dfb5cd272a7ed9fa971f970435a5133250182/bcrypt-4.3.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6746e6fec103fcd509b96bacdfdaa2fbde9a553245dbada284435173a6f1aef", size = 284285, upload-time = "2025-02-28T01:23:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/698580547a4a4988e415721b71eb45e80c879f0fb04a62da131f45987b96/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:afe327968aaf13fc143a56a3360cb27d4ad0345e34da12c7290f1b00b8fe9a8b", size = 279583, upload-time = "2025-02-28T01:23:38.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/87/62e1e426418204db520f955ffd06f1efd389feca893dad7095bf35612eec/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d9af79d322e735b1fc33404b5765108ae0ff232d4b54666d46730f8ac1a43676", size = 297896, upload-time = "2025-02-28T01:23:39.575Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c6/8fedca4c2ada1b6e889c52d2943b2f968d3427e5d65f595620ec4c06fa2f/bcrypt-4.3.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f1e3ffa1365e8702dc48c8b360fef8d7afeca482809c5e45e653af82ccd088c1", size = 284492, upload-time = "2025-02-28T01:23:40.901Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/4d/c43332dcaaddb7710a8ff5269fcccba97ed3c85987ddaa808db084267b9a/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:3004df1b323d10021fda07a813fd33e0fd57bef0e9a480bb143877f6cba996fe", size = 279213, upload-time = "2025-02-28T01:23:42.653Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/1e36379e169a7df3a14a1c160a49b7b918600a6008de43ff20d479e6f4b5/bcrypt-4.3.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:531457e5c839d8caea9b589a1bcfe3756b0547d7814e9ce3d437f17da75c32b0", size = 284162, upload-time = "2025-02-28T01:23:43.964Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0a/644b2731194b0d7646f3210dc4d80c7fee3ecb3a1f791a6e0ae6bb8684e3/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:17a854d9a7a476a89dcef6c8bd119ad23e0f82557afbd2c442777a16408e614f", size = 312856, upload-time = "2025-02-28T01:23:46.011Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/62/2a871837c0bb6ab0c9a88bf54de0fc021a6a08832d4ea313ed92a669d437/bcrypt-4.3.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6fb1fd3ab08c0cbc6826a2e0447610c6f09e983a281b919ed721ad32236b8b23", size = 316726, upload-time = "2025-02-28T01:23:47.575Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a1/9898ea3faac0b156d457fd73a3cb9c2855c6fd063e44b8522925cdd8ce46/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e965a9c1e9a393b8005031ff52583cedc15b7884fce7deb8b0346388837d6cfe", size = 343664, upload-time = "2025-02-28T01:23:49.059Z" },
+    { url = "https://files.pythonhosted.org/packages/40/f2/71b4ed65ce38982ecdda0ff20c3ad1b15e71949c78b2c053df53629ce940/bcrypt-4.3.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:79e70b8342a33b52b55d93b3a59223a844962bef479f6a0ea318ebbcadf71505", size = 363128, upload-time = "2025-02-28T01:23:50.399Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/12f6a58eca6dea4be992d6c681b7ec9410a1d9f5cf368c61437e31daa879/bcrypt-4.3.0-cp39-abi3-win32.whl", hash = "sha256:b4d4e57f0a63fd0b358eb765063ff661328f69a04494427265950c71b992a39a", size = 160598, upload-time = "2025-02-28T01:23:51.775Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/cf/45fb5261ece3e6b9817d3d82b2f343a505fd58674a92577923bc500bd1aa/bcrypt-4.3.0-cp39-abi3-win_amd64.whl", hash = "sha256:e53e074b120f2877a35cc6c736b8eb161377caae8925c17688bd46ba56daaa5b", size = 152799, upload-time = "2025-02-28T01:23:53.139Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/b1/1289e21d710496b88340369137cc4c5f6ee036401190ea116a7b4ae6d32a/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:a839320bf27d474e52ef8cb16449bb2ce0ba03ca9f44daba6d93fa1d8828e48a", size = 275103, upload-time = "2025-02-28T01:24:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/94/41/19be9fe17e4ffc5d10b7b67f10e459fc4eee6ffe9056a88de511920cfd8d/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:bdc6a24e754a555d7316fa4774e64c6c3997d27ed2d1964d55920c7c227bc4ce", size = 280513, upload-time = "2025-02-28T01:24:02.243Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/73/05687a9ef89edebdd8ad7474c16d8af685eb4591c3c38300bb6aad4f0076/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:55a935b8e9a1d2def0626c4269db3fcd26728cbff1e84f0341465c31c4ee56d8", size = 274685, upload-time = "2025-02-28T01:24:04.512Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/47bba97924ebe86a62ef83dc75b7c8a881d53c535f83e2c54c4bd701e05c/bcrypt-4.3.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:57967b7a28d855313a963aaea51bf6df89f833db4320da458e5b3c5ab6d4c938", size = 280110, upload-time = "2025-02-28T01:24:05.896Z" },
 ]
 
 [[package]]
 name = "boto3"
 version = "1.43.7"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/6b/0d/67ebf496fe061397f7eb907504e950fe6d2fa5945fd05891f3033376e471/boto3-1.43.7.tar.gz", hash = "sha256:b1e4b40f4a828c67291b12ebefd17d87a57321101e4a0c969b2f593a0310f343", size = 113170, upload-time = "2026-05-13T19:35:48.556Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/0d/67ebf496fe061397f7eb907504e950fe6d2fa5945fd05891f3033376e471/boto3-1.43.7.tar.gz", hash = "sha256:b1e4b40f4a828c67291b12ebefd17d87a57321101e4a0c969b2f593a0310f343", size = 113170, upload-time = "2026-05-13T19:35:48.556Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/40/87/68fdfc7eaed69c4c77de1b9f1ddbd52e529510161baf9b2bf863be07aad1/boto3-1.43.7-py3-none-any.whl", hash = "sha256:7060f603ca0f645153ee2244506db4db5968a858cd513399d8df70637c362159", size = 140524, upload-time = "2026-05-13T19:35:44.879Z" },
+    { url = "https://files.pythonhosted.org/packages/40/87/68fdfc7eaed69c4c77de1b9f1ddbd52e529510161baf9b2bf863be07aad1/boto3-1.43.7-py3-none-any.whl", hash = "sha256:7060f603ca0f645153ee2244506db4db5968a858cd513399d8df70637c362159", size = 140524, upload-time = "2026-05-13T19:35:44.879Z" },
 ]
 
 [[package]]
 name = "botocore"
 version = "1.43.7"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ed/be/59144884fa71908e2ac389cfe0fd2ebe8e8adb47bcc994188eb59967406a/botocore-1.43.7.tar.gz", hash = "sha256:abbbc623c52dce86ea9d4534d35e2d6ce447d98edfdaced1695ee0278d6063e3", size = 15350131, upload-time = "2026-05-13T19:35:33.106Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/be/59144884fa71908e2ac389cfe0fd2ebe8e8adb47bcc994188eb59967406a/botocore-1.43.7.tar.gz", hash = "sha256:abbbc623c52dce86ea9d4534d35e2d6ce447d98edfdaced1695ee0278d6063e3", size = 15350131, upload-time = "2026-05-13T19:35:33.106Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/19/f3/a9beaae1cda959fa438b3937fc995d82b2a08cb117c67c31547580f19849/botocore-1.43.7-py3-none-any.whl", hash = "sha256:e93f25dc186a9de033c87128c0f2016aedd74aea9057d918bfc0703a946b1ad1", size = 15031637, upload-time = "2026-05-13T19:35:27.288Z" },
+    { url = "https://files.pythonhosted.org/packages/19/f3/a9beaae1cda959fa438b3937fc995d82b2a08cb117c67c31547580f19849/botocore-1.43.7-py3-none-any.whl", hash = "sha256:e93f25dc186a9de033c87128c0f2016aedd74aea9057d918bfc0703a946b1ad1", size = 15031637, upload-time = "2026-05-13T19:35:27.288Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2026.4.22"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
 ]
 
 [[package]]
 name = "click"
 version = "8.3.3"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
 ]
 
 [[package]]
 name = "dnspython"
 version = "2.8.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
 name = "fastapi"
 version = "0.136.1"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
@@ -151,73 +151,73 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
 ]
 
 [[package]]
 name = "h11"
 version = "0.16.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
 name = "httpcore"
 version = "1.0.9"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
 ]
 
 [[package]]
 name = "httpx"
 version = "0.28.1"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "certifi" },
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.15"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
 name = "jmespath"
 version = "1.1.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -229,6 +229,7 @@ dependencies = [
     { name = "boto3" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "pillow" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
@@ -248,6 +249,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.35.0,<2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "pillow", specifier = ">=10.0.0,<11.0.0" },
     { name = "pydantic", specifier = ">=2.7.0,<3.0.0" },
     { name = "pydantic-settings", extras = ["dotenv"], specifier = ">=2.3.0,<3.0.0" },
     { name = "pymongo", specifier = ">=4.8.0,<5.0.0" },
@@ -261,122 +263,141 @@ provides-extras = ["dev"]
 [[package]]
 name = "packaging"
 version = "26.2"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "10.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/74/ad3d526f3bf7b6d3f408b73fde271ec69dfac8b81341a318ce825f2b3812/pillow-10.4.0.tar.gz", hash = "sha256:166c1cd4d24309b30d61f79f4a9114b7b2313d7450912277855ff5dfd7cd4a06", size = 46555059, upload-time = "2024-07-01T09:48:43.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/62/c9449f9c3043c37f73e7487ec4ef0c03eb9c9afc91a92b977a67b3c0bbc5/pillow-10.4.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:0a9ec697746f268507404647e531e92889890a087e03681a3606d9b920fbee3c", size = 3509265, upload-time = "2024-07-01T09:45:49.812Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/491dafc7bbf5a3cc1845dc0430872e8096eb9e2b6f8161509d124594ec2d/pillow-10.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dfe91cb65544a1321e631e696759491ae04a2ea11d36715eca01ce07284738be", size = 3375655, upload-time = "2024-07-01T09:45:52.462Z" },
+    { url = "https://files.pythonhosted.org/packages/73/d5/c4011a76f4207a3c151134cd22a1415741e42fa5ddecec7c0182887deb3d/pillow-10.4.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5dc6761a6efc781e6a1544206f22c80c3af4c8cf461206d46a1e6006e4429ff3", size = 4340304, upload-time = "2024-07-01T09:45:55.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/10/c67e20445a707f7a610699bba4fe050583b688d8cd2d202572b257f46600/pillow-10.4.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e84b6cc6a4a3d76c153a6b19270b3526a5a8ed6b09501d3af891daa2a9de7d6", size = 4452804, upload-time = "2024-07-01T09:45:58.437Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/83/6523837906d1da2b269dee787e31df3b0acb12e3d08f024965a3e7f64665/pillow-10.4.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:bbc527b519bd3aa9d7f429d152fea69f9ad37c95f0b02aebddff592688998abe", size = 4365126, upload-time = "2024-07-01T09:46:00.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e5/8c68ff608a4203085158cff5cc2a3c534ec384536d9438c405ed6370d080/pillow-10.4.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:76a911dfe51a36041f2e756b00f96ed84677cdeb75d25c767f296c1c1eda1319", size = 4533541, upload-time = "2024-07-01T09:46:03.235Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7c/01b8dbdca5bc6785573f4cee96e2358b0918b7b2c7b60d8b6f3abf87a070/pillow-10.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:59291fb29317122398786c2d44427bbd1a6d7ff54017075b22be9d21aa59bd8d", size = 4471616, upload-time = "2024-07-01T09:46:05.356Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/57/2899b82394a35a0fbfd352e290945440e3b3785655a03365c0ca8279f351/pillow-10.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:416d3a5d0e8cfe4f27f574362435bc9bae57f679a7158e0096ad2beb427b8696", size = 4600802, upload-time = "2024-07-01T09:46:08.145Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d7/a44f193d4c26e58ee5d2d9db3d4854b2cfb5b5e08d360a5e03fe987c0086/pillow-10.4.0-cp311-cp311-win32.whl", hash = "sha256:7086cc1d5eebb91ad24ded9f58bec6c688e9f0ed7eb3dbbf1e4800280a896496", size = 2235213, upload-time = "2024-07-01T09:46:10.211Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d0/5866318eec2b801cdb8c82abf190c8343d8a1cd8bf5a0c17444a6f268291/pillow-10.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:cbed61494057c0f83b83eb3a310f0bf774b09513307c434d4366ed64f4128a91", size = 2554498, upload-time = "2024-07-01T09:46:12.685Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/310ac16ac2b97e902d9eb438688de0d961660a87703ad1561fd3dfbd2aa0/pillow-10.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:f5f0c3e969c8f12dd2bb7e0b15d5c468b51e5017e01e2e867335c81903046a22", size = 2243219, upload-time = "2024-07-01T09:46:14.83Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
 name = "pydantic"
 version = "2.13.4"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
 version = "2.46.4"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
 name = "pydantic-settings"
 version = "2.14.1"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]
 name = "pymongo"
 version = "4.17.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dnspython" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/64/50be6fbac9c79fe2e4c17401a467da2d8764d82833d83cec325afe5cab32/pymongo-4.17.0.tar.gz", hash = "sha256:70ffa08ba641468cc068cf46c06b34f01a8ce3489f6411309fcb5ceabe6b2fc0", size = 2523370, upload-time = "2026-04-20T16:39:53.524Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e2/336d86f221cf1b56b2ed9330d4a3b98f9f38f0b37829ae9a9184617d5419/pymongo-4.17.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4141e6c6a339789b2974efa00ecd9409101672d77a0e3ee2cc3839eedf8ec4df", size = 874668, upload-time = "2026-04-20T16:37:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8e/75d3c6c935d187ab59c61e9c15d9aab3f274b563eaf1706e8cae5f508dec/pymongo-4.17.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e68c76b84e0c132d9dbf9307f12ff8185702328187a87b9aca8c941303873433", size = 875294, upload-time = "2026-04-20T16:37:43.432Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ec/62e855744489dbcd54fd778aae4d80fa4c4819e8fb228ca0cf6f21a03997/pymongo-4.17.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ba2195d4f386f839a52a23ea1cfd60ffaaba78a3d7841db51b7e433001139918", size = 1496233, upload-time = "2026-04-20T16:37:45.518Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e8/93e4e5e5ce8fdf8929dabeefe24aafa5ce046028eed0dfa8eeb936e72c49/pymongo-4.17.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8446ff4bfcb6ec2a2e50998c860986a1e992136f998b7f53e7a717fb8aa5a0b9", size = 1522927, upload-time = "2026-04-20T16:37:47.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/425dc1d21e0f17bdea0072fc463f662f7fa06d2852af52975c9eced3c07c/pymongo-4.17.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2a0d5ac205728c86e0a02192f1aa5f865b0d7d51f8df6101c01a69a7fc620d72", size = 1583468, upload-time = "2026-04-20T16:37:49.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9d/f08b07eeffda1a43c1759f0fa625e88ae12360996eb56d42aad832fa7dff/pymongo-4.17.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:485c8a8eaa4c739f00a331fc73757898ee7c092c214a79e63866ff76aaf282ff", size = 1572787, upload-time = "2026-04-20T16:37:51.061Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/c2/6855a07aafa7b894929af23675b6fb9634800ce43122b76a62f6eeb8da2a/pymongo-4.17.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2dfcc795f5b9fedbe179a11fdf6051581479d196582a3fe819a92a00e9b9969", size = 1526184, upload-time = "2026-04-20T16:37:53.358Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
 ]
 
 [[package]]
 name = "pytest"
 version = "8.4.2"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -384,126 +405,126 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
 version = "0.26.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
 ]
 
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427" },
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.2.2"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]
 name = "python-multipart"
 version = "0.0.28"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]
 name = "s3transfer"
 version = "0.17.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
 name = "starlette"
 version = "1.0.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
 ]
 
 [[package]]
 name = "typing-inspection"
 version = "0.4.2"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.7.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
 name = "uvicorn"
 version = "0.46.0"
-source = { registry = "https://mirrors.bfsu.edu.cn/pypi/web/simple" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://mirrors.bfsu.edu.cn/pypi/web/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]


### PR DESCRIPTION
## Summary

Implements backend extraction orchestration for committed bulk-ingestion items, including per-item crop generation, bounded-concurrency worker processing, recoverable leases, and retry.

## Linked Issue

Closes #364

## Issue Alignment

This PR implements the issue by:

- Generating cropped problem images from committed boxes and storing temporary crop media in S3.
- Claiming extraction work atomically using MongoDB item state/lease semantics.
- Adding an async API-triggered extraction start/resume operation that returns immediately while the client polls batch detail.
- Enforcing configured concurrency and lease timeouts in a global extraction worker.
- Routing extraction through math/english ingestion VLM clients based on the committed image subject.
- Persisting success/failure metadata, retry counts, model, raw extraction fields, and failure reason.
- Adding a retry operation for failed/stalled items.
- Ensuring completed items are not re-extracted.

Scope covered:

- Crop generation and storage.
- Atomic item claim/lease logic.
- Extraction worker with bounded concurrency.
- Extraction start/resume and retry API endpoints.
- Worker and API tests for the new behavior.

Out of scope / intentionally not included:

- Frontend extraction UI.
- Submit problem creation.
- Detection (already implemented in #363).
- New queue infrastructure such as Celery/Dramatiq.

## Implementation Notes

- Added `Pillow` as a minimal dependency for cropping source images.
- Item documents now store the source `box` at commit time so extraction can crop without recomputing the box index.
- `claim_item` uses a MongoDB `find_one_and_update` with `$elemMatch` and the positional `$` operator for atomic claims.
- `process_item` loads the source image, crops the box, uploads the crop, calls the subject-specific ingestion VLM, and records results.
- The global worker is started in the FastAPI lifespan when `bulk_ingestion_extraction_worker_enabled` is true; it loops, claims up to `bulk_ingestion_extraction_concurrency` items, and processes them concurrently.
- Tests use a disabled worker by default and drive extraction through direct worker helpers to keep assertions deterministic.
- Extended the shared `FakeCollection` query engine to support `$elemMatch` and positional `$` updates so the atomic claim/update paths are exercised in unit tests.

## Tests

Commands run:

- `uv run --extra dev pytest tests/worker tests/api tests/integration -q` — 286 passed
- `uv run --extra dev pytest tests -q` — 644 passed, 1 skipped

Automated tests added or updated:

- `tests/worker/test_extraction_worker.py` — claimability, atomic claim/lease, success/failure routing, retry/stall recovery, completed-item skipping.
- `tests/api/test_bulk_ingestion.py` — extraction start 202 response, extraction populates draft, retry resets failed items, retry rejects active items, auth checks.

Manual verification:

- Confirmed that the worker does not require process-local state to recover item status; stale leases are reclaimed via the claim query.

## Deviations From Issue Plan

None.

## Follow-Up Work

- #365 Implement draft review item and media-serving APIs.
- #366 Implement idempotent submit and problem creation workflow.
