### PR TITLE
feat(bulk-ingestion): implement draft review item and media-serving APIs

### DIFF
--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -564,6 +564,125 @@ async def reset_item_for_retry(
     return True
 
 
+async def update_item_draft(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    item_id: str,
+    *,
+    draft_update: dict[str, Any],
+    now: datetime,
+) -> dict[str, Any] | None:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    updated_item: dict[str, Any] | None = None
+    for item in items:
+        if item.get("itemId") != item_id:
+            continue
+        draft = dict(item.get("draft", {}))
+        allowed = {"text", "problemType", "graphDsl", "correctAnswer", "tags", "subject"}
+        for key, value in draft_update.items():
+            if key in allowed:
+                draft[key] = value
+        item["draft"] = draft
+        item["updatedAt"] = now
+        updated_item = item
+        break
+
+    if updated_item is None:
+        return None
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"items": items, "updatedAt": now}},
+    )
+    return updated_item
+
+
+async def mark_item_deleted(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    item_id: str,
+    *,
+    now: datetime,
+) -> bool:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    changed = False
+    for item in items:
+        if item.get("itemId") != item_id:
+            continue
+        status = item.get("status")
+        if status in {ItemState.DELETED.value, ItemState.SUBMITTED.value}:
+            return True
+        item["previousStatus"] = status
+        item["status"] = ItemState.DELETED.value
+        item["deletedAt"] = now
+        item["updatedAt"] = now
+        changed = True
+        break
+
+    if not changed:
+        return False
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"items": items, "updatedAt": now}},
+    )
+    return True
+
+
+async def undo_item_deletion(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    item_id: str,
+    *,
+    now: datetime,
+) -> bool:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    items = list(batch.get("items", []))
+    changed = False
+    for item in items:
+        if item.get("itemId") != item_id:
+            continue
+        if item.get("status") != ItemState.DELETED.value:
+            return False
+        previous_status = item.pop("previousStatus", None)
+        if previous_status is None:
+            return False
+        item["status"] = previous_status
+        item.pop("deletedAt", None)
+        item["updatedAt"] = now
+        changed = True
+        break
+
+    if not changed:
+        return False
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": {"items": items, "updatedAt": now}},
+    )
+    return True
+
+
 async def find_cleanup_candidates(
     database: Any,
     *,

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 import base64
+from io import BytesIO
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +24,7 @@ from app.domain.ingestion import (
     transition_image_state,
     validate_boxes,
 )
+from app.domain.models import ProblemSubject, ProblemType
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.ingestion.documents import build_source_image
 from app.infrastructure.ingestion.image_size import get_image_size
@@ -33,14 +36,17 @@ from app.infrastructure.ingestion.repository import (
     get_active_batch_for_user,
     get_batch,
     is_batch_expired,
+    mark_item_deleted,
     reset_item_for_retry,
     save_image_boxes_and_subject,
     save_image_detection_failure,
     save_image_detection_success,
     start_image_detection,
+    undo_item_deletion,
+    update_item_draft,
 )
 from app.infrastructure.storage.mongo import Document
-from app.infrastructure.storage.s3 import S3StorageAdapter
+from app.infrastructure.storage.s3 import S3StorageAdapter, StorageObjectNotFoundError
 from app.infrastructure.vlm.base_client import BaseVLMError
 from app.presentation.deps import (
     DatabaseDependency,
@@ -50,7 +56,12 @@ from app.presentation.deps import (
     get_s3_storage,
 )
 from app.presentation.errors import ApiError
-from app.presentation.helpers import parse_object_id
+from app.presentation.helpers import (
+    build_ingestion_crop_url,
+    build_ingestion_source_image_url,
+    normalize_tags,
+    parse_object_id,
+)
 from app.presentation.schemas import SourceImagePayload
 
 router = APIRouter(prefix="/ingestion-batches", tags=["bulk-ingestion"])
@@ -124,8 +135,12 @@ def _guess_extension(upload: UploadFile) -> str:
     return ".bin"
 
 
-def _serialize_source_image(source_image: dict[str, Any]) -> dict[str, Any]:
-    return {
+def _serialize_source_image(
+    source_image: dict[str, Any],
+    batch_id: str | None = None,
+    image_id: str | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
         "bucket": source_image["bucket"],
         "objectKey": source_image["objectKey"],
         "contentType": source_image.get("contentType"),
@@ -135,15 +150,20 @@ def _serialize_source_image(source_image: dict[str, Any]) -> dict[str, Any]:
         "height": source_image.get("height"),
         "uploadedAt": source_image.get("uploadedAt"),
     }
+    if batch_id and image_id:
+        data["mediaUrl"] = build_ingestion_source_image_url(batch_id, image_id)
+    return data
 
 
-def _serialize_image(image: dict[str, Any]) -> dict[str, Any]:
+def _serialize_image(image: dict[str, Any], batch_id: str | None = None) -> dict[str, Any]:
     detection = image.get("detection") or {}
     return {
         "imageId": image["imageId"],
         "status": image["status"],
         "order": image["order"],
-        "sourceImage": _serialize_source_image(image.get("sourceImage") or {}),
+        "sourceImage": _serialize_source_image(
+            image.get("sourceImage") or {}, batch_id=batch_id, image_id=image.get("imageId")
+        ),
         "subject": image.get("subject"),
         "boxes": list(image.get("boxes", [])),
         "detection": {
@@ -158,7 +178,11 @@ def _serialize_image(image: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _serialize_item(item: dict[str, Any]) -> dict[str, Any]:
+def _serialize_item(item: dict[str, Any], batch_id: str | None = None) -> dict[str, Any]:
+    crop = item.get("crop")
+    if crop and batch_id:
+        crop = dict(crop)
+        crop["mediaUrl"] = build_ingestion_crop_url(batch_id, item["itemId"])
     return {
         "itemId": item["itemId"],
         "imageId": item["imageId"],
@@ -170,29 +194,34 @@ def _serialize_item(item: dict[str, Any]) -> dict[str, Any]:
         "retryCount": item.get("retryCount", 0),
         "submit": dict(item.get("submit", {})),
         "origin": dict(item.get("origin", {})),
-        "crop": item.get("crop"),
+        "crop": crop,
         "leaseUntil": item.get("leaseUntil"),
         "createdAt": item["createdAt"],
         "updatedAt": item["updatedAt"],
     }
 
 
-def serialize_batch(batch: Document) -> dict[str, Any]:
-    images = [
-        image for image in batch.get("images", [])
-        if image.get("status") != ImageState.DELETED.value
-    ]
-    items = [
-        item for item in batch.get("items", [])
-        if item.get("status") != ItemState.DELETED.value
-    ]
+def serialize_batch(batch: Document, *, include_deleted: bool = False) -> dict[str, Any]:
+    batch_id = str(batch["_id"])
+    if include_deleted:
+        images = list(batch.get("images", []))
+        items = list(batch.get("items", []))
+    else:
+        images = [
+            image for image in batch.get("images", [])
+            if image.get("status") != ImageState.DELETED.value
+        ]
+        items = [
+            item for item in batch.get("items", [])
+            if item.get("status") != ItemState.DELETED.value
+        ]
     return {
         "batch": {
-            "id": str(batch["_id"]),
+            "id": batch_id,
             "userId": str(batch["userId"]),
             "status": batch["status"],
-            "images": [_serialize_image(image) for image in images],
-            "items": [_serialize_item(item) for item in items],
+            "images": [_serialize_image(image, batch_id=batch_id) for image in images],
+            "items": [_serialize_item(item, batch_id=batch_id) for item in items],
             "createdAt": batch["createdAt"],
             "updatedAt": batch["updatedAt"],
             "expiresAt": batch["expiresAt"],
@@ -225,6 +254,18 @@ async def _load_owned_batch(
         raise ApiError(409, "BATCH_EXPIRED", "Batch has expired")
     if batch["status"] != BatchState.ACTIVE.value:
         raise ApiError(409, "INVALID_BATCH_STATE", "Batch is not active")
+    return batch
+
+
+async def _load_owned_batch_for_read(
+    database: Any,
+    batch_id: str,
+    user_id: Any,
+) -> Document:
+    parse_object_id(batch_id, resource_name="Batch")
+    batch = await get_batch(database, batch_id, user_id)
+    if batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
     return batch
 
 
@@ -555,3 +596,157 @@ async def retry_item(
     if updated_batch is None:
         raise ApiError(404, "NOT_FOUND", "Batch not found")
     return BatchResponse(**serialize_batch(updated_batch))
+
+
+class UpdateItemDraftRequest(BaseModel):
+    text: str | None = None
+    problemType: ProblemType | None = None
+    graphDsl: str | None = None
+    correctAnswer: str | None = None
+    tags: list[str] | None = None
+    subject: ProblemSubject | None = None
+
+
+@router.get("/{batch_id}", response_model=BatchResponse)
+async def get_batch_detail(
+    batch_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    batch = await _load_owned_batch_for_read(database, batch_id, user["_id"])
+    return BatchResponse(**serialize_batch(batch, include_deleted=True))
+
+
+@router.patch("/{batch_id}/items/{item_id}", response_model=BatchResponse)
+async def update_item_draft_endpoint(
+    batch_id: str,
+    item_id: str,
+    request: UpdateItemDraftRequest,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    await _load_owned_batch(database, batch_id, user["_id"])
+
+    draft_update = request.model_dump(exclude_unset=True)
+    if "tags" in draft_update:
+        draft_update["tags"] = normalize_tags(draft_update["tags"])
+
+    updated = await update_item_draft(
+        database,
+        batch_id,
+        user["_id"],
+        item_id,
+        draft_update=draft_update,
+        now=datetime.now(UTC),
+    )
+    if updated is None:
+        raise ApiError(404, "NOT_FOUND", "Item not found")
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch, include_deleted=True))
+
+
+@router.delete("/{batch_id}/items/{item_id}", response_model=BatchResponse)
+async def delete_item(
+    batch_id: str,
+    item_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    await _load_owned_batch(database, batch_id, user["_id"])
+    await mark_item_deleted(
+        database,
+        batch_id,
+        user["_id"],
+        item_id,
+        now=datetime.now(UTC),
+    )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch, include_deleted=True))
+
+
+@router.post("/{batch_id}/items/{item_id}/undo-delete", response_model=BatchResponse)
+async def undo_delete_item_endpoint(
+    batch_id: str,
+    item_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> BatchResponse:
+    await _load_owned_batch(database, batch_id, user["_id"])
+    restored = await undo_item_deletion(
+        database,
+        batch_id,
+        user["_id"],
+        item_id,
+        now=datetime.now(UTC),
+    )
+    if not restored:
+        raise ApiError(
+            409,
+            "ITEM_NOT_DELETED",
+            "Item is not deleted or has no restorable state",
+        )
+
+    updated_batch = await get_batch(database, batch_id, user["_id"])
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+    return BatchResponse(**serialize_batch(updated_batch, include_deleted=True))
+
+
+@router.get("/{batch_id}/images/{image_id}/source")
+async def stream_source_image(
+    batch_id: str,
+    image_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+    storage: StorageDependency,
+) -> StreamingResponse:
+    batch = await _load_owned_batch(database, batch_id, user["_id"])
+    image = _find_image_or_404(batch, image_id)
+    source_image = dict(image.get("sourceImage") or {})
+    bucket = source_image.get("bucket")
+    object_key = source_image.get("objectKey")
+    if not bucket or not object_key:
+        raise ApiError(404, "NOT_FOUND", "Source image not found")
+
+    try:
+        image_bytes = storage.get_object(str(bucket), str(object_key))
+    except StorageObjectNotFoundError as exc:
+        raise ApiError(404, "NOT_FOUND", "Source image not found") from exc
+
+    return StreamingResponse(
+        BytesIO(image_bytes),
+        media_type=str(source_image.get("contentType") or "application/octet-stream"),
+    )
+
+
+@router.get("/{batch_id}/items/{item_id}/crop")
+async def stream_item_crop(
+    batch_id: str,
+    item_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+    storage: StorageDependency,
+) -> StreamingResponse:
+    batch = await _load_owned_batch(database, batch_id, user["_id"])
+    item = _find_item_or_404(batch, item_id)
+    crop = dict(item.get("crop") or {})
+    bucket = crop.get("bucket")
+    object_key = crop.get("objectKey")
+    if not bucket or not object_key:
+        raise ApiError(404, "NOT_FOUND", "Crop image not found")
+
+    try:
+        image_bytes = storage.get_object(str(bucket), str(object_key))
+    except StorageObjectNotFoundError as exc:
+        raise ApiError(404, "NOT_FOUND", "Crop image not found") from exc
+
+    return StreamingResponse(
+        BytesIO(image_bytes),
+        media_type=str(crop.get("contentType") or "application/octet-stream"),
+    )

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -739,7 +739,7 @@ async def stream_item_crop(
     bucket = crop.get("bucket")
     object_key = crop.get("objectKey")
     if not bucket or not object_key:
-        raise ApiError(404, "NOT_FOUND", "Crop image not found")
+        raise ApiError(404, "CROP_NOT_FOUND", "Crop image not found")
 
     try:
         image_bytes = storage.get_object(str(bucket), str(object_key))

--- a/backend/app/presentation/helpers.py
+++ b/backend/app/presentation/helpers.py
@@ -27,6 +27,14 @@ def build_problem_image_url(problem_id: Any) -> str:
     return f"/api/v1/problems/{problem_id}/image"
 
 
+def build_ingestion_source_image_url(batch_id: Any, image_id: str) -> str:
+    return f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/source"
+
+
+def build_ingestion_crop_url(batch_id: Any, item_id: str) -> str:
+    return f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/crop"
+
+
 def parse_object_id(raw_id: str, *, resource_name: str) -> ObjectId:
     if not ObjectId.is_valid(raw_id):
         raise ApiError(404, "NOT_FOUND", f"{resource_name} not found")

--- a/backend/app/presentation/schemas.py
+++ b/backend/app/presentation/schemas.py
@@ -21,3 +21,4 @@ class SourceImagePayload(BaseModel):
     width: int | None = None
     height: int | None = None
     uploadedAt: datetime | None = None
+    mediaUrl: str | None = None

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -1076,3 +1076,413 @@ async def test_retry_requires_authentication(
         f"/api/v1/ingestion-batches/{ObjectId()}/items/item-1/retry"
     )
     assert response.status_code == 401
+
+
+async def create_ready_item(
+    client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+    *,
+    subject: str = "math",
+) -> tuple[str, str, str]:
+    batch_id, image_id, item_id = await create_committed_item(
+        client, helper_vlm, subject=subject
+    )
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    storage: FakeStorage = bulk_app.state.fake_storage
+    batch = await database["ingestion_batches"].find_one({"_id": ObjectId(batch_id)})
+    assert batch is not None
+
+    math_ingestion_vlm.responses.append(
+        make_extraction_result(text=f"Extracted {subject} text", model="math-model")
+    )
+
+    from app.infrastructure.worker.extraction_worker import process_item
+    from app.infrastructure.config.settings import Settings as AppSettings
+
+    settings = AppSettings(s3_bucket="learnloop-media")
+    await process_item(
+        batch["items"][0],
+        batch,
+        database,
+        storage,
+        math_ingestion_vlm,
+        bulk_app.state.fake_english_ingestion_vlm,
+        settings,
+    )
+    return batch_id, image_id, item_id
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_returns_review_state_with_media_urls(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}"
+    )
+    assert response.status_code == 200
+    batch = response.json()["batch"]
+    assert batch["id"] == batch_id
+    assert len(batch["images"]) == 1
+    assert batch["images"][0]["sourceImage"]["mediaUrl"] == (
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/source"
+    )
+    assert len(batch["items"]) == 1
+    item = batch["items"][0]
+    assert item["itemId"] == item_id
+    assert item["status"] == "ready"
+    assert item["draft"]["text"] == "Extracted math text"
+    assert item["crop"]["mediaUrl"] == (
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/crop"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_includes_deleted_items(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, image_id, _item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    await authenticated_bulk_client.delete(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}"
+    )
+
+    response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}"
+    )
+    assert response.status_code == 200
+    batch = response.json()["batch"]
+    assert len(batch["images"]) == 1
+    assert batch["images"][0]["status"] == "deleted"
+    assert len(batch["items"]) == 1
+    assert batch["items"][0]["status"] == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_update_item_draft_persists_all_editable_fields(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+        json={
+            "text": "New text",
+            "problemType": "single-choice",
+            "graphDsl": "graph",
+            "correctAnswer": "A",
+            "tags": ["tag-a", " tag-b ", "tag-a"],
+            "subject": "english",
+        },
+    )
+    assert response.status_code == 200
+    item = response.json()["batch"]["items"][0]
+    assert item["draft"]["text"] == "New text"
+    assert item["draft"]["problemType"] == "single-choice"
+    assert item["draft"]["graphDsl"] == "graph"
+    assert item["draft"]["correctAnswer"] == "A"
+    assert item["draft"]["tags"] == ["tag-a", "tag-b"]
+    assert item["draft"]["subject"] == "english"
+
+
+@pytest.mark.asyncio
+async def test_update_item_draft_omitted_fields_preserved(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+        json={"text": "First"},
+    )
+    await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+        json={"correctAnswer": "Second"},
+    )
+
+    response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}"
+    )
+    item = response.json()["batch"]["items"][0]
+    assert item["draft"]["text"] == "First"
+    assert item["draft"]["correctAnswer"] == "Second"
+
+
+@pytest.mark.asyncio
+async def test_update_item_draft_rejects_invalid_problem_type(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+        json={"problemType": "invalid"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_update_item_draft_rejects_expired_batch(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    await database["ingestion_batches"].update_one(
+        {"_id": ObjectId(batch_id)},
+        {"$set": {"expiresAt": datetime.now(UTC) - timedelta(seconds=1)}},
+    )
+
+    response = await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+        json={"text": "New"},
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "BATCH_EXPIRED"
+
+
+@pytest.mark.asyncio
+async def test_delete_item_marks_deleted_and_keeps_in_review_state(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.delete(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}"
+    )
+    assert response.status_code == 200
+    item = response.json()["batch"]["items"][0]
+    assert item["itemId"] == item_id
+    assert item["status"] == "deleted"
+
+    detail = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}"
+    )
+    assert detail.json()["batch"]["items"][0]["status"] == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_undo_delete_item_restores_previous_status(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    await authenticated_bulk_client.delete(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}"
+    )
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/undo-delete"
+    )
+    assert response.status_code == 200
+    item = response.json()["batch"]["items"][0]
+    assert item["status"] == "ready"
+
+
+@pytest.mark.asyncio
+async def test_undo_delete_item_rejects_non_deleted(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/undo-delete"
+    )
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "ITEM_NOT_DELETED"
+
+
+@pytest.mark.asyncio
+async def test_stream_source_image_returns_owned_image(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, image_id, _item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/source"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert len(response.content) > 0
+
+
+@pytest.mark.asyncio
+async def test_stream_item_crop_returns_owned_crop(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/crop"
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert len(response.content) > 0
+
+
+@pytest.mark.asyncio
+async def test_stream_source_image_rejects_cross_user(
+    bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    await register_and_login(bulk_client, bulk_app, username="owner")
+    batch_id, image_id, _item_id = await create_ready_item(
+        bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    await register_and_login(bulk_client, bulk_app, username="other")
+    response = await bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/source"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_stream_crop_rejects_missing_crop(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm
+    )
+
+    response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/crop"
+    )
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_review_routes_require_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    batch_id = str(ObjectId())
+    item_id = "item-1"
+    image_id = "image-1"
+
+    assert (
+        await bulk_client.get(f"/api/v1/ingestion-batches/{batch_id}")
+    ).status_code == 401
+    assert (
+        await bulk_client.patch(
+            f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}", json={}
+        )
+    ).status_code == 401
+    assert (
+        await bulk_client.delete(
+            f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}"
+        )
+    ).status_code == 401
+    assert (
+        await bulk_client.post(
+            f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/undo-delete"
+        )
+    ).status_code == 401
+    assert (
+        await bulk_client.get(
+            f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/source"
+        )
+    ).status_code == 401
+    assert (
+        await bulk_client.get(
+            f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/crop"
+        )
+    ).status_code == 401

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -1447,7 +1447,7 @@ async def test_stream_crop_rejects_missing_crop(
         f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/crop"
     )
     assert response.status_code == 404
-    assert response.json()["error"]["code"] == "NOT_FOUND"
+    assert response.json()["error"]["code"] == "CROP_NOT_FOUND"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements backend APIs for reviewing extraction items and fetching owned batch media.

## Linked Issue

Closes #365

## Issue Alignment

This PR implements the issue by:

- Adding `GET /ingestion-batches/{batch_id}` to return the full review state for the owning user, including deleted items and media URLs for source images and item crops.
- Adding `PATCH /ingestion-batches/{batch_id}/items/{item_id}` to edit draft fields (`text`, `problemType`, `graphDsl`, `correctAnswer`, `tags`, `subject`).
- Validating `problemType` and `subject` against existing `ProblemType` / `ProblemSubject` enums and normalizing tags with the shared helper.
- Adding `DELETE /ingestion-batches/{batch_id}/items/{item_id}` to mark an item as deleted while keeping it in the review state.
- Adding `POST /ingestion-batches/{batch_id}/items/{item_id}/undo-delete` to restore a deleted item to its previous status.
- Adding authenticated media-serving endpoints for source images and item crops.
- Enforcing ownership and active/non-expired batch state on edits and media access.
- Ensuring completed/expired batches are not editable.

Scope covered:

- Batch review detail with media URLs.
- Item draft patching with validation/normalization.
- Item delete/undo-delete.
- Source-image and crop streaming.
- Ownership and expiry/completion enforcement.
- API tests for the new behavior.

Out of scope / intentionally not included:

- Frontend review UI.
- Submit problem creation (tracked in #366).
- Duplicate detection.
- Extraction worker logic (already implemented in #364).

## Implementation Notes

- `serialize_batch` now accepts an `include_deleted` flag so the review endpoint can surface deleted images/items; other batch endpoints keep the existing filtered view.
- `_serialize_source_image` and `_serialize_item` add `mediaUrl` fields pointing at the new authenticated media routes.
- `update_item_draft` merges only allowed draft keys and stores `correctAnswer` as raw user-entered text (normalization happens later during problem creation).
- `mark_item_deleted` stores the item's `previousStatus` so `undo_item_deletion` can restore it.
- Media endpoints load the batch via `_load_owned_batch`, which already rejects cross-user, expired, and non-active batches, then stream the object from S3 without exposing the raw object key as authorization.

## Tests

Commands run:

- `uv run --extra dev pytest tests/api/test_bulk_ingestion.py -q` — 49 passed
- `uv run --extra dev pytest tests/api tests/integration -q` — 276 passed
- `uv run --extra dev pytest tests -q` — 658 passed, 1 skipped

Automated tests added or updated:

- `tests/api/test_bulk_ingestion.py` — review state fetch, media URLs, all draft field patches, tag normalization, invalid problem type rejection, expired-batch edit rejection, delete/undo-delete, source/crop streaming, cross-user media rejection, missing crop 404, auth checks.

Manual verification:

- Confirmed that deleted items remain visible in the review state returned by `GET /ingestion-batches/{batch_id}`.

## Deviations From Issue Plan

None.

## Follow-Up Work

- #366 Implement idempotent submit and problem creation workflow.
- #369 Build extraction progress and draft review UI.
