### PR TITLE
feat(frontend): build extraction progress and draft review UI

### DIFF
--- a/frontend/src/api/bulkIngestion.test.ts
+++ b/frontend/src/api/bulkIngestion.test.ts
@@ -2,11 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   commitImage,
   createBatch,
+  deleteBatchItem,
   deleteImage,
   detectImageBoxes,
   getActiveBatch,
   getBatch,
+  retryItem,
   saveImageBoxes,
+  startBatchExtraction,
+  undoDeleteBatchItem,
+  updateItemDraft,
   uploadBatchImages,
 } from "./bulkIngestion";
 import type { BatchResponse } from "@/types/bulkIngestion";
@@ -214,6 +219,124 @@ describe("bulk ingestion API client", () => {
         {
           method: "DELETE",
           credentials: "include",
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("startBatchExtraction", () => {
+    it("posts to the extract endpoint", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ batchId: "batch-1", status: "extracting" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await startBatchExtraction("batch-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/extract",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: undefined,
+        },
+      );
+      expect(result).toEqual({ batchId: "batch-1", status: "extracting" });
+    });
+  });
+
+  describe("updateItemDraft", () => {
+    it("patches item draft fields", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const draft = { text: "updated", correctAnswer: "5" };
+      const result = await updateItemDraft("batch-1", "item-1", draft);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/items/item-1",
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify(draft),
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("retryItem", () => {
+    it("posts to the item retry endpoint", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await retryItem("batch-1", "item-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/items/item-1/retry",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: undefined,
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("deleteBatchItem", () => {
+    it("deletes the item", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await deleteBatchItem("batch-1", "item-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/items/item-1",
+        {
+          method: "DELETE",
+          credentials: "include",
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("undoDeleteBatchItem", () => {
+    it("posts to the undo-delete endpoint", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await undoDeleteBatchItem("batch-1", "item-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/items/item-1/undo-delete",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: undefined,
         },
       );
       expect(result).toEqual(response);

--- a/frontend/src/api/bulkIngestion.ts
+++ b/frontend/src/api/bulkIngestion.ts
@@ -1,5 +1,9 @@
 import { api } from "./client";
-import type { BatchResponse, BulkImageBox } from "@/types/bulkIngestion";
+import type {
+  BatchResponse,
+  BulkDraft,
+  BulkImageBox,
+} from "@/types/bulkIngestion";
 
 export async function createBatch(): Promise<BatchResponse> {
   return api.post<BatchResponse>("/ingestion-batches", undefined);
@@ -65,5 +69,54 @@ export async function deleteImage(
 ): Promise<BatchResponse> {
   return api.delete<BatchResponse>(
     `/ingestion-batches/${batchId}/images/${imageId}`,
+  );
+}
+
+export async function startBatchExtraction(
+  batchId: string,
+): Promise<{ batchId: string; status: string }> {
+  return api.post<{ batchId: string; status: string }>(
+    `/ingestion-batches/${batchId}/extract`,
+    undefined,
+  );
+}
+
+export async function updateItemDraft(
+  batchId: string,
+  itemId: string,
+  draft: Partial<BulkDraft>,
+): Promise<BatchResponse> {
+  return api.patch<BatchResponse>(
+    `/ingestion-batches/${batchId}/items/${itemId}`,
+    draft,
+  );
+}
+
+export async function retryItem(
+  batchId: string,
+  itemId: string,
+): Promise<BatchResponse> {
+  return api.post<BatchResponse>(
+    `/ingestion-batches/${batchId}/items/${itemId}/retry`,
+    undefined,
+  );
+}
+
+export async function deleteBatchItem(
+  batchId: string,
+  itemId: string,
+): Promise<BatchResponse> {
+  return api.delete<BatchResponse>(
+    `/ingestion-batches/${batchId}/items/${itemId}`,
+  );
+}
+
+export async function undoDeleteBatchItem(
+  batchId: string,
+  itemId: string,
+): Promise<BatchResponse> {
+  return api.post<BatchResponse>(
+    `/ingestion-batches/${batchId}/items/${itemId}/undo-delete`,
+    undefined,
   );
 }

--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { BulkIngestionWizard } from "./BulkIngestionWizard";
 import { ApiError } from "@/api/client";
 import type { BatchResponse, BulkBatch } from "@/types/bulkIngestion";
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   saveImageBoxes: vi.fn<() => Promise<BatchResponse>>(),
   commitImage: vi.fn<() => Promise<BatchResponse>>(),
   deleteImage: vi.fn<() => Promise<BatchResponse>>(),
+  startBatchExtraction: vi.fn<() => Promise<BatchResponse>>(),
 }));
 
 vi.mock("@/api/bulkIngestion", () => ({
@@ -24,6 +25,7 @@ vi.mock("@/api/bulkIngestion", () => ({
   saveImageBoxes: mocks.saveImageBoxes,
   commitImage: mocks.commitImage,
   deleteImage: mocks.deleteImage,
+  startBatchExtraction: mocks.startBatchExtraction,
 }));
 
 function makeBatch(overrides: Partial<BulkBatch> = {}): BulkBatch {
@@ -190,6 +192,124 @@ describe("BulkIngestionWizard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
     });
+  });
+
+  it("starts extraction once when entering the review step and not again on poll refresh", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "queued",
+            order: 0,
+            draft: {},
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.startBatchExtraction.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "queued",
+            order: 0,
+            draft: {},
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "extracting",
+            order: 0,
+            draft: {},
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+    expect(mocks.startBatchExtraction).toHaveBeenCalledTimes(1);
+    expect(mocks.startBatchExtraction).toHaveBeenCalledWith("batch-1");
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    await waitFor(() => {
+      expect(mocks.getBatch).toHaveBeenCalledWith("batch-1");
+    });
+    expect(mocks.startBatchExtraction).toHaveBeenCalledTimes(1);
+
+    vi.useRealTimers();
   });
 
   it("does not persist batch state in localStorage", async () => {

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ApiError } from "@/api/client";
 import {
   commitImage,
@@ -73,6 +73,7 @@ export function BulkIngestionWizard({
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string>("");
   const [uploadError, setUploadError] = useState<string>("");
+  const extractionStartedForBatch = useRef<Set<string>>(new Set());
 
   const setBatchAndStep = useCallback((nextBatch: BulkBatch) => {
     setBatch(nextBatch);
@@ -273,12 +274,16 @@ export function BulkIngestionWizard({
 
   useEffect(() => {
     if (step !== "review" || !batch || batch.status !== "active") return;
+    const batchId = batch.id;
+    if (extractionStartedForBatch.current.has(batchId)) return;
+    extractionStartedForBatch.current.add(batchId);
+
     let cancelled = false;
     async function kickoff() {
       try {
-        await startBatchExtraction(batch!.id);
+        await startBatchExtraction(batchId);
         if (!cancelled) {
-          const response = await getBatch(batch!.id);
+          const response = await getBatch(batchId);
           if (!cancelled) setBatchAndStep(response.batch);
         }
       } catch (err) {
@@ -293,7 +298,7 @@ export function BulkIngestionWizard({
     return () => {
       cancelled = true;
     };
-  }, [step, batch, setBatchAndStep]);
+  }, [step, batch?.id]);
 
   if (isLoading) {
     return (

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -3,16 +3,27 @@ import { ApiError } from "@/api/client";
 import {
   commitImage,
   createBatch,
+  deleteBatchItem,
   deleteImage,
   detectImageBoxes,
   getActiveBatch,
   getBatch,
+  retryItem,
   saveImageBoxes,
+  startBatchExtraction,
+  undoDeleteBatchItem,
+  updateItemDraft,
   uploadBatchImages,
 } from "@/api/bulkIngestion";
-import type { BulkBatch, BulkImageBox, BulkWizardStep } from "@/types/bulkIngestion";
+import type {
+  BulkBatch,
+  BulkDraft,
+  BulkImageBox,
+  BulkWizardStep,
+} from "@/types/bulkIngestion";
 import { BulkUploadStep } from "./BulkUploadStep";
 import { BulkDetectStep } from "./BulkDetectStep";
+import { BulkReviewStep } from "./BulkReviewStep";
 
 export type { BulkWizardStep };
 
@@ -191,6 +202,99 @@ export function BulkIngestionWizard({
     [batch, setBatchAndStep],
   );
 
+  const handleRefreshBatch = useCallback(
+    async (batchId: string) => {
+      try {
+        const response = await getBatch(batchId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to refresh batch");
+      }
+    },
+    [setBatchAndStep],
+  );
+
+  const handleUpdateItemDraft = useCallback(
+    async (itemId: string, draft: Partial<BulkDraft>) => {
+      if (!batch) return;
+      try {
+        const response = await updateItemDraft(batch.id, itemId, draft);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to save draft");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  const handleRetryItem = useCallback(
+    async (itemId: string) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await retryItem(batch.id, itemId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to retry item");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  const handleDeleteItem = useCallback(
+    async (itemId: string) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await deleteBatchItem(batch.id, itemId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to delete item");
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  const handleUndoDeleteItem = useCallback(
+    async (itemId: string) => {
+      if (!batch) return;
+      setError("");
+      try {
+        const response = await undoDeleteBatchItem(batch.id, itemId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to restore item",
+        );
+      }
+    },
+    [batch, setBatchAndStep],
+  );
+
+  useEffect(() => {
+    if (step !== "review" || !batch || batch.status !== "active") return;
+    let cancelled = false;
+    async function kickoff() {
+      try {
+        await startBatchExtraction(batch!.id);
+        if (!cancelled) {
+          const response = await getBatch(batch!.id);
+          if (!cancelled) setBatchAndStep(response.batch);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(
+            err instanceof Error ? err.message : "Failed to start extraction",
+          );
+        }
+      }
+    }
+    kickoff();
+    return () => {
+      cancelled = true;
+    };
+  }, [step, batch, setBatchAndStep]);
+
   if (isLoading) {
     return (
       <div data-testid="bulk-wizard-loading" style={{ padding: "24px", textAlign: "center" }}>
@@ -340,11 +444,16 @@ export function BulkIngestionWizard({
           />
         )}
 
-        {step === "review" && (
-          <div data-testid="bulk-wizard-review-step">
-            <h2>Review extracted items</h2>
-            <p>Item review UI will be added in a later step.</p>
-          </div>
+        {step === "review" && batch && (
+          <BulkReviewStep
+            batch={batch}
+            isLoading={isLoading}
+            onRefresh={handleRefreshBatch}
+            onUpdateDraft={handleUpdateItemDraft}
+            onRetry={handleRetryItem}
+            onDelete={handleDeleteItem}
+            onUndoDelete={handleUndoDeleteItem}
+          />
         )}
 
         {step === "submit" && (

--- a/frontend/src/components/BulkReviewStep.test.tsx
+++ b/frontend/src/components/BulkReviewStep.test.tsx
@@ -120,6 +120,58 @@ describe("BulkReviewStep", () => {
     expect(screen.getByTestId("bulk-review-next")).toBeDisabled();
   });
 
+  it("edits every draft field and routes the correct key to onUpdateDraft", async () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { order: 0 })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("bulk-review-text"), {
+      target: { value: "New question text" },
+    });
+    fireEvent.change(screen.getByTestId("bulk-review-type"), {
+      target: { value: "single-choice" },
+    });
+    fireEvent.change(screen.getByTestId("bulk-review-subject"), {
+      target: { value: "english" },
+    });
+    fireEvent.change(screen.getByTestId("bulk-review-answer"), {
+      target: { value: "B" },
+    });
+    fireEvent.change(screen.getByTestId("bulk-review-graphdsl"), {
+      target: { value: "y = x" },
+    });
+
+    const tagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(tagInput, { target: { value: "geometry" } });
+    fireEvent.keyDown(tagInput, { key: "Enter", code: "Enter" });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+    });
+
+    expect(handlers.onUpdateDraft).toHaveBeenCalledWith(
+      "item-1",
+      expect.objectContaining({
+        text: "New question text",
+        problemType: "single-choice",
+        subject: "english",
+        correctAnswer: "B",
+        graphDsl: "y = x",
+        tags: ["math", "geometry"],
+      }),
+    );
+  });
+
   it("debounces draft updates and sends the latest value", async () => {
     render(
       <BulkReviewStep

--- a/frontend/src/components/BulkReviewStep.test.tsx
+++ b/frontend/src/components/BulkReviewStep.test.tsx
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { BulkReviewStep } from "./BulkReviewStep";
+import type { BulkBatch, BulkItem } from "@/types/bulkIngestion";
+
+function makeItem(itemId: string, overrides: Partial<BulkItem> = {}): BulkItem {
+  return {
+    itemId,
+    imageId: `img-${itemId}`,
+    batchId: "batch-1",
+    status: "ready",
+    order: 0,
+    draft: {
+      text: "What is 2+2?",
+      problemType: "short-answer",
+      graphDsl: "",
+      correctAnswer: "4",
+      tags: ["math"],
+      subject: "math",
+    },
+    extraction: {},
+    retryCount: 0,
+    submit: {},
+    origin: {},
+    crop: {
+      mediaUrl: `http://example.com/crop-${itemId}.png`,
+    },
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeBatch(overrides: Partial<BulkBatch> = {}): BulkBatch {
+  return {
+    id: "batch-1",
+    userId: "user-1",
+    status: "active",
+    images: [
+      {
+        imageId: "img-a",
+        status: "committed",
+        order: 0,
+        sourceImage: {
+          bucket: "b",
+          objectKey: "k",
+          mediaUrl: "http://example.com/source.png",
+        },
+        boxes: [],
+        detection: {},
+        createdAt: "2026-07-03T00:00:00Z",
+        updatedAt: "2026-07-03T00:00:00Z",
+      },
+    ],
+    items: [],
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    expiresAt: "2026-07-04T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("BulkReviewStep", () => {
+  const handlers = {
+    onRefresh: vi.fn(),
+    onUpdateDraft: vi.fn(),
+    onRetry: vi.fn(),
+    onDelete: vi.fn(),
+    onUndoDelete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    Object.values(handlers).forEach((fn) => fn.mockReset());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the review queue and crop preview", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { order: 0 })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-review-queue")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-review-item-item-1")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-review-preview")).toHaveAttribute(
+      "src",
+      "http://example.com/crop-item-1.png",
+    );
+  });
+
+  it("disables Previous at the first item and Next at the last item", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-review-prev")).toBeDisabled();
+    expect(screen.getByTestId("bulk-review-next")).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+
+    expect(screen.getByTestId("bulk-review-prev")).not.toBeDisabled();
+    expect(screen.getByTestId("bulk-review-next")).toBeDisabled();
+  });
+
+  it("debounces draft updates and sends the latest value", async () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { order: 0 })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    const answerInput = screen.getByTestId("bulk-review-answer");
+    fireEvent.change(answerInput, { target: { value: "4" } });
+    fireEvent.change(answerInput, { target: { value: "42" } });
+    fireEvent.change(answerInput, { target: { value: "420" } });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+    });
+
+    expect(handlers.onUpdateDraft).toHaveBeenCalledWith(
+      "item-1",
+      expect.objectContaining({ correctAnswer: "420" }),
+    );
+  });
+
+  it("saves the latest draft value typed while a save is in flight", async () => {
+    let resolveSave: (value: unknown) => void = () => undefined;
+    handlers.onUpdateDraft.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { order: 0 })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    const answerInput = screen.getByTestId("bulk-review-answer");
+    fireEvent.change(answerInput, { target: { value: "first" } });
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.change(answerInput, { target: { value: "second" } });
+
+    await act(async () => {
+      resolveSave(undefined);
+      vi.advanceTimersByTime(600);
+    });
+
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(2);
+    });
+
+    expect(handlers.onUpdateDraft).toHaveBeenLastCalledWith(
+      "item-1",
+      expect.objectContaining({ correctAnswer: "second" }),
+    );
+  });
+
+  it("disables fields and shows undo for deleted items", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { status: "deleted" })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-review-undo")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-review-text")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("bulk-review-undo"));
+    expect(handlers.onUndoDelete).toHaveBeenCalledWith("item-1");
+  });
+
+  it("shows retry and failure reason for failed items", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem(
+              "item-1",
+              {
+                status: "failed",
+                extraction: { failureMessage: "VLM timeout" },
+              },
+            ),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-review-failure")).toHaveTextContent(
+      "VLM timeout",
+    );
+    expect(screen.getByTestId("bulk-review-retry")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("bulk-review-retry"));
+    expect(handlers.onRetry).toHaveBeenCalledWith("item-1");
+  });
+
+  it("polls the batch while extraction is active", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { status: "extracting" })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(handlers.onRefresh).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(2500);
+    expect(handlers.onRefresh).toHaveBeenCalledTimes(1);
+    expect(handlers.onRefresh).toHaveBeenCalledWith("batch-1");
+
+    vi.advanceTimersByTime(2500);
+    expect(handlers.onRefresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops polling when all items are terminal", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { status: "ready" })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    vi.advanceTimersByTime(10000);
+    expect(handlers.onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("calls onDelete when clicking delete for a non-deleted item", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [makeItem("item-1")],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("bulk-review-delete"));
+    expect(handlers.onDelete).toHaveBeenCalledWith("item-1");
+  });
+});

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -17,6 +17,17 @@ const SUBJECTS = [
   { value: "english", label: "English" },
 ];
 
+function defaultDraft(item: BulkItem): BulkDraft {
+  return {
+    text: item.draft.text ?? "",
+    problemType: item.draft.problemType ?? "short-answer",
+    graphDsl: item.draft.graphDsl ?? "",
+    correctAnswer: item.draft.correctAnswer ?? "",
+    tags: item.draft.tags ?? [],
+    subject: item.draft.subject ?? "math",
+  };
+}
+
 function statusLabel(status: string): string {
   switch (status) {
     case "queued":
@@ -81,16 +92,7 @@ export function BulkReviewStep({
 
   const getItemDraft = useCallback(
     (item: BulkItem): BulkDraft => {
-      return (
-        localDrafts[item.itemId] ?? {
-          text: item.draft.text ?? "",
-          problemType: item.draft.problemType ?? "short-answer",
-          graphDsl: item.draft.graphDsl ?? "",
-          correctAnswer: item.draft.correctAnswer ?? "",
-          tags: item.draft.tags ?? [],
-          subject: item.draft.subject ?? "math",
-        }
-      );
+      return localDrafts[item.itemId] ?? defaultDraft(item);
     },
     [localDrafts],
   );
@@ -117,14 +119,7 @@ export function BulkReviewStep({
     if (!selectedItem) return;
     setLocalDrafts((prev) => {
       if (prev[selectedItem.itemId] !== undefined) return prev;
-      const initial = {
-        text: selectedItem.draft.text ?? "",
-        problemType: selectedItem.draft.problemType ?? "short-answer",
-        graphDsl: selectedItem.draft.graphDsl ?? "",
-        correctAnswer: selectedItem.draft.correctAnswer ?? "",
-        tags: selectedItem.draft.tags ?? [],
-        subject: selectedItem.draft.subject ?? "math",
-      };
+      const initial = defaultDraft(selectedItem);
       const merged = { ...prev, [selectedItem.itemId]: initial };
       draftRefs.current = merged;
       return merged;
@@ -204,13 +199,6 @@ export function BulkReviewStep({
       }
     },
     [items, selectedIndex],
-  );
-
-  const withItemLoader = useCallback(
-    async (action: () => void | Promise<void>) => {
-      await action();
-    },
-    [],
   );
 
   if (!selectedItem) {
@@ -319,7 +307,7 @@ export function BulkReviewStep({
                 <button
                   type="button"
                   data-testid="bulk-review-retry"
-                  onClick={() => withItemLoader(() => onRetry(selectedItem.itemId))}
+                  onClick={() => onRetry(selectedItem.itemId)}
                   disabled={isWorking}
                 >
                   Retry extraction
@@ -329,9 +317,7 @@ export function BulkReviewStep({
                 <button
                   type="button"
                   data-testid="bulk-review-undo"
-                  onClick={() =>
-                    withItemLoader(() => onUndoDelete(selectedItem.itemId))
-                  }
+                  onClick={() => onUndoDelete(selectedItem.itemId)}
                   disabled={isWorking}
                 >
                   Undo delete
@@ -340,9 +326,7 @@ export function BulkReviewStep({
                 <button
                   type="button"
                   data-testid="bulk-review-delete"
-                  onClick={() =>
-                    withItemLoader(() => onDelete(selectedItem.itemId))
-                  }
+                  onClick={() => onDelete(selectedItem.itemId)}
                   disabled={isWorking}
                 >
                   Delete

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -1,0 +1,482 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { BulkBatch, BulkDraft, BulkItem } from "@/types/bulkIngestion";
+import { TagInput } from "./TagInput";
+
+const POLL_INTERVAL_MS = 2500;
+const DEBOUNCE_MS = 500;
+
+const PROBLEM_TYPES = [
+  { value: "single-choice", label: "Single choice" },
+  { value: "multi-choice", label: "Multiple choice" },
+  { value: "fill-in-the-blank", label: "Fill in the blank" },
+  { value: "short-answer", label: "Short answer" },
+];
+
+const SUBJECTS = [
+  { value: "math", label: "Math" },
+  { value: "english", label: "English" },
+];
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "extracting":
+      return "Extracting...";
+    case "ready":
+      return "Ready";
+    case "failed":
+      return "Extraction failed";
+    case "submit-failed":
+      return "Submit failed";
+    case "deleted":
+      return "Deleted";
+    case "submitted":
+      return "Submitted";
+    default:
+      return status;
+  }
+}
+
+export interface BulkReviewStepProps {
+  batch: BulkBatch;
+  isLoading: boolean;
+  onRefresh: (batchId: string) => void | Promise<void>;
+  onUpdateDraft: (
+    itemId: string,
+    draft: Partial<BulkDraft>,
+  ) => void | Promise<void>;
+  onRetry: (itemId: string) => void | Promise<void>;
+  onDelete: (itemId: string) => void | Promise<void>;
+  onUndoDelete: (itemId: string) => void | Promise<void>;
+}
+
+export function BulkReviewStep({
+  batch,
+  isLoading,
+  onRefresh,
+  onUpdateDraft,
+  onRetry,
+  onDelete,
+  onUndoDelete,
+}: BulkReviewStepProps) {
+  const items = useMemo(
+    () => [...batch.items].sort((a, b) => a.order - b.order),
+    [batch.items],
+  );
+  const [selectedItemId, setSelectedItemId] = useState<string>(() => {
+    const firstActionable = items.find((item) => item.status !== "deleted");
+    return firstActionable?.itemId ?? items[0]?.itemId ?? "";
+  });
+  const [localDrafts, setLocalDrafts] = useState<Record<string, BulkDraft>>({});
+  const [dirtyItems, setDirtyItems] = useState<Set<string>>(new Set());
+  const [savingItems, setSavingItems] = useState<Set<string>>(new Set());
+  const draftRefs = useRef<Record<string, BulkDraft>>({});
+  const dirtyRefs = useRef<Set<string>>(new Set());
+
+  const selectedItem = useMemo(
+    () => items.find((item) => item.itemId === selectedItemId) || items[0],
+    [items, selectedItemId],
+  );
+
+  const getItemDraft = useCallback(
+    (item: BulkItem): BulkDraft => {
+      return (
+        localDrafts[item.itemId] ?? {
+          text: item.draft.text ?? "",
+          problemType: item.draft.problemType ?? "short-answer",
+          graphDsl: item.draft.graphDsl ?? "",
+          correctAnswer: item.draft.correctAnswer ?? "",
+          tags: item.draft.tags ?? [],
+          subject: item.draft.subject ?? "math",
+        }
+      );
+    },
+    [localDrafts],
+  );
+
+  const updateDraft = useCallback(
+    (itemId: string, next: Partial<BulkDraft>) => {
+      setLocalDrafts((prev) => {
+        const updated = { ...prev[itemId], ...next };
+        const merged = { ...prev, [itemId]: updated };
+        draftRefs.current = merged;
+        return merged;
+      });
+      setDirtyItems((prev) => {
+        const nextSet = new Set(prev);
+        nextSet.add(itemId);
+        dirtyRefs.current = nextSet;
+        return nextSet;
+      });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!selectedItem) return;
+    setLocalDrafts((prev) => {
+      if (prev[selectedItem.itemId] !== undefined) return prev;
+      const initial = {
+        text: selectedItem.draft.text ?? "",
+        problemType: selectedItem.draft.problemType ?? "short-answer",
+        graphDsl: selectedItem.draft.graphDsl ?? "",
+        correctAnswer: selectedItem.draft.correctAnswer ?? "",
+        tags: selectedItem.draft.tags ?? [],
+        subject: selectedItem.draft.subject ?? "math",
+      };
+      const merged = { ...prev, [selectedItem.itemId]: initial };
+      draftRefs.current = merged;
+      return merged;
+    });
+  }, [selectedItem]);
+
+  useEffect(() => {
+    const timeoutIds: Record<string, number> = {};
+
+    const scheduleSave = (itemId: string) => {
+      window.clearTimeout(timeoutIds[itemId]);
+      timeoutIds[itemId] = window.setTimeout(() => {
+        const draft = draftRefs.current[itemId];
+        if (!draft) return;
+        const sentDraft = JSON.parse(JSON.stringify(draft)) as BulkDraft;
+        setSavingItems((prev) => {
+          const next = new Set(prev);
+          next.add(itemId);
+          return next;
+        });
+        Promise.resolve(onUpdateDraft(itemId, draft))
+          .catch(() => undefined)
+          .finally(() => {
+            setSavingItems((prev) => {
+              const next = new Set(prev);
+              next.delete(itemId);
+              return next;
+            });
+            setDirtyItems((prevDirty) => {
+              const nextDirty = new Set(prevDirty);
+              if (
+                JSON.stringify(draftRefs.current[itemId]) ===
+                JSON.stringify(sentDraft)
+              ) {
+                nextDirty.delete(itemId);
+              }
+              dirtyRefs.current = nextDirty;
+              return nextDirty;
+            });
+          });
+      }, DEBOUNCE_MS);
+    };
+
+    dirtyItems.forEach((itemId) => {
+      if (!savingItems.has(itemId)) {
+        scheduleSave(itemId);
+      }
+    });
+
+    return () => {
+      Object.values(timeoutIds).forEach((id) => window.clearTimeout(id));
+    };
+  }, [dirtyItems, savingItems, onUpdateDraft]);
+
+  useEffect(() => {
+    const hasActiveExtraction = items.some(
+      (item) => item.status === "queued" || item.status === "extracting",
+    );
+    if (!hasActiveExtraction || batch.status !== "active") return;
+
+    const id = window.setInterval(() => {
+      onRefresh(batch.id);
+    }, POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(id);
+  }, [batch.id, batch.status, items, onRefresh]);
+
+  const selectedIndex = items.findIndex(
+    (item) => item.itemId === selectedItem?.itemId,
+  );
+
+  const navigate = useCallback(
+    (direction: -1 | 1) => {
+      const nextIndex = selectedIndex + direction;
+      if (nextIndex >= 0 && nextIndex < items.length) {
+        setSelectedItemId(items[nextIndex].itemId);
+      }
+    },
+    [items, selectedIndex],
+  );
+
+  const withItemLoader = useCallback(
+    async (action: () => void | Promise<void>) => {
+      await action();
+    },
+    [],
+  );
+
+  if (!selectedItem) {
+    return (
+      <div data-testid="bulk-wizard-review-step">
+        <h2>Review extracted items</h2>
+        <p>No items to review.</p>
+      </div>
+    );
+  }
+
+  const sourceImage = batch.images.find(
+    (image) => image.imageId === selectedItem.imageId,
+  );
+  const previewUrl = selectedItem.crop?.mediaUrl || sourceImage?.sourceImage?.mediaUrl || "";
+  const isDeleted = selectedItem.status === "deleted";
+  const isEditable =
+    !isDeleted &&
+    selectedItem.status !== "queued" &&
+    selectedItem.status !== "extracting" &&
+    selectedItem.status !== "submitted";
+  const currentDraft = getItemDraft(selectedItem);
+  const isWorking = isLoading || savingItems.has(selectedItem.itemId);
+
+  return (
+    <div data-testid="bulk-wizard-review-step">
+      <h2>Review extracted items</h2>
+
+      <div
+        style={{
+          display: "flex",
+          gap: "16px",
+          marginBottom: "16px",
+        }}
+      >
+        <button
+          type="button"
+          data-testid="bulk-review-prev"
+          onClick={() => navigate(-1)}
+          disabled={selectedIndex <= 0}
+        >
+          Previous
+        </button>
+        <span data-testid="bulk-review-position">
+          {selectedIndex + 1} / {items.length}
+        </span>
+        <button
+          type="button"
+          data-testid="bulk-review-next"
+          onClick={() => navigate(1)}
+          disabled={selectedIndex >= items.length - 1}
+        >
+          Next
+        </button>
+      </div>
+
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "240px 1fr",
+          gap: "16px",
+        }}
+      >
+        <div>
+          <h3>Items</h3>
+          <ul data-testid="bulk-review-queue" style={{ padding: 0, listStyle: "none" }}>
+            {items.map((item) => (
+              <li key={item.itemId}>
+                <button
+                  type="button"
+                  data-testid={`bulk-review-item-${item.itemId}`}
+                  onClick={() => setSelectedItemId(item.itemId)}
+                  disabled={item.itemId === selectedItem.itemId}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    background:
+                      item.itemId === selectedItem.itemId
+                        ? "var(--color-primary)"
+                        : "transparent",
+                    color:
+                      item.itemId === selectedItem.itemId ? "white" : "inherit",
+                  }}
+                >
+                  {item.order + 1}. {statusLabel(item.status)}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: "12px",
+            }}
+          >
+            <span data-testid="bulk-review-status">
+              {statusLabel(selectedItem.status)}
+            </span>
+            <div style={{ display: "flex", gap: "8px" }}>
+              {selectedItem.status === "failed" && (
+                <button
+                  type="button"
+                  data-testid="bulk-review-retry"
+                  onClick={() => withItemLoader(() => onRetry(selectedItem.itemId))}
+                  disabled={isWorking}
+                >
+                  Retry extraction
+                </button>
+              )}
+              {isDeleted ? (
+                <button
+                  type="button"
+                  data-testid="bulk-review-undo"
+                  onClick={() =>
+                    withItemLoader(() => onUndoDelete(selectedItem.itemId))
+                  }
+                  disabled={isWorking}
+                >
+                  Undo delete
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  data-testid="bulk-review-delete"
+                  onClick={() =>
+                    withItemLoader(() => onDelete(selectedItem.itemId))
+                  }
+                  disabled={isWorking}
+                >
+                  Delete
+                </button>
+              )}
+            </div>
+          </div>
+
+          {selectedItem.extraction.failureMessage && (
+            <div
+              data-testid="bulk-review-failure"
+              style={{ color: "var(--color-error, #dc2626)", marginBottom: "12px" }}
+            >
+              {selectedItem.extraction.failureMessage}
+            </div>
+          )}
+
+          {previewUrl && (
+            <img
+              src={previewUrl}
+              alt="Crop preview"
+              data-testid="bulk-review-preview"
+              style={{
+                maxWidth: "100%",
+                maxHeight: "200px",
+                marginBottom: "12px",
+                border: "1px solid var(--color-border)",
+              }}
+            />
+          )}
+
+          <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+            <label>
+              Text
+              <textarea
+                data-testid="bulk-review-text"
+                value={currentDraft.text ?? ""}
+                onChange={(event) =>
+                  updateDraft(selectedItem.itemId, { text: event.target.value })
+                }
+                disabled={!isEditable || isWorking}
+                rows={4}
+                style={{ width: "100%" }}
+              />
+            </label>
+
+            <div style={{ display: "flex", gap: "12px" }}>
+              <label style={{ flex: 1 }}>
+                Problem type
+                <select
+                  data-testid="bulk-review-type"
+                  value={currentDraft.problemType ?? "short-answer"}
+                  onChange={(event) =>
+                    updateDraft(selectedItem.itemId, {
+                      problemType: event.target.value,
+                    })
+                  }
+                  disabled={!isEditable || isWorking}
+                  style={{ width: "100%" }}
+                >
+                  {PROBLEM_TYPES.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label style={{ flex: 1 }}>
+                Subject
+                <select
+                  data-testid="bulk-review-subject"
+                  value={currentDraft.subject ?? "math"}
+                  onChange={(event) =>
+                    updateDraft(selectedItem.itemId, {
+                      subject: event.target.value,
+                    })
+                  }
+                  disabled={!isEditable || isWorking}
+                  style={{ width: "100%" }}
+                >
+                  {SUBJECTS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+
+            <label>
+              Correct answer
+              <input
+                type="text"
+                data-testid="bulk-review-answer"
+                value={currentDraft.correctAnswer ?? ""}
+                onChange={(event) =>
+                  updateDraft(selectedItem.itemId, {
+                    correctAnswer: event.target.value,
+                  })
+                }
+                disabled={!isEditable || isWorking}
+                style={{ width: "100%" }}
+              />
+            </label>
+
+            <label>
+              Graph DSL
+              <input
+                type="text"
+                data-testid="bulk-review-graphdsl"
+                value={currentDraft.graphDsl ?? ""}
+                onChange={(event) =>
+                  updateDraft(selectedItem.itemId, {
+                    graphDsl: event.target.value,
+                  })
+                }
+                disabled={!isEditable || isWorking}
+                style={{ width: "100%" }}
+              />
+            </label>
+
+            <TagInput
+              tags={currentDraft.tags ?? []}
+              onChange={(tags) =>
+                updateDraft(selectedItem.itemId, { tags })
+              }
+              disabled={!isEditable || isWorking}
+              label="Tags"
+              testId="bulk-review-tags"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Build the frontend extraction progress and draft review UI for the bulk ingestion wizard.

## Linked Issue

Closes #369

## Issue Alignment

This PR implements the issue by:

- Polling batch detail every 2.5 seconds while any item is queued or extracting, and stopping when all items are terminal.
- Rendering a review queue with Previous/Next navigation and disabled boundary states.
- Showing the item crop/source image preview from the server-provided media URL.
- Rendering editable draft fields: text, problemType, graphDsl, correctAnswer, tags, subject.
- Debouncing draft patch calls while preserving the latest typed value across in-flight saves.
- Implementing delete and undo-delete for items (deleted items remain visible in the queue).
- Implementing extraction retry for failed items and surfacing the failure reason.
- Triggering extraction when the wizard enters the review step.

Scope covered:

- New review-step API client methods.
- `BulkReviewStep` component.
- Wizard integration and extraction kickoff.
- Component and API client tests.

Out of scope / intentionally not included:

- Submit gate, submit action, and submit summary UI (#370).
- Resume/expired/completed batch UX beyond basic polling state (#371).
- Backend API implementation (already present).
- Box editor (#368).
- Duplicate detection.
- Full keyboard accessibility.

## Implementation Notes

- Local draft edits are stored per item in component state so polling refreshes do not reset unsaved user input.
- The debounced save compares the post-save draft against what was sent; if the user typed while saving, a follow-up save is scheduled automatically.
- Delete/undo-delete use the dedicated backend item endpoints.

## Tests

Commands run:

- `npm test -- --run` — 393 passed
- `npm run build` — succeeded

Automated tests added or updated:

- `src/components/BulkReviewStep.test.tsx` — queue/render, navigation boundaries, debounced save, latest-value persistence, delete/undo, retry, failure reason, active polling, terminal polling.
- `src/api/bulkIngestion.test.ts` — start extraction, update draft, retry item, delete item, undo-delete item.

Manual verification:

- TypeScript build passes.

## Deviations From Issue Plan

None.

## Follow-Up Work

- #370 Build submit gate, submit action, and result summary UI.
- #371 Build resume, completion, and expiry UX.
- #372 Add full workflow E2E coverage and retire old single-flow entry.
