### PR TITLE
feat(frontend): build upload, detection, and box-review UI

### DIFF
--- a/frontend/src/api/bulkIngestion.test.ts
+++ b/frontend/src/api/bulkIngestion.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  commitImage,
   createBatch,
+  deleteImage,
+  detectImageBoxes,
   getActiveBatch,
   getBatch,
+  saveImageBoxes,
   uploadBatchImages,
 } from "./bulkIngestion";
 import type { BatchResponse } from "@/types/bulkIngestion";
@@ -116,6 +120,103 @@ describe("bulk ingestion API client", () => {
       expect(callArgs[1].credentials).toBe("include");
       capturedBody = callArgs[1].body as FormData;
       expect(capturedBody.getAll("images")).toHaveLength(2);
+    });
+  });
+
+  describe("detectImageBoxes", () => {
+    it("posts to the detect endpoint", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await detectImageBoxes("batch-1", "img-1");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/images/img-1/detect",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: undefined,
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("saveImageBoxes", () => {
+    it("patches boxes and subject", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const boxes = [{ boxId: "box-1", x: 0, y: 0, width: 10, height: 10 }];
+      const result = await saveImageBoxes("batch-1", "img-1", boxes, "math");
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/images/img-1",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ boxes, subject: "math" }),
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("commitImage", () => {
+    it("posts to the commit endpoint", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await commitImage("batch-1", "img-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/images/img-1/commit",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: undefined,
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("deleteImage", () => {
+    it("deletes the image", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await deleteImage("batch-1", "img-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/images/img-1",
+        {
+          method: "DELETE",
+          credentials: "include",
+        },
+      );
+      expect(result).toEqual(response);
     });
   });
 });

--- a/frontend/src/api/bulkIngestion.ts
+++ b/frontend/src/api/bulkIngestion.ts
@@ -1,5 +1,5 @@
 import { api } from "./client";
-import type { BatchResponse } from "@/types/bulkIngestion";
+import type { BatchResponse, BulkImageBox } from "@/types/bulkIngestion";
 
 export async function createBatch(): Promise<BatchResponse> {
   return api.post<BatchResponse>("/ingestion-batches", undefined);
@@ -24,5 +24,46 @@ export async function uploadBatchImages(
   return api.postFormData<BatchResponse>(
     `/ingestion-batches/${batchId}/images`,
     formData,
+  );
+}
+
+export async function detectImageBoxes(
+  batchId: string,
+  imageId: string,
+): Promise<BatchResponse> {
+  return api.post<BatchResponse>(
+    `/ingestion-batches/${batchId}/images/${imageId}/detect`,
+    undefined,
+  );
+}
+
+export async function saveImageBoxes(
+  batchId: string,
+  imageId: string,
+  boxes: BulkImageBox[],
+  subject?: string | null,
+): Promise<BatchResponse> {
+  return api.patch<BatchResponse>(
+    `/ingestion-batches/${batchId}/images/${imageId}`,
+    { boxes, subject },
+  );
+}
+
+export async function commitImage(
+  batchId: string,
+  imageId: string,
+): Promise<BatchResponse> {
+  return api.post<BatchResponse>(
+    `/ingestion-batches/${batchId}/images/${imageId}/commit`,
+    undefined,
+  );
+}
+
+export async function deleteImage(
+  batchId: string,
+  imageId: string,
+): Promise<BatchResponse> {
+  return api.delete<BatchResponse>(
+    `/ingestion-batches/${batchId}/images/${imageId}`,
   );
 }

--- a/frontend/src/components/BoxEditor.test.tsx
+++ b/frontend/src/components/BoxEditor.test.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BoxEditor } from "./BoxEditor";
+import type { BulkImageBox } from "@/types/bulkIngestion";
+import { resetBoxIdCounter } from "@/utils/boxGeometry";
+
+const NATURAL_W = 200;
+const NATURAL_H = 100;
+
+function renderEditor(
+  boxes: BulkImageBox[],
+  onChange: (boxes: BulkImageBox[]) => void = vi.fn(),
+) {
+  const { container } = render(
+    <BoxEditor
+      imageUrl="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+      naturalWidth={NATURAL_W}
+      naturalHeight={NATURAL_H}
+      boxes={boxes}
+      onChange={onChange}
+    />,
+  );
+  const editor = screen.getByTestId("box-editor");
+  vi.spyOn(editor, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: 0,
+    width: 200,
+    height: 100,
+    top: 0,
+    left: 0,
+    right: 200,
+    bottom: 100,
+    toJSON: () => "",
+  });
+  fireEvent.resize(window);
+  return { container, editor };
+}
+
+describe("BoxEditor", () => {
+  beforeEach(() => {
+    resetBoxIdCounter();
+  });
+
+  it("renders the image and a box overlay", () => {
+    renderEditor([{ boxId: "b1", x: 10, y: 10, width: 50, height: 30 }]);
+    expect(screen.getByTestId("box-editor-image")).toBeInTheDocument();
+    expect(screen.getByTestId("box-b1")).toBeInTheDocument();
+  });
+
+  it("creates a new box by dragging on the image", () => {
+    const onChange = vi.fn();
+    renderEditor([], onChange);
+    const editor = screen.getByTestId("box-editor");
+
+    fireEvent.mouseDown(editor, { clientX: 20, clientY: 20 });
+    fireEvent.mouseMove(editor, { clientX: 80, clientY: 60 });
+    fireEvent.mouseUp(editor);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const boxes = onChange.mock.calls[0][0];
+    expect(boxes).toHaveLength(1);
+    expect(boxes[0].x).toBe(20);
+    expect(boxes[0].y).toBe(20);
+    expect(boxes[0].width).toBe(60);
+    expect(boxes[0].height).toBe(40);
+  });
+
+  it("clamps created boxes inside image bounds", () => {
+    const onChange = vi.fn();
+    renderEditor([], onChange);
+    const editor = screen.getByTestId("box-editor");
+
+    fireEvent.mouseDown(editor, { clientX: 180, clientY: 80 });
+    fireEvent.mouseMove(editor, { clientX: 300, clientY: 150 });
+    fireEvent.mouseUp(editor);
+
+    const box = onChange.mock.calls[0][0][0];
+    expect(box.x + box.width).toBeLessThanOrEqual(NATURAL_W);
+    expect(box.y + box.height).toBeLessThanOrEqual(NATURAL_H);
+  });
+
+  it("does not call onChange during mousemove", () => {
+    const onChange = vi.fn();
+    renderEditor([], onChange);
+    const editor = screen.getByTestId("box-editor");
+
+    fireEvent.mouseDown(editor, { clientX: 10, clientY: 10 });
+    fireEvent.mouseMove(editor, { clientX: 20, clientY: 20 });
+    fireEvent.mouseMove(editor, { clientX: 30, clientY: 30 });
+    fireEvent.mouseMove(editor, { clientX: 40, clientY: 40 });
+    fireEvent.mouseUp(editor);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes a selected box when clicking the delete button", () => {
+    const onChange = vi.fn();
+    const { editor } = renderEditor([{ boxId: "b1", x: 10, y: 10, width: 50, height: 30 }], onChange);
+
+    fireEvent.mouseDown(editor, { clientX: 15, clientY: 15 });
+    fireEvent.mouseUp(editor);
+    fireEvent.click(screen.getByTestId("delete-box-b1"));
+
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it("selects a box on click and shows handles", () => {
+    const { editor } = renderEditor([{ boxId: "b1", x: 10, y: 10, width: 50, height: 30 }]);
+
+    fireEvent.mouseDown(editor, { clientX: 15, clientY: 15 });
+    fireEvent.mouseUp(editor);
+
+    expect(screen.getByTestId("handle-nw-b1")).toBeInTheDocument();
+    expect(screen.getByTestId("handle-se-b1")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/BoxEditor.test.tsx
+++ b/frontend/src/components/BoxEditor.test.tsx
@@ -113,4 +113,36 @@ describe("BoxEditor", () => {
     expect(screen.getByTestId("handle-nw-b1")).toBeInTheDocument();
     expect(screen.getByTestId("handle-se-b1")).toBeInTheDocument();
   });
+
+  it("moves a box by dragging its body", () => {
+    const onChange = vi.fn();
+    const { editor } = renderEditor([{ boxId: "b1", x: 10, y: 10, width: 50, height: 30 }], onChange);
+
+    fireEvent.mouseDown(editor, { clientX: 35, clientY: 25 });
+    fireEvent.mouseMove(editor, { clientX: 45, clientY: 35 });
+    fireEvent.mouseUp(editor);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const box = onChange.mock.calls[0][0][0];
+    expect(box.x).toBe(20);
+    expect(box.y).toBe(20);
+    expect(box.width).toBe(50);
+    expect(box.height).toBe(30);
+  });
+
+  it("resizes a box by dragging a handle", () => {
+    const onChange = vi.fn();
+    const { editor } = renderEditor([{ boxId: "b1", x: 10, y: 10, width: 50, height: 30 }], onChange);
+
+    fireEvent.mouseDown(editor, { clientX: 60, clientY: 40 });
+    fireEvent.mouseMove(editor, { clientX: 80, clientY: 60 });
+    fireEvent.mouseUp(editor);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const box = onChange.mock.calls[0][0][0];
+    expect(box.x).toBe(10);
+    expect(box.y).toBe(10);
+    expect(box.width).toBe(70);
+    expect(box.height).toBe(50);
+  });
 });

--- a/frontend/src/components/BoxEditor.tsx
+++ b/frontend/src/components/BoxEditor.tsx
@@ -3,7 +3,6 @@ import type { BulkImageBox } from "@/types/bulkIngestion";
 import {
   createBox,
   naturalBoxToRender,
-  renderBoxToNatural,
   type Point,
   clampBox,
 } from "@/utils/boxGeometry";

--- a/frontend/src/components/BoxEditor.tsx
+++ b/frontend/src/components/BoxEditor.tsx
@@ -1,0 +1,386 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { BulkImageBox } from "@/types/bulkIngestion";
+import {
+  createBox,
+  naturalBoxToRender,
+  renderBoxToNatural,
+  type Point,
+  clampBox,
+} from "@/utils/boxGeometry";
+
+export interface BoxEditorProps {
+  imageUrl: string;
+  naturalWidth: number;
+  naturalHeight: number;
+  boxes: BulkImageBox[];
+  onChange: (boxes: BulkImageBox[]) => void;
+  readOnly?: boolean;
+}
+
+type InteractionMode =
+  | { type: "idle" }
+  | { type: "creating"; start: Point }
+  | { type: "moving"; boxId: string; offset: Point }
+  | { type: "resizing"; boxId: string; handle: ResizeHandle; start: Point };
+
+type ResizeHandle = "nw" | "ne" | "sw" | "se";
+
+const HANDLE_SIZE = 8;
+const BOX_BORDER_WIDTH = 2;
+
+export function BoxEditor({
+  imageUrl,
+  naturalWidth,
+  naturalHeight,
+  boxes,
+  onChange,
+  readOnly = false,
+}: BoxEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [renderedSize, setRenderedSize] = useState({ width: 0, height: 0 });
+  const [selectedBoxId, setSelectedBoxId] = useState<string | null>(null);
+  const [mode, setMode] = useState<InteractionMode>({ type: "idle" });
+  const [previewBox, setPreviewBox] = useState<BulkImageBox | null>(null);
+
+  const dims = {
+    naturalWidth,
+    naturalHeight,
+    renderedWidth: renderedSize.width,
+    renderedHeight: renderedSize.height,
+  };
+
+  const refreshSize = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    setRenderedSize({ width: rect.width, height: rect.height });
+  }, []);
+
+  useEffect(() => {
+    refreshSize();
+    window.addEventListener("resize", refreshSize);
+    return () => window.removeEventListener("resize", refreshSize);
+  }, [refreshSize]);
+
+  const getEventPoint = useCallback(
+    (event: { clientX: number; clientY: number }): { point: Point; natural: Point } => {
+      const container = containerRef.current;
+      if (!container) {
+        return { point: { x: 0, y: 0 }, natural: { x: 0, y: 0 } };
+      }
+      const rect = container.getBoundingClientRect();
+      const point = {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      };
+      return {
+        point,
+        natural: {
+          x: (point.x / rect.width) * naturalWidth,
+          y: (point.y / rect.height) * naturalHeight,
+        },
+      };
+    },
+    [naturalWidth, naturalHeight],
+  );
+
+  const handleBoxChange = useCallback(
+    (nextBoxes: BulkImageBox[]) => {
+      onChange(nextBoxes.map((box) => clampBox(box, naturalWidth, naturalHeight)));
+    },
+    [onChange, naturalWidth, naturalHeight],
+  );
+
+  const findBoxAt = useCallback(
+    (point: Point): BulkImageBox | null => {
+      for (let i = boxes.length - 1; i >= 0; i--) {
+        const rendered = naturalBoxToRender(boxes[i], dims);
+        if (
+          point.x >= rendered.x - BOX_BORDER_WIDTH &&
+          point.x <= rendered.x + rendered.width + BOX_BORDER_WIDTH &&
+          point.y >= rendered.y - BOX_BORDER_WIDTH &&
+          point.y <= rendered.y + rendered.height + BOX_BORDER_WIDTH
+        ) {
+          return boxes[i];
+        }
+      }
+      return null;
+    },
+    [boxes, dims],
+  );
+
+  const findResizeHandle = useCallback(
+    (box: BulkImageBox, point: Point): ResizeHandle | null => {
+      const rendered = naturalBoxToRender(box, dims);
+      const handles: { key: ResizeHandle; x: number; y: number }[] = [
+        { key: "nw", x: rendered.x, y: rendered.y },
+        { key: "ne", x: rendered.x + rendered.width, y: rendered.y },
+        { key: "sw", x: rendered.x, y: rendered.y + rendered.height },
+        { key: "se", x: rendered.x + rendered.width, y: rendered.y + rendered.height },
+      ];
+      for (const handle of handles) {
+        if (
+          Math.abs(point.x - handle.x) <= HANDLE_SIZE &&
+          Math.abs(point.y - handle.y) <= HANDLE_SIZE
+        ) {
+          return handle.key;
+        }
+      }
+      return null;
+    },
+    [dims],
+  );
+
+  const handleMouseDown = useCallback(
+    (event: React.MouseEvent) => {
+      if (readOnly || renderedSize.width === 0) return;
+      event.preventDefault();
+      const { point, natural } = getEventPoint(event);
+
+      const targetBox = findBoxAt(point);
+      if (targetBox) {
+        setSelectedBoxId(targetBox.boxId);
+        const handle = findResizeHandle(targetBox, point);
+        if (handle) {
+          setMode({ type: "resizing", boxId: targetBox.boxId, handle, start: natural });
+        } else {
+          setMode({
+            type: "moving",
+            boxId: targetBox.boxId,
+            offset: {
+              x: natural.x - targetBox.x,
+              y: natural.y - targetBox.y,
+            },
+          });
+        }
+        return;
+      }
+
+      setSelectedBoxId(null);
+      setMode({ type: "creating", start: natural });
+    },
+    [readOnly, renderedSize, getEventPoint, findBoxAt, findResizeHandle],
+  );
+
+  const handleMouseMove = useCallback(
+    (event: React.MouseEvent) => {
+      if (mode.type === "idle" || renderedSize.width === 0) return;
+      event.preventDefault();
+      const { natural } = getEventPoint(event);
+
+      if (mode.type === "creating") {
+        setPreviewBox(createBox(mode.start, natural, naturalWidth, naturalHeight));
+        return;
+      }
+
+      if (mode.type === "moving") {
+        setPreviewBox(
+          clampBox(
+            {
+              ...boxes.find((b) => b.boxId === mode.boxId)!,
+              x: natural.x - mode.offset.x,
+              y: natural.y - mode.offset.y,
+            },
+            naturalWidth,
+            naturalHeight,
+          ),
+        );
+        return;
+      }
+
+      if (mode.type === "resizing") {
+        const box = boxes.find((b) => b.boxId === mode.boxId)!;
+        let nextBox = { ...box };
+        switch (mode.handle) {
+          case "nw":
+            nextBox = {
+              ...box,
+              x: Math.min(natural.x, box.x + box.width),
+              y: Math.min(natural.y, box.y + box.height),
+              width: Math.abs(box.x + box.width - natural.x),
+              height: Math.abs(box.y + box.height - natural.y),
+            };
+            break;
+          case "ne":
+            nextBox = {
+              ...box,
+              y: Math.min(natural.y, box.y + box.height),
+              width: Math.max(0, natural.x - box.x),
+              height: Math.abs(box.y + box.height - natural.y),
+            };
+            break;
+          case "sw":
+            nextBox = {
+              ...box,
+              x: Math.min(natural.x, box.x + box.width),
+              width: Math.abs(box.x + box.width - natural.x),
+              height: Math.max(0, natural.y - box.y),
+            };
+            break;
+          case "se":
+            nextBox = {
+              ...box,
+              width: Math.max(0, natural.x - box.x),
+              height: Math.max(0, natural.y - box.y),
+            };
+            break;
+        }
+        setPreviewBox(clampBox(nextBox, naturalWidth, naturalHeight));
+      }
+    },
+    [mode, getEventPoint, naturalWidth, naturalHeight, boxes, renderedSize],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    if (mode.type === "idle") return;
+
+    if (mode.type === "creating" && previewBox) {
+      if (previewBox.width > 0 && previewBox.height > 0) {
+        const newBox = clampBox(previewBox, naturalWidth, naturalHeight);
+        handleBoxChange([...boxes, newBox]);
+        setSelectedBoxId(newBox.boxId);
+      }
+    } else if ((mode.type === "moving" || mode.type === "resizing") && previewBox) {
+      handleBoxChange(
+        boxes.map((box) => (box.boxId === previewBox.boxId ? previewBox : box)),
+      );
+    }
+
+    setMode({ type: "idle" });
+    setPreviewBox(null);
+  }, [mode, previewBox, boxes, handleBoxChange, naturalWidth, naturalHeight]);
+
+  const handleDelete = useCallback(
+    (boxId: string) => {
+      handleBoxChange(boxes.filter((box) => box.boxId !== boxId));
+      if (selectedBoxId === boxId) setSelectedBoxId(null);
+    },
+    [boxes, handleBoxChange, selectedBoxId],
+  );
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Delete" || event.key === "Backspace") {
+        if (selectedBoxId) handleDelete(selectedBoxId);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [selectedBoxId, handleDelete]);
+
+  const displayBoxes = previewBox
+    ? mode.type === "creating"
+      ? [...boxes, previewBox]
+      : boxes.map((box) => (box.boxId === previewBox.boxId ? previewBox : box))
+    : boxes;
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="box-editor"
+      style={{
+        position: "relative",
+        display: "inline-block",
+        maxWidth: "100%",
+        userSelect: "none",
+      }}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+    >
+      <img
+        src={imageUrl}
+        alt="Review"
+        data-testid="box-editor-image"
+        style={{
+          display: "block",
+          maxWidth: "100%",
+          height: "auto",
+          pointerEvents: "none",
+        }}
+      />
+      {displayBoxes.map((box) => {
+        const rendered = naturalBoxToRender(box, dims);
+        const isSelected = selectedBoxId === box.boxId;
+        return (
+          <div key={box.boxId}>
+            <div
+              data-testid={`box-${box.boxId}`}
+              style={{
+                position: "absolute",
+                left: rendered.x,
+                top: rendered.y,
+                width: rendered.width,
+                height: rendered.height,
+                border: `${BOX_BORDER_WIDTH}px solid ${isSelected ? "var(--color-primary, #2563eb)" : "var(--color-success, #16a34a)"}`,
+                backgroundColor: isSelected
+                  ? "rgba(37, 99, 235, 0.1)"
+                  : "rgba(22, 163, 74, 0.1)",
+                cursor: readOnly ? "default" : "move",
+              }}
+            />
+            {isSelected && !readOnly && (
+              <>
+                {(["nw", "ne", "sw", "se"] as ResizeHandle[]).map((handle) => {
+                  const left =
+                    handle === "nw" || handle === "sw"
+                      ? rendered.x - HANDLE_SIZE / 2
+                      : rendered.x + rendered.width - HANDLE_SIZE / 2;
+                  const top =
+                    handle === "nw" || handle === "ne"
+                      ? rendered.y - HANDLE_SIZE / 2
+                      : rendered.y + rendered.height - HANDLE_SIZE / 2;
+                  return (
+                    <div
+                      key={handle}
+                      data-testid={`handle-${handle}-${box.boxId}`}
+                      style={{
+                        position: "absolute",
+                        left,
+                        top,
+                        width: HANDLE_SIZE,
+                        height: HANDLE_SIZE,
+                        backgroundColor: "var(--color-primary, #2563eb)",
+                        borderRadius: "50%",
+                        cursor:
+                          handle === "nw" || handle === "se"
+                            ? "nwse-resize"
+                            : "nesw-resize",
+                      }}
+                    />
+                  );
+                })}
+                <button
+                  type="button"
+                  data-testid={`delete-box-${box.boxId}`}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleDelete(box.boxId);
+                  }}
+                  style={{
+                    position: "absolute",
+                    left: rendered.x + rendered.width - 12,
+                    top: rendered.y - 12,
+                    width: 20,
+                    height: 20,
+                    borderRadius: "50%",
+                    border: "none",
+                    backgroundColor: "var(--color-error, #dc2626)",
+                    color: "white",
+                    cursor: "pointer",
+                    fontSize: 12,
+                    lineHeight: "20px",
+                    padding: 0,
+                  }}
+                >
+                  ×
+                </button>
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/BulkDetectStep.tsx
+++ b/frontend/src/components/BulkDetectStep.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useState } from "react";
+import type { BulkBatch, BulkImageBox } from "@/types/bulkIngestion";
+import { BoxEditor } from "./BoxEditor";
+
+export interface BulkDetectStepProps {
+  batch: BulkBatch;
+  isLoading: boolean;
+  onDetect: (imageId: string) => void | Promise<void>;
+  onSaveBoxes: (
+    imageId: string,
+    boxes: BulkImageBox[],
+    subject?: string | null,
+  ) => void | Promise<void>;
+  onCommit: (imageId: string) => void | Promise<void>;
+  onDelete: (imageId: string) => void | Promise<void>;
+}
+
+const SUBJECTS = [
+  { value: "math", label: "Math" },
+  { value: "english", label: "English" },
+];
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "uploaded":
+      return "Ready to detect";
+    case "detecting":
+      return "Detecting boxes...";
+    case "detect-failed":
+      return "Detection failed";
+    case "ready":
+      return "Review boxes";
+    default:
+      return status;
+  }
+}
+
+export function BulkDetectStep({
+  batch,
+  isLoading,
+  onDetect,
+  onSaveBoxes,
+  onCommit,
+  onDelete,
+}: BulkDetectStepProps) {
+  const [workingImageId, setWorkingImageId] = useState<string | null>(null);
+  const [pendingBoxes, setPendingBoxes] = useState<Record<string, BulkImageBox[]>>({});
+  const [pendingSubjects, setPendingSubjects] = useState<Record<string, string>>({});
+
+  const withImageLoader = useCallback(
+    async (imageId: string, action: () => void | Promise<void>) => {
+      setWorkingImageId(imageId);
+      try {
+        await action();
+      } finally {
+        setWorkingImageId(null);
+      }
+    },
+    [],
+  );
+
+  const actionableImages = batch.images.filter(
+    (image) => image.status !== "committed" && image.status !== "deleted",
+  );
+
+  return (
+    <div data-testid="bulk-wizard-detect-step">
+      <h2>Review detected boxes</h2>
+      {actionableImages.length === 0 ? (
+        <p data-testid="bulk-detect-empty">All images have been committed.</p>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "24px",
+          }}
+        >
+          {actionableImages.map((image) => {
+            const boxes = pendingBoxes[image.imageId] ?? image.boxes;
+            const subject = pendingSubjects[image.imageId] ?? image.subject ?? "math";
+            const isWorking = isLoading || workingImageId === image.imageId;
+            const canDetect =
+              image.status === "uploaded" || image.status === "detect-failed";
+            const isReady = image.status === "ready";
+
+            return (
+              <div
+                key={image.imageId}
+                data-testid={`bulk-detect-image-${image.imageId}`}
+                style={{
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "8px",
+                  padding: "16px",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    marginBottom: "12px",
+                  }}
+                >
+                  <span data-testid={`bulk-detect-status-${image.imageId}`}>
+                    {statusLabel(image.status)}
+                  </span>
+                  <div style={{ display: "flex", gap: "8px" }}>
+                    <select
+                      data-testid={`bulk-detect-subject-${image.imageId}`}
+                      value={subject}
+                      onChange={(event) =>
+                        setPendingSubjects((prev) => ({
+                          ...prev,
+                          [image.imageId]: event.target.value,
+                        }))
+                      }
+                      disabled={isWorking}
+                    >
+                      {SUBJECTS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                    {canDetect && (
+                      <button
+                        type="button"
+                        data-testid={`bulk-detect-run-${image.imageId}`}
+                        onClick={() =>
+                          withImageLoader(image.imageId, () => onDetect(image.imageId))
+                        }
+                        disabled={isWorking}
+                      >
+                        Detect
+                      </button>
+                    )}
+                    {isReady && (
+                      <button
+                        type="button"
+                        data-testid={`bulk-detect-commit-${image.imageId}`}
+                        onClick={() =>
+                          withImageLoader(image.imageId, () => onCommit(image.imageId))
+                        }
+                        disabled={isWorking}
+                      >
+                        Commit
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      data-testid={`bulk-detect-delete-${image.imageId}`}
+                      onClick={() =>
+                        withImageLoader(image.imageId, () => onDelete(image.imageId))
+                      }
+                      disabled={isWorking}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                {image.detection.failureMessage && (
+                  <div
+                    data-testid={`bulk-detect-failure-${image.imageId}`}
+                    style={{ color: "var(--color-error, #dc2626)", marginBottom: "12px" }}
+                  >
+                    {image.detection.failureMessage}
+                  </div>
+                )}
+
+                <BoxEditor
+                  imageUrl={image.sourceImage.mediaUrl || ""}
+                  naturalWidth={image.sourceImage.width || 1}
+                  naturalHeight={image.sourceImage.height || 1}
+                  boxes={boxes}
+                  onChange={(next) =>
+                    setPendingBoxes((prev) => ({
+                      ...prev,
+                      [image.imageId]: next,
+                    }))
+                  }
+                  readOnly={isWorking}
+                />
+
+                {JSON.stringify(boxes) !== JSON.stringify(image.boxes) && (
+                  <div style={{ marginTop: "12px" }}>
+                    <button
+                      type="button"
+                      data-testid={`bulk-detect-save-${image.imageId}`}
+                      onClick={() =>
+                        withImageLoader(image.imageId, () =>
+                          onSaveBoxes(image.imageId, boxes, subject),
+                        )
+                      }
+                      disabled={isWorking}
+                    >
+                      Save boxes
+                    </button>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/BulkDetectStep.tsx
+++ b/frontend/src/components/BulkDetectStep.tsx
@@ -59,6 +59,23 @@ export function BulkDetectStep({
     [],
   );
 
+  const handleSave = useCallback(
+    async (imageId: string, boxes: BulkImageBox[], subject: string) => {
+      await onSaveBoxes(imageId, boxes, subject);
+      setPendingBoxes((prev) => {
+        const next = { ...prev };
+        delete next[imageId];
+        return next;
+      });
+      setPendingSubjects((prev) => {
+        const next = { ...prev };
+        delete next[imageId];
+        return next;
+      });
+    },
+    [onSaveBoxes],
+  );
+
   const actionableImages = batch.images.filter(
     (image) => image.status !== "committed" && image.status !== "deleted",
   );
@@ -78,8 +95,12 @@ export function BulkDetectStep({
         >
           {actionableImages.map((image) => {
             const boxes = pendingBoxes[image.imageId] ?? image.boxes;
-            const subject = pendingSubjects[image.imageId] ?? image.subject ?? "math";
+            const currentSubject = image.subject ?? "math";
+            const subject = pendingSubjects[image.imageId] ?? currentSubject;
             const isWorking = isLoading || workingImageId === image.imageId;
+            const boxesChanged =
+              JSON.stringify(boxes) !== JSON.stringify(image.boxes);
+            const subjectChanged = subject !== currentSubject;
             const canDetect =
               image.status === "uploaded" || image.status === "detect-failed";
             const isReady = image.status === "ready";
@@ -183,19 +204,19 @@ export function BulkDetectStep({
                   readOnly={isWorking}
                 />
 
-                {JSON.stringify(boxes) !== JSON.stringify(image.boxes) && (
+                {(boxesChanged || subjectChanged) && (
                   <div style={{ marginTop: "12px" }}>
                     <button
                       type="button"
                       data-testid={`bulk-detect-save-${image.imageId}`}
                       onClick={() =>
                         withImageLoader(image.imageId, () =>
-                          onSaveBoxes(image.imageId, boxes, subject),
+                          handleSave(image.imageId, boxes, subject),
                         )
                       }
                       disabled={isWorking}
                     >
-                      Save boxes
+                      Save
                     </button>
                   </div>
                 )}

--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -360,4 +360,174 @@ describe("BulkIngestionWizard", () => {
       expect(mocks.commitImage).toHaveBeenCalledWith("batch-1", "img-1");
     });
   });
+
+  it("surfaces upload validation failures", async () => {
+    mocks.getActiveBatch.mockRejectedValue(
+      new ApiError("No active batch found", 404, "NOT_FOUND"),
+    );
+    mocks.createBatch.mockResolvedValue({ batch: makeBatch({ id: "batch-new" }) });
+    mocks.uploadBatchImages.mockRejectedValue(new Error("Unsupported image type"));
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-create-batch")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-wizard-create-batch"));
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-upload-input")).toBeInTheDocument();
+    });
+
+    const file = new File(["image"], "test.bmp", { type: "image/bmp" });
+    fireEvent.change(screen.getByTestId("bulk-wizard-upload-input"), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-upload-error")).toHaveTextContent(
+        "Unsupported image type",
+      );
+    });
+    expect(mocks.uploadBatchImages).toHaveBeenCalledWith("batch-new", [file]);
+  });
+
+  it("renders detection failure state with retry and manual box entry", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "detect-failed",
+            order: 0,
+            sourceImage: {
+              bucket: "b",
+              objectKey: "k",
+              width: 100,
+              height: 100,
+              mediaUrl: "http://example.com/img.png",
+            },
+            boxes: [],
+            detection: { failureMessage: "Vision model error" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-failure-img-1")).toHaveTextContent(
+        "Vision model error",
+      );
+    });
+    expect(screen.getByTestId("box-editor")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-detect-run-img-1")).toBeInTheDocument();
+  });
+
+  it("renders a ready image with no boxes for manual box entry", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: {
+              bucket: "b",
+              objectKey: "k",
+              width: 100,
+              height: 100,
+              mediaUrl: "http://example.com/img.png",
+            },
+            boxes: [],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("box-editor")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("bulk-detect-status-img-1")).toHaveTextContent(
+      "Review boxes",
+    );
+  });
+
+  it("persists subject override through the save API", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: {
+              bucket: "b",
+              objectKey: "k",
+              width: 100,
+              height: 100,
+              mediaUrl: "http://example.com/img.png",
+            },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.saveImageBoxes.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: {
+              bucket: "b",
+              objectKey: "k",
+              width: 100,
+              height: 100,
+              mediaUrl: "http://example.com/img.png",
+            },
+            subject: "english",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-subject-img-1")).toHaveValue("math");
+    });
+
+    fireEvent.change(screen.getByTestId("bulk-detect-subject-img-1"), {
+      target: { value: "english" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-save-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-detect-save-img-1"));
+
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledWith(
+        "batch-1",
+        "img-1",
+        [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+        "english",
+      );
+    });
+  });
 });

--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -9,6 +9,10 @@ const mocks = vi.hoisted(() => ({
   getBatch: vi.fn<() => Promise<BatchResponse>>(),
   createBatch: vi.fn<() => Promise<BatchResponse>>(),
   uploadBatchImages: vi.fn<() => Promise<BatchResponse>>(),
+  detectImageBoxes: vi.fn<() => Promise<BatchResponse>>(),
+  saveImageBoxes: vi.fn<() => Promise<BatchResponse>>(),
+  commitImage: vi.fn<() => Promise<BatchResponse>>(),
+  deleteImage: vi.fn<() => Promise<BatchResponse>>(),
 }));
 
 vi.mock("@/api/bulkIngestion", () => ({
@@ -16,6 +20,10 @@ vi.mock("@/api/bulkIngestion", () => ({
   getBatch: mocks.getBatch,
   createBatch: mocks.createBatch,
   uploadBatchImages: mocks.uploadBatchImages,
+  detectImageBoxes: mocks.detectImageBoxes,
+  saveImageBoxes: mocks.saveImageBoxes,
+  commitImage: mocks.commitImage,
+  deleteImage: mocks.deleteImage,
 }));
 
 function makeBatch(overrides: Partial<BulkBatch> = {}): BulkBatch {
@@ -199,5 +207,157 @@ describe("BulkIngestionWizard", () => {
 
     expect(getItemSpy).not.toHaveBeenCalledWith(expect.stringContaining("batch"));
     expect(setItemSpy).not.toHaveBeenCalledWith(expect.stringContaining("batch"), expect.anything());
+  });
+
+  it("uploads images and advances to the detect step", async () => {
+    mocks.getActiveBatch.mockRejectedValue(
+      new ApiError("No active batch found", 404, "NOT_FOUND"),
+    );
+    mocks.createBatch.mockResolvedValue({ batch: makeBatch({ id: "batch-new" }) });
+    mocks.uploadBatchImages.mockResolvedValue({
+      batch: makeBatch({
+        id: "batch-new",
+        images: [
+          {
+            imageId: "img-1",
+            status: "uploaded",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-create-batch")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-wizard-create-batch"));
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-upload-input")).toBeInTheDocument();
+    });
+
+    const file = new File(["image"], "test.png", { type: "image/png" });
+    fireEvent.change(screen.getByTestId("bulk-wizard-upload-input"), {
+      target: { files: [file] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-detect-step")).toBeInTheDocument();
+    });
+    expect(mocks.uploadBatchImages).toHaveBeenCalledWith("batch-new", [file]);
+  });
+
+  it("runs detection for an uploaded image", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "uploaded",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.detectImageBoxes.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-detect-run-img-1"));
+
+    await waitFor(() => {
+      expect(mocks.detectImageBoxes).toHaveBeenCalledWith("batch-1", "img-1");
+    });
+  });
+
+  it("commits an image after reviewing boxes", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.commitImage.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "queued",
+            order: 0,
+            draft: {},
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-commit-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-detect-commit-img-1"));
+
+    await waitFor(() => {
+      expect(mocks.commitImage).toHaveBeenCalledWith("batch-1", "img-1");
+    });
   });
 });

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -61,6 +61,7 @@ export function BulkIngestionWizard({
   const [step, setStep] = useState<BulkWizardStep>("upload");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>("");
+  const [uploadError, setUploadError] = useState<string>("");
 
   const setBatchAndStep = useCallback((nextBatch: BulkBatch) => {
     setBatch(nextBatch);
@@ -102,6 +103,7 @@ export function BulkIngestionWizard({
   const handleCreateBatch = useCallback(async () => {
     setIsLoading(true);
     setError("");
+    setUploadError("");
     try {
       const response = await createBatch();
       setBatchAndStep(response.batch);
@@ -118,12 +120,14 @@ export function BulkIngestionWizard({
       if (fileArray.length === 0 || !batch) return;
 
       setIsLoading(true);
-      setError("");
+      setUploadError("");
       try {
         const response = await uploadBatchImages(batch.id, fileArray);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to upload images");
+        setUploadError(
+          err instanceof Error ? err.message : "Failed to upload images",
+        );
       } finally {
         setIsLoading(false);
       }
@@ -319,7 +323,7 @@ export function BulkIngestionWizard({
           <BulkUploadStep
             batch={batch}
             isLoading={isLoading}
-            error={error}
+            error={uploadError}
             onCreateBatch={handleCreateBatch}
             onUpload={handleUploadFiles}
           />

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -1,13 +1,18 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { ChangeEvent } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ApiError } from "@/api/client";
 import {
+  commitImage,
   createBatch,
+  deleteImage,
+  detectImageBoxes,
   getActiveBatch,
   getBatch,
+  saveImageBoxes,
   uploadBatchImages,
 } from "@/api/bulkIngestion";
-import type { BulkBatch, BulkWizardStep } from "@/types/bulkIngestion";
+import type { BulkBatch, BulkImageBox, BulkWizardStep } from "@/types/bulkIngestion";
+import { BulkUploadStep } from "./BulkUploadStep";
+import { BulkDetectStep } from "./BulkDetectStep";
 
 export type { BulkWizardStep };
 
@@ -56,7 +61,6 @@ export function BulkIngestionWizard({
   const [step, setStep] = useState<BulkWizardStep>("upload");
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>("");
-  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const setBatchAndStep = useCallback((nextBatch: BulkBatch) => {
     setBatch(nextBatch);
@@ -108,16 +112,15 @@ export function BulkIngestionWizard({
     }
   }, [setBatchAndStep]);
 
-  const handleFileSelection = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const files = Array.from(event.target.files ?? []);
-      event.target.value = "";
-      if (files.length === 0 || !batch) return;
+  const handleUploadFiles = useCallback(
+    async (files: FileList | null) => {
+      const fileArray = Array.from(files ?? []);
+      if (fileArray.length === 0 || !batch) return;
 
       setIsLoading(true);
       setError("");
       try {
-        const response = await uploadBatchImages(batch.id, files);
+        const response = await uploadBatchImages(batch.id, fileArray);
         setBatchAndStep(response.batch);
       } catch (err) {
         setError(err instanceof Error ? err.message : "Failed to upload images");
@@ -128,9 +131,61 @@ export function BulkIngestionWizard({
     [batch, setBatchAndStep],
   );
 
-  const handleStartUpload = useCallback(() => {
-    fileInputRef.current?.click();
-  }, []);
+  const handleDetect = useCallback(
+    async (imageId: string) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await detectImageBoxes(batch.id, imageId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to detect boxes");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  const handleSaveBoxes = useCallback(
+    async (imageId: string, boxes: BulkImageBox[], subject?: string | null) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await saveImageBoxes(batch.id, imageId, boxes, subject);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to save boxes");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  const handleCommit = useCallback(
+    async (imageId: string) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await commitImage(batch.id, imageId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to commit image");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  const handleDeleteImage = useCallback(
+    async (imageId: string) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await deleteImage(batch.id, imageId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to delete image");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
 
   if (isLoading) {
     return (
@@ -261,40 +316,24 @@ export function BulkIngestionWizard({
         }}
       >
         {step === "upload" && (
-          <div data-testid="bulk-wizard-upload-step">
-            <h2>Upload images</h2>
-            {batch ? (
-              <>
-                <p>Add images to your batch.</p>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  multiple
-                  onChange={handleFileSelection}
-                  data-testid="bulk-wizard-upload-input"
-                  style={{ display: "none" }}
-                />
-                <button type="button" onClick={handleStartUpload}>
-                  Choose image files
-                </button>
-              </>
-            ) : (
-              <>
-                <p>No active batch found. Create one to get started.</p>
-                <button type="button" onClick={handleCreateBatch} data-testid="bulk-wizard-create-batch">
-                  Create batch
-                </button>
-              </>
-            )}
-          </div>
+          <BulkUploadStep
+            batch={batch}
+            isLoading={isLoading}
+            error={error}
+            onCreateBatch={handleCreateBatch}
+            onUpload={handleUploadFiles}
+          />
         )}
 
-        {step === "detect" && (
-          <div data-testid="bulk-wizard-detect-step">
-            <h2>Review detected boxes</h2>
-            <p>Box editor will be added in a later step.</p>
-          </div>
+        {step === "detect" && batch && (
+          <BulkDetectStep
+            batch={batch}
+            isLoading={isLoading}
+            onDetect={handleDetect}
+            onSaveBoxes={handleSaveBoxes}
+            onCommit={handleCommit}
+            onDelete={handleDeleteImage}
+          />
         )}
 
         {step === "review" && (

--- a/frontend/src/components/BulkUploadStep.tsx
+++ b/frontend/src/components/BulkUploadStep.tsx
@@ -1,0 +1,78 @@
+import type { BulkBatch } from "@/types/bulkIngestion";
+
+export interface BulkUploadStepProps {
+  batch: BulkBatch | null;
+  isLoading: boolean;
+  error?: string;
+  onCreateBatch: () => void;
+  onUpload: (files: FileList | null) => void;
+}
+
+export function BulkUploadStep({
+  batch,
+  isLoading,
+  error,
+  onCreateBatch,
+  onUpload,
+}: BulkUploadStepProps) {
+  return (
+    <div data-testid="bulk-wizard-upload-step">
+      <h2>Upload images</h2>
+      {error && (
+        <div
+          data-testid="bulk-upload-error"
+          style={{ color: "var(--color-error, #dc2626)", marginBottom: "16px" }}
+        >
+          {error}
+        </div>
+      )}
+      {batch ? (
+        <>
+          <p>Add images to your batch.</p>
+          {batch.images.length > 0 && (
+            <ul data-testid="bulk-upload-image-list">
+              {batch.images.map((image) => (
+                <li key={image.imageId}>{image.sourceImage.objectKey || image.imageId}</li>
+              ))}
+            </ul>
+          )}
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            data-testid="bulk-wizard-upload-input"
+            onChange={(event) => onUpload(event.target.files)}
+            style={{ display: "none" }}
+          />
+          <label>
+            <button
+              type="button"
+              data-testid="bulk-wizard-upload-button"
+              onClick={() => {
+                const input = document.querySelector<HTMLInputElement>(
+                  '[data-testid="bulk-wizard-upload-input"]',
+                );
+                input?.click();
+              }}
+              disabled={isLoading}
+            >
+              Choose image files
+            </button>
+          </label>
+        </>
+      ) : (
+        <>
+          <p>No active batch found. Create one to get started.</p>
+          <button
+            type="button"
+            onClick={onCreateBatch}
+            disabled={isLoading}
+            data-testid="bulk-wizard-create-batch"
+          >
+            Create batch
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/BulkUploadStep.tsx
+++ b/frontend/src/components/BulkUploadStep.tsx
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import type { BulkBatch } from "@/types/bulkIngestion";
 
 export interface BulkUploadStepProps {
@@ -15,6 +16,8 @@ export function BulkUploadStep({
   onCreateBatch,
   onUpload,
 }: BulkUploadStepProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
   return (
     <div data-testid="bulk-wizard-upload-step">
       <h2>Upload images</h2>
@@ -37,28 +40,25 @@ export function BulkUploadStep({
             </ul>
           )}
           <input
+            ref={inputRef}
             type="file"
             accept="image/*"
             multiple
             data-testid="bulk-wizard-upload-input"
-            onChange={(event) => onUpload(event.target.files)}
+            onChange={(event) => {
+              onUpload(event.target.files);
+              event.target.value = "";
+            }}
             style={{ display: "none" }}
           />
-          <label>
-            <button
-              type="button"
-              data-testid="bulk-wizard-upload-button"
-              onClick={() => {
-                const input = document.querySelector<HTMLInputElement>(
-                  '[data-testid="bulk-wizard-upload-input"]',
-                );
-                input?.click();
-              }}
-              disabled={isLoading}
-            >
-              Choose image files
-            </button>
-          </label>
+          <button
+            type="button"
+            data-testid="bulk-wizard-upload-button"
+            onClick={() => inputRef.current?.click()}
+            disabled={isLoading}
+          >
+            Choose image files
+          </button>
         </>
       ) : (
         <>

--- a/frontend/src/utils/boxGeometry.test.ts
+++ b/frontend/src/utils/boxGeometry.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import type { BulkImageBox } from "@/types/bulkIngestion";
+import {
+  clampBox,
+  createBox,
+  naturalBoxToRender,
+  naturalPointToRender,
+  renderBoxToNatural,
+  renderPointToNatural,
+  resetBoxIdCounter,
+} from "./boxGeometry";
+
+const dims = {
+  naturalWidth: 200,
+  naturalHeight: 100,
+  renderedWidth: 100,
+  renderedHeight: 50,
+};
+
+describe("boxGeometry", () => {
+  beforeEach(() => {
+    resetBoxIdCounter();
+  });
+
+  it("converts a rendered point to natural coordinates", () => {
+    expect(renderPointToNatural({ x: 50, y: 25 }, dims)).toEqual({
+      x: 100,
+      y: 50,
+    });
+  });
+
+  it("converts a natural point to rendered coordinates", () => {
+    expect(naturalPointToRender({ x: 100, y: 50 }, dims)).toEqual({
+      x: 50,
+      y: 25,
+    });
+  });
+
+  it("converts a natural box to rendered coordinates", () => {
+    const box: BulkImageBox = {
+      boxId: "a",
+      x: 40,
+      y: 20,
+      width: 60,
+      height: 30,
+    };
+    expect(naturalBoxToRender(box, dims)).toEqual({
+      boxId: "a",
+      x: 20,
+      y: 10,
+      width: 30,
+      height: 15,
+    });
+  });
+
+  it("converts a rendered box to natural coordinates", () => {
+    const box: BulkImageBox = {
+      boxId: "a",
+      x: 20,
+      y: 10,
+      width: 30,
+      height: 15,
+    };
+    expect(renderBoxToNatural(box, dims)).toEqual({
+      boxId: "a",
+      x: 40,
+      y: 20,
+      width: 60,
+      height: 30,
+    });
+  });
+
+  it("clamps boxes inside image bounds and enforces a minimum size", () => {
+    const box: BulkImageBox = {
+      boxId: "a",
+      x: 190,
+      y: 90,
+      width: 20,
+      height: 20,
+    };
+    expect(clampBox(box, 200, 100)).toEqual({
+      boxId: "a",
+      x: 190,
+      y: 90,
+      width: 10,
+      height: 10,
+    });
+  });
+
+  it("creates a box from two natural points", () => {
+    const box = createBox({ x: 100, y: 80 }, { x: 50, y: 40 }, 200, 100);
+    expect(box).toMatchObject({
+      boxId: "box-1",
+      x: 50,
+      y: 40,
+      width: 50,
+      height: 40,
+    });
+  });
+});

--- a/frontend/src/utils/boxGeometry.test.ts
+++ b/frontend/src/utils/boxGeometry.test.ts
@@ -5,8 +5,6 @@ import {
   createBox,
   naturalBoxToRender,
   naturalPointToRender,
-  renderBoxToNatural,
-  renderPointToNatural,
   resetBoxIdCounter,
 } from "./boxGeometry";
 
@@ -20,13 +18,6 @@ const dims = {
 describe("boxGeometry", () => {
   beforeEach(() => {
     resetBoxIdCounter();
-  });
-
-  it("converts a rendered point to natural coordinates", () => {
-    expect(renderPointToNatural({ x: 50, y: 25 }, dims)).toEqual({
-      x: 100,
-      y: 50,
-    });
   });
 
   it("converts a natural point to rendered coordinates", () => {
@@ -53,23 +44,6 @@ describe("boxGeometry", () => {
     });
   });
 
-  it("converts a rendered box to natural coordinates", () => {
-    const box: BulkImageBox = {
-      boxId: "a",
-      x: 20,
-      y: 10,
-      width: 30,
-      height: 15,
-    };
-    expect(renderBoxToNatural(box, dims)).toEqual({
-      boxId: "a",
-      x: 40,
-      y: 20,
-      width: 60,
-      height: 30,
-    });
-  });
-
   it("clamps boxes inside image bounds and enforces a minimum size", () => {
     const box: BulkImageBox = {
       boxId: "a",
@@ -90,7 +64,7 @@ describe("boxGeometry", () => {
   it("creates a box from two natural points", () => {
     const box = createBox({ x: 100, y: 80 }, { x: 50, y: 40 }, 200, 100);
     expect(box).toMatchObject({
-      boxId: "box-1",
+      boxId: "client-box-1",
       x: 50,
       y: 40,
       width: 50,

--- a/frontend/src/utils/boxGeometry.ts
+++ b/frontend/src/utils/boxGeometry.ts
@@ -17,18 +17,6 @@ export interface RenderedImageDimensions {
   renderedHeight: number;
 }
 
-export function renderPointToNatural(
-  point: Point,
-  dims: RenderedImageDimensions,
-): Point {
-  const scaleX = dims.naturalWidth / dims.renderedWidth;
-  const scaleY = dims.naturalHeight / dims.renderedHeight;
-  return {
-    x: point.x * scaleX,
-    y: point.y * scaleY,
-  };
-}
-
 export function naturalPointToRender(
   point: Point,
   dims: RenderedImageDimensions,
@@ -47,24 +35,6 @@ export function naturalBoxToRender(
 ): BulkImageBox {
   const topLeft = naturalPointToRender({ x: box.x, y: box.y }, dims);
   const bottomRight = naturalPointToRender(
-    { x: box.x + box.width, y: box.y + box.height },
-    dims,
-  );
-  return {
-    ...box,
-    x: topLeft.x,
-    y: topLeft.y,
-    width: bottomRight.x - topLeft.x,
-    height: bottomRight.y - topLeft.y,
-  };
-}
-
-export function renderBoxToNatural(
-  box: BulkImageBox,
-  dims: RenderedImageDimensions,
-): BulkImageBox {
-  const topLeft = renderPointToNatural({ x: box.x, y: box.y }, dims);
-  const bottomRight = renderPointToNatural(
     { x: box.x + box.width, y: box.y + box.height },
     dims,
   );
@@ -119,7 +89,7 @@ let boxIdCounter = 0;
 
 export function generateBoxId(): string {
   boxIdCounter += 1;
-  return `box-${boxIdCounter}`;
+  return `client-box-${boxIdCounter}`;
 }
 
 export function resetBoxIdCounter(): void {

--- a/frontend/src/utils/boxGeometry.ts
+++ b/frontend/src/utils/boxGeometry.ts
@@ -5,11 +5,6 @@ export interface Point {
   y: number;
 }
 
-export interface Size {
-  width: number;
-  height: number;
-}
-
 export interface RenderedImageDimensions {
   naturalWidth: number;
   naturalHeight: number;

--- a/frontend/src/utils/boxGeometry.ts
+++ b/frontend/src/utils/boxGeometry.ts
@@ -1,0 +1,127 @@
+import type { BulkImageBox } from "@/types/bulkIngestion";
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface RenderedImageDimensions {
+  naturalWidth: number;
+  naturalHeight: number;
+  renderedWidth: number;
+  renderedHeight: number;
+}
+
+export function renderPointToNatural(
+  point: Point,
+  dims: RenderedImageDimensions,
+): Point {
+  const scaleX = dims.naturalWidth / dims.renderedWidth;
+  const scaleY = dims.naturalHeight / dims.renderedHeight;
+  return {
+    x: point.x * scaleX,
+    y: point.y * scaleY,
+  };
+}
+
+export function naturalPointToRender(
+  point: Point,
+  dims: RenderedImageDimensions,
+): Point {
+  const scaleX = dims.renderedWidth / dims.naturalWidth;
+  const scaleY = dims.renderedHeight / dims.naturalHeight;
+  return {
+    x: point.x * scaleX,
+    y: point.y * scaleY,
+  };
+}
+
+export function naturalBoxToRender(
+  box: BulkImageBox,
+  dims: RenderedImageDimensions,
+): BulkImageBox {
+  const topLeft = naturalPointToRender({ x: box.x, y: box.y }, dims);
+  const bottomRight = naturalPointToRender(
+    { x: box.x + box.width, y: box.y + box.height },
+    dims,
+  );
+  return {
+    ...box,
+    x: topLeft.x,
+    y: topLeft.y,
+    width: bottomRight.x - topLeft.x,
+    height: bottomRight.y - topLeft.y,
+  };
+}
+
+export function renderBoxToNatural(
+  box: BulkImageBox,
+  dims: RenderedImageDimensions,
+): BulkImageBox {
+  const topLeft = renderPointToNatural({ x: box.x, y: box.y }, dims);
+  const bottomRight = renderPointToNatural(
+    { x: box.x + box.width, y: box.y + box.height },
+    dims,
+  );
+  return {
+    ...box,
+    x: topLeft.x,
+    y: topLeft.y,
+    width: bottomRight.x - topLeft.x,
+    height: bottomRight.y - topLeft.y,
+  };
+}
+
+const MIN_BOX_SIZE = 4;
+
+export function clampBox(
+  box: BulkImageBox,
+  naturalWidth: number,
+  naturalHeight: number,
+): BulkImageBox {
+  let x = Math.max(0, Math.min(box.x, naturalWidth - MIN_BOX_SIZE));
+  let y = Math.max(0, Math.min(box.y, naturalHeight - MIN_BOX_SIZE));
+  let width = Math.max(MIN_BOX_SIZE, box.width);
+  let height = Math.max(MIN_BOX_SIZE, box.height);
+
+  if (x + width > naturalWidth) {
+    width = naturalWidth - x;
+  }
+  if (y + height > naturalHeight) {
+    height = naturalHeight - y;
+  }
+
+  return { ...box, x, y, width, height };
+}
+
+export function createBox(
+  naturalStart: Point,
+  naturalEnd: Point,
+  naturalWidth: number,
+  naturalHeight: number,
+): BulkImageBox {
+  const raw: BulkImageBox = {
+    boxId: generateBoxId(),
+    x: Math.min(naturalStart.x, naturalEnd.x),
+    y: Math.min(naturalStart.y, naturalEnd.y),
+    width: Math.abs(naturalEnd.x - naturalStart.x),
+    height: Math.abs(naturalEnd.y - naturalStart.y),
+  };
+  return clampBox(raw, naturalWidth, naturalHeight);
+}
+
+let boxIdCounter = 0;
+
+export function generateBoxId(): string {
+  boxIdCounter += 1;
+  return `box-${boxIdCounter}`;
+}
+
+export function resetBoxIdCounter(): void {
+  boxIdCounter = 0;
+}


### PR DESCRIPTION
## Summary

Builds the frontend upload, detection, and box-review UI for the bulk ingestion wizard.

## Linked Issue

Closes #368

## Issue Alignment

This PR implements the issue by:

- Adding an upload UI with file selection and validation-error display.
- Showing per-image detection status (uploaded/detecting/ready/detect-failed) in the detect step.
- Adding a mouse-first rectangle box editor with add, move, resize, and delete.
- Constraining boxes within natural image bounds and enforcing a minimum size.
- Supporting image-level subject override (math/english).
- Supporting commit/advance and delete for each image.
- Supporting manual box entry after detection failure.
- Keeping mouse interactions local (no API calls on `mousemove`).

Scope covered:

- Bulk ingestion API client extensions for detect/save/commit/delete.
- `boxGeometry` coordinate-conversion utilities.
- `BoxEditor`, `BulkUploadStep`, and `BulkDetectStep` components.
- Wizard integration and step derivation.
- Component and utility tests.

Out of scope / intentionally not included:

- Keyboard-first box editing.
- Split/merge/polygon/rotated boxes.
- Manual reading-order editing.
- Extraction review UI (#369).
- Submit UI (#370).
- E2E coverage (#372).

## Implementation Notes

- Boxes are stored in natural image coordinates (pixels) and transformed to/from rendered dimensions for display and mouse input.
- `BoxEditor` batches changes and only calls `onChange` on mouse up.
- `BulkDetectStep` keeps pending box/subject edits locally until the user clicks Save.

## Tests

Commands run:

- `npm test -- --run` — 375 passed
- `npm run build` — succeeded

Automated tests added or updated:

- `src/utils/boxGeometry.test.ts` — coordinate conversion, clamping, box creation.
- `src/components/BoxEditor.test.tsx` — create, select, delete, bounds clamping, no `onChange` during `mousemove`.
- `src/components/BulkIngestionWizard.test.tsx` — upload success, detection run, commit.
- `src/api/bulkIngestion.test.ts` — detect, save boxes, commit, delete endpoints.

Manual verification:

- TypeScript build passes.

## Deviations From Issue Plan

None.

## Follow-Up Work

- #369 Build extraction progress and draft review UI.
- #370 Build submit gate, submit action, and result summary UI.
- #372 Add full workflow E2E coverage and retire old single-flow entry.
