### PR TITLE
feat(frontend): surface and retry failed draft saves in BulkReviewStep

### DIFF
--- a/frontend/src/components/BulkReviewStep.test.tsx
+++ b/frontend/src/components/BulkReviewStep.test.tsx
@@ -344,4 +344,158 @@ describe("BulkReviewStep", () => {
     fireEvent.click(screen.getByTestId("bulk-review-delete"));
     expect(handlers.onDelete).toHaveBeenCalledWith("item-1");
   });
+
+  it("retries a failed draft save after a bounded backoff delay", async () => {
+    handlers.onUpdateDraft.mockRejectedValueOnce(new Error("network error"));
+
+    render(
+      <BulkReviewStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("bulk-review-answer"), {
+      target: { value: "A" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("increases retry backoff up to a cap", async () => {
+    handlers.onUpdateDraft.mockRejectedValue(new Error("persistent error"));
+
+    render(
+      <BulkReviewStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("bulk-review-answer"), {
+      target: { value: "A" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(4);
+
+    await act(async () => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(5);
+  });
+
+  it("clears the failure state and stops retrying after a successful save", async () => {
+    handlers.onUpdateDraft
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(undefined);
+
+    render(
+      <BulkReviewStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("bulk-review-answer"), {
+      target: { value: "A" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-review-save-status")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("bulk-review-save-status"),
+      ).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(2);
+  });
+
+  it("shows a save-failed indicator that disappears on success", async () => {
+    handlers.onUpdateDraft
+      .mockRejectedValueOnce(new Error("network error"))
+      .mockResolvedValueOnce(undefined);
+
+    render(
+      <BulkReviewStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("bulk-review-answer"), {
+      target: { value: "A" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(1);
+
+    expect(screen.getByTestId("bulk-review-save-status")).toHaveTextContent(
+      "Save failed, retrying...",
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+    });
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId("bulk-review-save-status"),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -4,6 +4,12 @@ import { TagInput } from "./TagInput";
 
 const POLL_INTERVAL_MS = 2500;
 const DEBOUNCE_MS = 500;
+const BASE_RETRY_MS = 500;
+const MAX_RETRY_MS = 4000;
+
+function retryDelayMs(failureCount: number): number {
+  return Math.min(BASE_RETRY_MS * 2 ** failureCount, MAX_RETRY_MS);
+}
 
 const PROBLEM_TYPES = [
   { value: "single-choice", label: "Single choice" },
@@ -82,8 +88,10 @@ export function BulkReviewStep({
   const [localDrafts, setLocalDrafts] = useState<Record<string, BulkDraft>>({});
   const [dirtyItems, setDirtyItems] = useState<Set<string>>(new Set());
   const [savingItems, setSavingItems] = useState<Set<string>>(new Set());
+  const [saveFailures, setSaveFailures] = useState<Record<string, number>>({});
   const draftRefs = useRef<Record<string, BulkDraft>>({});
   const dirtyRefs = useRef<Set<string>>(new Set());
+  const saveFailuresRef = useRef<Record<string, number>>({});
 
   const selectedItem = useMemo(
     () => items.find((item) => item.itemId === selectedItemId) || items[0],
@@ -131,6 +139,7 @@ export function BulkReviewStep({
 
     const scheduleSave = (itemId: string) => {
       window.clearTimeout(timeoutIds[itemId]);
+      const failures = saveFailuresRef.current[itemId] ?? 0;
       timeoutIds[itemId] = window.setTimeout(() => {
         const draft = draftRefs.current[itemId];
         if (!draft) return;
@@ -141,8 +150,13 @@ export function BulkReviewStep({
           return next;
         });
         Promise.resolve(onUpdateDraft(itemId, draft))
-          .catch(() => undefined)
-          .finally(() => {
+          .then(() => {
+            setSaveFailures((prev) => {
+              const next = { ...prev };
+              delete next[itemId];
+              saveFailuresRef.current = next;
+              return next;
+            });
             setSavingItems((prev) => {
               const next = new Set(prev);
               next.delete(itemId);
@@ -159,8 +173,20 @@ export function BulkReviewStep({
               dirtyRefs.current = nextDirty;
               return nextDirty;
             });
+          })
+          .catch(() => {
+            setSaveFailures((prev) => {
+              const next = { ...prev, [itemId]: (prev[itemId] ?? 0) + 1 };
+              saveFailuresRef.current = next;
+              return next;
+            });
+            setSavingItems((prev) => {
+              const next = new Set(prev);
+              next.delete(itemId);
+              return next;
+            });
           });
-      }, DEBOUNCE_MS);
+      }, retryDelayMs(failures));
     };
 
     dirtyItems.forEach((itemId) => {
@@ -222,6 +248,8 @@ export function BulkReviewStep({
     selectedItem.status !== "submitted";
   const currentDraft = getItemDraft(selectedItem);
   const isWorking = isLoading || savingItems.has(selectedItem.itemId);
+  const saveFailureCount = saveFailures[selectedItem.itemId] ?? 0;
+  const hasSaveFailed = saveFailureCount > 0;
 
   return (
     <div data-testid="bulk-wizard-review-step">
@@ -284,6 +312,12 @@ export function BulkReviewStep({
                   }}
                 >
                   {item.order + 1}. {statusLabel(item.status)}
+                  {saveFailures[item.itemId] !== undefined && (
+                    <span style={{ fontSize: "0.85em", opacity: 0.8 }}>
+                      {" "}
+                      (save failed)
+                    </span>
+                  )}
                 </button>
               </li>
             ))}
@@ -299,9 +333,19 @@ export function BulkReviewStep({
               marginBottom: "12px",
             }}
           >
-            <span data-testid="bulk-review-status">
-              {statusLabel(selectedItem.status)}
-            </span>
+            <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+              <span data-testid="bulk-review-status">
+                {statusLabel(selectedItem.status)}
+              </span>
+              {hasSaveFailed && (
+                <span
+                  data-testid="bulk-review-save-status"
+                  style={{ color: "var(--color-error, #dc2626)", fontSize: "0.85em" }}
+                >
+                  Save failed, retrying...
+                </span>
+              )}
+            </div>
             <div style={{ display: "flex", gap: "8px" }}>
               {selectedItem.status === "failed" && (
                 <button

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -3,7 +3,6 @@ import type { BulkBatch, BulkDraft, BulkItem } from "@/types/bulkIngestion";
 import { TagInput } from "./TagInput";
 
 const POLL_INTERVAL_MS = 2500;
-const DEBOUNCE_MS = 500;
 const BASE_RETRY_MS = 500;
 const MAX_RETRY_MS = 4000;
 


### PR DESCRIPTION
## Summary

Improves `BulkReviewStep` so a failed draft PATCH is surfaced to the user, the item remains dirty, and retries use a bounded exponential backoff instead of silently dropping the change.

## Linked Issue

Closes #388

## Issue Alignment

This PR implements the issue by:

- Tracking per-item save failure counts in `BulkReviewStep`.
- Keeping an item dirty when `onUpdateDraft` rejects so the debounced save effect schedules a retry.
- Computing the next retry delay with bounded exponential backoff (base 500ms, cap 4000ms).
- Rendering a lightweight "Save failed, retrying..." indicator next to the selected item status and in the review queue.
- Adding automated tests for failure → retry, backoff cap, recovery, and UI indicator visibility.

Scope covered:

- Per-item failure tracking and bounded backoff in `BulkReviewStep.tsx`.
- UI indicator for failed/pending-retry saves.
- Regression tests for the new behavior.

Out of scope / intentionally not included:

- Global error toast system.
- Conflict resolution for concurrent edits.
- Offline persistence or queueing.
- Backend PATCH endpoint changes.

## Implementation Notes

- Added `saveFailures` state and a matching ref so the debounce effect can read the latest failure count synchronously when scheduling a retry.
- Split the save promise handling into `.then` (success: clear failures, clear dirty if draft unchanged) and `.catch` (failure: increment failures, keep dirty).
- The retry delay is `Math.min(500 * 2 ** failures, 4000)`, giving delays of 500ms, 1000ms, 2000ms, 4000ms, and then capping at 4000ms.
- Existing happy-path debounce and "latest value typed while save is in flight" behavior is preserved.

## Tests

Commands run:

- `npm test -- --run src/components/BulkReviewStep.test.tsx` — passed (14 tests)
- `npm test -- --run` — passed (399 tests across 30 files)
- `npm run build` — succeeded

Automated tests added or updated:

- `retries a failed draft save after a bounded backoff delay`
- `increases retry backoff up to a cap`
- `clears the failure state and stops retrying after a successful save`
- `shows a save-failed indicator that disappears on success`

Manual verification:

- Inspected the rendered indicator in the component tests; no additional manual UI steps required beyond the automated coverage.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.