### PR TITLE
feat(bulk-ingestion): implement idempotent submit and problem creation workflow

### DIFF
--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -683,6 +683,60 @@ async def undo_item_deletion(
     return True
 
 
+async def submit_items_and_complete_batch(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    *,
+    item_results: list[dict[str, Any]],
+    now: datetime,
+) -> Document | None:
+    """Persist per-item submit outcomes and mark the batch completed if appropriate.
+
+    The batch is marked ``completed`` when every non-deleted item has status
+    ``submitted``. Items in other states (including ``submit-failed``) keep the
+    batch active so they can be retried or deleted.
+    """
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+
+    result_by_item = {result["itemId"]: result for result in item_results}
+    items = list(batch.get("items", []))
+    for item in items:
+        result = result_by_item.get(item.get("itemId"))
+        if result is None:
+            continue
+        item["status"] = result["status"]
+        item["submit"] = result["submit"]
+        item["updatedAt"] = now
+
+    all_submitted = True
+    has_submitted = False
+    for item in items:
+        status = item.get("status")
+        if status == ItemState.DELETED.value:
+            continue
+        if status == ItemState.SUBMITTED.value:
+            has_submitted = True
+        else:
+            all_submitted = False
+
+    update: dict[str, Any] = {"items": items, "updatedAt": now}
+    if all_submitted and has_submitted:
+        update["status"] = BatchState.COMPLETED.value
+
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": update},
+    )
+    return await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+
+
 async def find_cleanup_candidates(
     database: Any,
     *,

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -24,6 +24,7 @@ from app.domain.ingestion import (
     transition_image_state,
     validate_boxes,
 )
+
 from app.domain.models import ProblemSubject, ProblemType
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.ingestion.documents import build_source_image
@@ -42,6 +43,7 @@ from app.infrastructure.ingestion.repository import (
     save_image_detection_failure,
     save_image_detection_success,
     start_image_detection,
+    submit_items_and_complete_batch,
     undo_item_deletion,
     update_item_draft,
 )
@@ -62,6 +64,7 @@ from app.presentation.helpers import (
     normalize_tags,
     parse_object_id,
 )
+from app.presentation.problem_creation import create_problem_from_draft
 from app.presentation.schemas import SourceImagePayload
 
 router = APIRouter(prefix="/ingestion-batches", tags=["bulk-ingestion"])
@@ -121,6 +124,24 @@ class BatchPayload(BaseModel):
 
 class BatchResponse(BaseModel):
     batch: BatchPayload
+
+
+class SubmitItemResult(BaseModel):
+    itemId: str
+    status: str
+    submittedProblemId: str | None = None
+    failureCode: str | None = None
+    failureMessage: str | None = None
+
+
+class SubmitSummaryPayload(BaseModel):
+    batchId: str
+    status: str
+    items: list[SubmitItemResult]
+
+
+class SubmitSummaryResponse(BaseModel):
+    submitSummary: SubmitSummaryPayload
 
 
 def _guess_extension(upload: UploadFile) -> str:
@@ -696,6 +717,120 @@ async def undo_delete_item_endpoint(
     if updated_batch is None:
         raise ApiError(404, "NOT_FOUND", "Batch not found")
     return BatchResponse(**serialize_batch(updated_batch, include_deleted=True))
+
+
+def _build_submit_result(item: dict[str, Any]) -> SubmitItemResult:
+    submit = dict(item.get("submit") or {})
+    return SubmitItemResult(
+        itemId=item["itemId"],
+        status=item["status"],
+        submittedProblemId=submit.get("submittedProblemId"),
+        failureCode=submit.get("failureCode"),
+        failureMessage=submit.get("failureMessage"),
+    )
+
+
+@router.post("/{batch_id}/submit", response_model=SubmitSummaryResponse)
+async def submit_batch(
+    batch_id: str,
+    database: DatabaseDependency,
+    user: CurrentUserDependency,
+) -> SubmitSummaryResponse:
+    batch = await _load_owned_batch_for_read(database, batch_id, user["_id"])
+    if is_batch_expired(batch):
+        raise ApiError(409, "BATCH_EXPIRED", "Batch has expired")
+    if batch["status"] not in {
+        BatchState.ACTIVE.value,
+        BatchState.COMPLETED.value,
+    }:
+        raise ApiError(
+            409,
+            "INVALID_BATCH_STATE",
+            "Batch is not active",
+        )
+
+    if batch["status"] == BatchState.COMPLETED.value:
+        results = [
+            _build_submit_result(item)
+            for item in batch.get("items", [])
+            if item.get("status") != ItemState.DELETED.value
+        ]
+        return SubmitSummaryResponse(
+            submitSummary=SubmitSummaryPayload(
+                batchId=batch_id,
+                status=batch["status"],
+                items=results,
+            )
+        )
+
+    now = datetime.now(UTC)
+    item_results: list[dict[str, Any]] = []
+    for item in batch.get("items", []):
+        if item.get("status") != ItemState.READY.value:
+            continue
+
+        try:
+            problem = await create_problem_from_draft(
+                database,
+                user["_id"],
+                draft=item.get("draft"),
+                source_image=item.get("crop"),
+                origin=item.get("origin"),
+                now=now,
+            )
+            item_results.append(
+                {
+                    "itemId": item["itemId"],
+                    "status": ItemState.SUBMITTED.value,
+                    "submit": {
+                        "submittedProblemId": str(problem["_id"]),
+                        "success": True,
+                        "failureCode": None,
+                        "failureMessage": None,
+                    },
+                }
+            )
+        except ApiError as exc:
+            item_results.append(
+                {
+                    "itemId": item["itemId"],
+                    "status": ItemState.SUBMIT_FAILED.value,
+                    "submit": {
+                        "submittedProblemId": None,
+                        "success": False,
+                        "failureCode": exc.code,
+                        "failureMessage": exc.message,
+                    },
+                }
+            )
+
+    updated_batch = await submit_items_and_complete_batch(
+        database,
+        batch_id,
+        user["_id"],
+        item_results=item_results,
+        now=now,
+    )
+    if updated_batch is None:
+        raise ApiError(404, "NOT_FOUND", "Batch not found")
+
+    results = [
+        SubmitItemResult(
+            itemId=r["itemId"],
+            status=r["status"],
+            submittedProblemId=r["submit"]["submittedProblemId"],
+            failureCode=r["submit"]["failureCode"],
+            failureMessage=r["submit"]["failureMessage"],
+        )
+        for r in item_results
+    ]
+    return SubmitSummaryResponse(
+        submitSummary=SubmitSummaryPayload(
+            batchId=batch_id,
+            status=updated_batch["status"],
+            items=results,
+        )
+    )
 
 
 @router.get("/{batch_id}/images/{image_id}/source")

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends, File, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
-from app.domain import IngestionPreviewStatus, ProblemSubject, ProblemType, normalize_answer
+from app.domain import IngestionPreviewStatus, ProblemSubject, ProblemType
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
@@ -31,8 +31,7 @@ from app.presentation.deps import (
 from app.presentation.errors import ApiError
 from app.presentation.helpers import normalize_tags, parse_object_id
 from app.presentation.ingestion_serialization import ProblemResponse, PreviewResponse, serialize_preview, serialize_problem, _enum_value
-from app.presentation.tags import _register_tags
-from app.presentation.solution_generation import enqueue_solution_generation_task_for_problem
+from app.presentation.problem_creation import create_problem_from_draft
 from app.presentation.ingestion_workflow import (
     DEFAULT_SYNC_WAIT_SECONDS,
     clean_optional_text,
@@ -393,66 +392,35 @@ async def confirm_preview(
         )
 
     draft = dict(claimed_preview.get("editableDraft", {}))
-    text = clean_optional_text(draft.get("text"))
-    problem_type_value = draft.get("problemType")
-    correct_answer = clean_optional_text(draft.get("correctAnswer"))
-    if text is None or problem_type_value is None or correct_answer is None:
-        await previews.update_one(
-            {"_id": preview_oid},
-            {"$set": {"status": claimed_preview["status"], "updatedAt": now}},
-        )
-        raise ApiError(400, "INVALID_PREVIEW", "Preview draft is missing required fields")
-
-    problem_type = ProblemType(problem_type_value)
-    subject_value = draft.get("subject", ProblemSubject.MATH.value)
-    normalized_answer = normalize_answer(correct_answer, problem_type)
-    problem: Document = {
-        "_id": ObjectId(),
-        "userId": user["_id"],
-        "text": text,
-        "problemType": problem_type.value,
-        "subject": str(subject_value),
-        "graphDsl": draft.get("graphDsl"),
-        "correctAnswer": normalized_answer.model_dump(),
-        "tags": normalize_tags(list(draft.get("tags", []))),
-        "sourceImage": dict(claimed_preview.get("sourceImage", {})),
-        "origin": {
-            "previewId": str(claimed_preview["_id"]),
-            "vlmModel": dict(claimed_preview.get("extraction", {})).get("requestModel"),
-            "rawExtractedText": dict(claimed_preview.get("extraction", {})).get("rawText"),
-            "rawExtractedProblemType": _enum_value(
-                dict(claimed_preview.get("extraction", {})).get("rawProblemType")
-            ),
-            "rawExtractedGraphDsl": dict(claimed_preview.get("extraction", {})).get("rawGraphDsl"),
-        },
-        "tracking": {
-            "exposureCount": 0,
-            "correctCount": 0,
-            "failedCount": 0,
-            "lastTestedAt": None,
-            "lastAttemptCorrect": None,
-        },
-        "isDeleted": False,
-        "deletedAt": None,
-        "createdAt": now,
-        "updatedAt": now,
-    }
     try:
-        await database["problems"].insert_one(problem)
-        await enqueue_solution_generation_task_for_problem(database, problem, now=now)
-    except Exception:
-        delete_problem = getattr(database["problems"], "delete_one", None)
-        if callable(delete_problem):
-            try:
-                await delete_problem({"_id": problem["_id"]})
-            except Exception:
-                pass
+        problem = await create_problem_from_draft(
+            database,
+            user["_id"],
+            draft=draft,
+            source_image=claimed_preview.get("sourceImage"),
+            origin={
+                "previewId": str(claimed_preview["_id"]),
+                "vlmModel": dict(claimed_preview.get("extraction", {})).get("requestModel"),
+                "rawExtractedText": dict(claimed_preview.get("extraction", {})).get("rawText"),
+                "rawExtractedProblemType": _enum_value(
+                    dict(claimed_preview.get("extraction", {})).get("rawProblemType")
+                ),
+                "rawExtractedGraphDsl": dict(claimed_preview.get("extraction", {})).get("rawGraphDsl"),
+            },
+            now=now,
+        )
+    except ApiError as exc:
         await previews.update_one(
             {"_id": preview_oid},
             {"$set": {"status": claimed_preview["status"], "updatedAt": now}},
         )
-        raise ApiError(500, "PROBLEM_CREATION_FAILED", "Failed to create problem. Please retry confirmation.")
-    await _register_tags(database, user["_id"], list(draft.get("tags", [])))
+        if exc.code == "MISSING_REQUIRED_FIELD":
+            raise ApiError(
+                400,
+                "INVALID_PREVIEW",
+                "Preview draft is missing required fields",
+            ) from exc
+        raise
     return ProblemResponse(problem=serialize_problem(problem))
 
 

--- a/backend/app/presentation/problem_creation.py
+++ b/backend/app/presentation/problem_creation.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import ObjectId
+
+from app.domain import ProblemSubject, ProblemType, normalize_answer
+from app.presentation.errors import ApiError
+from app.presentation.helpers import normalize_tags
+from app.presentation.solution_generation import enqueue_solution_generation_task_for_problem
+from app.presentation.tags import _register_tags
+
+
+async def create_problem_from_draft(
+    database: Any,
+    user_id: Any,
+    *,
+    draft: Mapping[str, Any] | None,
+    source_image: Mapping[str, Any] | None,
+    origin: Mapping[str, Any] | None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Create a problem from a draft, enqueue a solution task, and register tags.
+
+    Idempotent: if a problem already exists for the same ``origin`` metadata, it
+    is returned instead of creating a duplicate.
+
+    On failure after inserting the problem document, the problem is deleted so
+    that partial failures do not leave visible problems.
+    """
+    current = now or datetime.now(UTC)
+    draft_dict = dict(draft or {})
+
+    text = (draft_dict.get("text") or "").strip() or None
+    problem_type_value = draft_dict.get("problemType")
+    correct_answer_raw = (draft_dict.get("correctAnswer") or "").strip() or None
+    if text is None or problem_type_value is None or correct_answer_raw is None:
+        raise ApiError(
+            400,
+            "MISSING_REQUIRED_FIELD",
+            "Draft is missing required fields (text, problemType, correctAnswer)",
+        )
+
+    try:
+        problem_type = ProblemType(problem_type_value)
+    except ValueError as exc:
+        raise ApiError(400, "INVALID_PROBLEM_TYPE", str(exc)) from exc
+
+    normalized_answer = normalize_answer(correct_answer_raw, problem_type)
+    tags = normalize_tags(list(draft_dict.get("tags", [])))
+
+    subject_value = draft_dict.get("subject", ProblemSubject.MATH.value)
+    try:
+        ProblemSubject(subject_value)
+    except ValueError:
+        subject_value = ProblemSubject.MATH.value
+
+    origin_dict = dict(origin or {})
+    existing_query = _build_origin_query(origin_dict)
+    if existing_query:
+        existing = await database["problems"].find_one(existing_query)
+        if existing is not None:
+            await enqueue_solution_generation_task_for_problem(
+                database, existing, now=current
+            )
+            try:
+                await _register_tags(database, user_id, tags)
+            except Exception:
+                pass
+            return existing
+
+    problem: dict[str, Any] = {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "text": text,
+        "problemType": problem_type.value,
+        "subject": str(subject_value),
+        "graphDsl": draft_dict.get("graphDsl"),
+        "correctAnswer": normalized_answer.model_dump(),
+        "tags": tags,
+        "sourceImage": dict(source_image) if source_image else None,
+        "origin": origin_dict,
+        "tracking": {
+            "exposureCount": 0,
+            "correctCount": 0,
+            "failedCount": 0,
+            "lastTestedAt": None,
+            "lastAttemptCorrect": None,
+        },
+        "isDeleted": False,
+        "deletedAt": None,
+        "createdAt": current,
+        "updatedAt": current,
+    }
+
+    try:
+        await database["problems"].insert_one(problem)
+        await enqueue_solution_generation_task_for_problem(
+            database, problem, now=current
+        )
+        await _register_tags(database, user_id, tags)
+    except Exception:
+        delete_problem = getattr(database["problems"], "delete_one", None)
+        if callable(delete_problem):
+            try:
+                await delete_problem({"_id": problem["_id"]})
+            except Exception:
+                pass
+        raise ApiError(
+            500,
+            "PROBLEM_CREATION_FAILED",
+            "Failed to create problem. Please retry.",
+        )
+
+    return problem
+
+
+def _build_origin_query(origin: dict[str, Any]) -> dict[str, Any] | None:
+    query: dict[str, Any] = {}
+    if origin.get("previewId"):
+        query["origin.previewId"] = origin["previewId"]
+    if origin.get("batchId"):
+        query["origin.batchId"] = origin["batchId"]
+    if origin.get("itemId"):
+        query["origin.itemId"] = origin["itemId"]
+    return query if query else None

--- a/backend/app/presentation/problem_creation.py
+++ b/backend/app/presentation/problem_creation.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Any
 
 from bson import ObjectId
+
+logger = logging.getLogger(__name__)
 
 from app.domain import ProblemSubject, ProblemType, normalize_answer
 from app.presentation.errors import ApiError
@@ -102,6 +105,7 @@ async def create_problem_from_draft(
         )
         await _register_tags(database, user_id, tags)
     except Exception:
+        logger.exception("Problem creation failed")
         delete_problem = getattr(database["problems"], "delete_one", None)
         if callable(delete_problem):
             try:

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -1450,6 +1450,346 @@ async def test_stream_crop_rejects_missing_crop(
     assert response.json()["error"]["code"] == "CROP_NOT_FOUND"
 
 
+async def create_ready_item_with_draft(
+    client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+    *,
+    correct_answer: str = "4",
+    subject: str = "math",
+) -> tuple[str, str, str]:
+    batch_id, image_id, item_id = await create_ready_item(
+        client, bulk_app, helper_vlm, math_ingestion_vlm, subject=subject
+    )
+    response = await client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+        json={"correctAnswer": correct_answer},
+    )
+    assert response.status_code == 200
+    return batch_id, image_id, item_id
+
+
+async def create_two_ready_items(
+    client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> tuple[str, list[str]]:
+    create_response = await client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    image_bytes = make_valid_png_bytes()
+    upload_response = await client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("test.png", image_bytes, "image/png")},
+    )
+    assert upload_response.status_code == 201
+    image_id = upload_response.json()["batch"]["images"][0]["imageId"]
+
+    helper_vlm.responses.append(
+        make_detection_result(
+            subject="math",
+            boxes=[
+                ProblemBox(x=0, y=0, width=1, height=1),
+                ProblemBox(x=0, y=0, width=1, height=1),
+            ],
+        )
+    )
+    detect_response = await client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/detect"
+    )
+    assert detect_response.status_code == 200
+
+    commit_response = await client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images/{image_id}/commit"
+    )
+    assert commit_response.status_code == 200
+    item_ids = [item["itemId"] for item in commit_response.json()["batch"]["items"]]
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    storage: FakeStorage = bulk_app.state.fake_storage
+    batch = await database["ingestion_batches"].find_one({"_id": ObjectId(batch_id)})
+    assert batch is not None
+
+    from app.infrastructure.worker.extraction_worker import process_item
+    from app.infrastructure.config.settings import Settings as AppSettings
+
+    settings = AppSettings(s3_bucket="learnloop-media")
+    for _ in item_ids:
+        math_ingestion_vlm.responses.append(
+            make_extraction_result(text="Extracted text", model="math-model")
+        )
+
+    for item in batch["items"]:
+        await process_item(
+            item,
+            batch,
+            database,
+            storage,
+            math_ingestion_vlm,
+            bulk_app.state.fake_english_ingestion_vlm,
+            settings,
+        )
+
+    return batch_id, item_ids
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_creates_problems_and_solution_tasks(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item_with_draft(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+
+    assert response.status_code == 200
+    summary = response.json()["submitSummary"]
+    assert summary["batchId"] == batch_id
+    assert summary["status"] == "completed"
+    assert len(summary["items"]) == 1
+    assert summary["items"][0]["itemId"] == item_id
+    assert summary["items"][0]["status"] == "submitted"
+    assert summary["items"][0]["submittedProblemId"] is not None
+    assert summary["items"][0]["failureCode"] is None
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    problems = database["problems"]._documents
+    assert len(problems) == 1
+    assert problems[0]["origin"] == {
+        "batchId": batch_id,
+        "imageId": _image_id,
+        "itemId": item_id,
+    }
+
+    tasks = database["solution_generation_tasks"]._documents
+    assert len(tasks) == 1
+    assert tasks[0]["problem_id"] == str(problems[0]["_id"])
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_gate_blocks_missing_fields(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item(
+        authenticated_bulk_client, bulk_app, helper_vlm, math_ingestion_vlm
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+
+    assert response.status_code == 200
+    summary = response.json()["submitSummary"]
+    assert summary["status"] == "active"
+    assert summary["items"][0]["status"] == "submit-failed"
+    assert summary["items"][0]["failureCode"] == "MISSING_REQUIRED_FIELD"
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    assert len(database["problems"]._documents) == 0
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_gate_skips_non_ready_items(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, _image_id, _item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+
+    assert response.status_code == 200
+    summary = response.json()["submitSummary"]
+    assert summary["status"] == "active"
+    assert summary["items"] == []
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    assert len(database["problems"]._documents) == 0
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_best_effort_partial_failure(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, item_ids = await create_two_ready_items(
+        authenticated_bulk_client, bulk_app, helper_vlm, math_ingestion_vlm
+    )
+
+    await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_ids[0]}",
+        json={"correctAnswer": "A"},
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+
+    assert response.status_code == 200
+    summary = response.json()["submitSummary"]
+    assert summary["status"] == "active"
+    assert len(summary["items"]) == 2
+
+    by_item = {item["itemId"]: item for item in summary["items"]}
+    assert by_item[item_ids[0]]["status"] == "submitted"
+    assert by_item[item_ids[0]]["submittedProblemId"] is not None
+    assert by_item[item_ids[1]]["status"] == "submit-failed"
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    assert len(database["problems"]._documents) == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_is_idempotent(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item_with_draft(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+    )
+
+    first = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+    assert first.status_code == 200
+    first_problem_id = first.json()["submitSummary"]["items"][0]["submittedProblemId"]
+
+    second = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+    assert second.status_code == 200
+    second_problem_id = second.json()["submitSummary"]["items"][0]["submittedProblemId"]
+
+    assert first_problem_id == second_problem_id
+
+    database: FakeDatabase = bulk_app.state.fake_database
+    assert len(database["problems"]._documents) == 1
+    assert len(database["solution_generation_tasks"]._documents) == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_marks_batch_completed_when_all_submitted(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, item_ids = await create_two_ready_items(
+        authenticated_bulk_client, bulk_app, helper_vlm, math_ingestion_vlm
+    )
+
+    for item_id in item_ids:
+        response = await authenticated_bulk_client.patch(
+            f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}",
+            json={"correctAnswer": "4"},
+        )
+        assert response.status_code == 200
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+
+    assert response.status_code == 200
+    summary = response.json()["submitSummary"]
+    assert summary["status"] == "completed"
+    assert all(item["status"] == "submitted" for item in summary["items"])
+
+
+@pytest.mark.asyncio
+async def test_submit_batch_completes_after_remaining_items_deleted(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, item_ids = await create_two_ready_items(
+        authenticated_bulk_client, bulk_app, helper_vlm, math_ingestion_vlm
+    )
+
+    await authenticated_bulk_client.patch(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_ids[0]}",
+        json={"correctAnswer": "4"},
+    )
+    await authenticated_bulk_client.delete(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_ids[1]}"
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+
+    assert response.status_code == 200
+    summary = response.json()["submitSummary"]
+    assert summary["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_full_batch_lifecycle_through_completion(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+    math_ingestion_vlm: FakeIngestionVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_ready_item_with_draft(
+        authenticated_bulk_client,
+        bulk_app,
+        helper_vlm,
+        math_ingestion_vlm,
+        correct_answer="A",
+    )
+
+    submit_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/submit"
+    )
+    assert submit_response.status_code == 200
+    assert submit_response.json()["submitSummary"]["status"] == "completed"
+
+    detail_response = await authenticated_bulk_client.get(
+        f"/api/v1/ingestion-batches/{batch_id}"
+    )
+    assert detail_response.status_code == 200
+    batch = detail_response.json()["batch"]
+    assert batch["status"] == "completed"
+    assert batch["items"][0]["status"] == "submitted"
+    assert batch["items"][0]["submit"]["submittedProblemId"] is not None
+
+
+@pytest.mark.asyncio
+async def test_submit_requires_authentication(
+    bulk_client: AsyncClient,
+) -> None:
+    response = await bulk_client.post(
+        f"/api/v1/ingestion-batches/{ObjectId()}/submit"
+    )
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "UNAUTHENTICATED"
+
+
 @pytest.mark.asyncio
 async def test_review_routes_require_authentication(
     bulk_client: AsyncClient,

--- a/backend/tests/presentation/test_problem_creation.py
+++ b/backend/tests/presentation/test_problem_creation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+
+from app.presentation.errors import ApiError
+from app.presentation.problem_creation import create_problem_from_draft
+from tests.conftest import FakeDatabase
+
+
+def _make_draft(
+    *,
+    text: str = "What is 2+2?",
+    problem_type: str = "short-answer",
+    correct_answer: str = "4",
+    subject: str = "math",
+    tags: list[str] | None = None,
+    graph_dsl: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "text": text,
+        "problemType": problem_type,
+        "correctAnswer": correct_answer,
+        "subject": subject,
+        "tags": tags or [],
+        "graphDsl": graph_dsl,
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_problem_rejects_missing_required_fields() -> None:
+    database = FakeDatabase()
+    with pytest.raises(ApiError) as exc_info:
+        await create_problem_from_draft(
+            database,
+            ObjectId(),
+            draft={"text": "Only text"},
+            source_image=None,
+            origin={"previewId": "prev-1"},
+        )
+    assert exc_info.value.code == "MISSING_REQUIRED_FIELD"
+
+
+@pytest.mark.asyncio
+async def test_create_problem_inserts_problem_and_enqueues_solution() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+    draft = _make_draft(tags=["tag-a", "tag-a"])
+    source_image = {"bucket": "bucket", "objectKey": "key"}
+
+    problem = await create_problem_from_draft(
+        database,
+        user_id,
+        draft=draft,
+        source_image=source_image,
+        origin={"previewId": "prev-2"},
+        now=datetime.now(UTC),
+    )
+
+    assert problem["userId"] == user_id
+    assert problem["text"] == draft["text"]
+    assert problem["problemType"] == "short-answer"
+    assert problem["sourceImage"] == source_image
+    assert problem["tags"] == ["tag-a"]
+    assert problem["isDeleted"] is False
+
+    problems = database["problems"]._documents
+    assert len(problems) == 1
+
+    tasks = database["solution_generation_tasks"]._documents
+    assert len(tasks) == 1
+    assert tasks[0]["problem_id"] == str(problem["_id"])
+
+    tags = database["tags"]._documents
+    assert len(tags) == 1
+    assert tags[0]["userId"] == user_id
+    assert tags[0]["name"] == "tag-a"
+
+
+@pytest.mark.asyncio
+async def test_create_problem_is_idempotent_by_origin() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+    origin = {"batchId": "batch-1", "itemId": "item-1"}
+    draft = _make_draft()
+
+    first = await create_problem_from_draft(
+        database, user_id, draft=draft, source_image=None, origin=origin
+    )
+    second = await create_problem_from_draft(
+        database, user_id, draft=draft, source_image=None, origin=origin
+    )
+
+    assert first["_id"] == second["_id"]
+    assert len(database["problems"]._documents) == 1
+    assert len(database["solution_generation_tasks"]._documents) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_problem_deletes_inserted_problem_when_enqueue_fails() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+
+    with patch(
+        "app.presentation.problem_creation.enqueue_solution_generation_task_for_problem",
+        new=AsyncMock(side_effect=RuntimeError("enqueue failed")),
+    ):
+        with pytest.raises(ApiError) as exc_info:
+            await create_problem_from_draft(
+                database,
+                user_id,
+                draft=_make_draft(),
+                source_image=None,
+                origin={"previewId": "prev-3"},
+            )
+
+    assert exc_info.value.code == "PROBLEM_CREATION_FAILED"
+    assert len(database["problems"]._documents) == 0
+    assert len(database["tags"]._documents) == 0


### PR DESCRIPTION
## Summary

Implements the backend batch submit operation: READY items are validated, turned into problems, and enqueued for solution generation. The operation is idempotent and compensates on partial failure.

## Linked Issue

Closes #366

## Issue Alignment

This PR implements the issue by:

- Extracting shared problem-creation logic from the single-preview confirm path into `create_problem_from_draft`.
- Adding `POST /ingestion-batches/{batch_id}/submit`.
- Enforcing the submit gate (READY status + text/problemType/correctAnswer).
- Persisting one final problem per submitted item and associating the item crop as `sourceImage`.
- Enqueuing a canonical solution generation task per successful problem.
- Storing per-item submit outcomes including `submittedProblemId`.
- Making retry idempotent by checking existing problems via `origin.batchId` + `origin.itemId`.
- Compensating for insert/enqueue failures by deleting the inserted problem.
- Marking the batch `completed` when every non-deleted item is `submitted`.
- Adding a backend full-lifecycle integration test plus unit tests for the helper.

Scope covered:

- Shared problem-creation helper.
- Batch submit endpoint and repository support.
- Submit gate, idempotency, compensation, batch completion.
- API, integration, and unit tests.

Out of scope / intentionally not included:

- Frontend submit UI (#370).
- Extraction worker changes.
- Duplicate detection against existing problems.
- Long-term batch archival.

## Implementation Notes

- `create_problem_from_draft` lives in `app/presentation/problem_creation.py` and is reused by both `confirm_preview` and `submit_batch`.
- The single-preview path keeps its existing `INVALID_PREVIEW` error code by translating the helper's `MISSING_REQUIRED_FIELD`.
- Submit uses `_load_owned_batch_for_read` so retries on a `completed` batch return the stored summary without reprocessing.
- Batch completion is decided in the repository: all non-deleted items must be `submitted`.

## Tests

Commands run:

- `uv run --extra dev pytest tests/api tests/integration tests/worker -q` — 309 passed
- `uv run --extra dev pytest tests -q` — 671 passed, 1 skipped

Automated tests added or updated:

- `tests/presentation/test_problem_creation.py` — missing-field rejection, successful creation, idempotency by origin, compensation on enqueue failure.
- `tests/api/test_bulk_ingestion.py` — successful submit, gate blocks missing fields/non-ready items, best-effort partial failure, idempotency, batch completion, completion after deletions, full lifecycle, auth.

Manual verification:

- Confirmed submit summary includes per-item success/failure and batch status.

## Deviations From Issue Plan

None.

## Follow-Up Work

- #370 Build submit gate, submit action, and result summary UI.
- #372 Add full workflow E2E coverage and retire old single-flow entry.
