### PR TITLE
feat(frontend): build submit gate, submit action, and result summary UI

### DIFF
--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -543,10 +543,14 @@ async def reset_item_for_retry(
             continue
         status = item.get("status")
         lease_until = item.get("leaseUntil")
-        if status == ItemState.FAILED.value or (
-            status == ItemState.EXTRACTING.value
-            and isinstance(lease_until, datetime)
-            and lease_until <= now
+        if (
+            status == ItemState.FAILED.value
+            or status == ItemState.SUBMIT_FAILED.value
+            or (
+                status == ItemState.EXTRACTING.value
+                and isinstance(lease_until, datetime)
+                and lease_until <= now
+            )
         ):
             item["status"] = ItemState.QUEUED.value
             item["leaseUntil"] = None

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -1031,6 +1031,34 @@ async def test_retry_item_resets_failed_item(
 
 
 @pytest.mark.asyncio
+async def test_retry_item_resets_submit_failed_item(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+    helper_vlm: FakeHelperVLMClient,
+) -> None:
+    batch_id, _image_id, item_id = await create_committed_item(
+        authenticated_bulk_client, helper_vlm
+    )
+    database: FakeDatabase = bulk_app.state.fake_database
+    await database["ingestion_batches"].update_one(
+        {"_id": ObjectId(batch_id), "items.itemId": item_id},
+        {
+            "$set": {
+                "items.$.status": "submit-failed",
+                "items.$.leaseUntil": None,
+            }
+        },
+    )
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/items/{item_id}/retry"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["batch"]["items"][0]["status"] == "queued"
+
+
+@pytest.mark.asyncio
 async def test_retry_item_rejects_active_item(
     authenticated_bulk_client: AsyncClient,
     bulk_app: FastAPI,

--- a/frontend/src/api/bulkIngestion.test.ts
+++ b/frontend/src/api/bulkIngestion.test.ts
@@ -10,6 +10,7 @@ import {
   retryItem,
   saveImageBoxes,
   startBatchExtraction,
+  submitBatch,
   undoDeleteBatchItem,
   updateItemDraft,
   uploadBatchImages,
@@ -332,6 +333,44 @@ describe("bulk ingestion API client", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "/api/v1/ingestion-batches/batch-1/items/item-1/undo-delete",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: undefined,
+        },
+      );
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe("submitBatch", () => {
+    it("posts to the submit endpoint", async () => {
+      const response = {
+        submitSummary: {
+          batchId: "batch-1",
+          status: "completed",
+          items: [
+            {
+              itemId: "item-1",
+              status: "submitted",
+              submittedProblemId: "problem-1",
+              failureCode: null,
+              failureMessage: null,
+            },
+          ],
+        },
+      };
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await submitBatch("batch-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/v1/ingestion-batches/batch-1/submit",
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },

--- a/frontend/src/api/bulkIngestion.ts
+++ b/frontend/src/api/bulkIngestion.ts
@@ -3,6 +3,7 @@ import type {
   BatchResponse,
   BulkDraft,
   BulkImageBox,
+  SubmitSummaryResponse,
 } from "@/types/bulkIngestion";
 
 export async function createBatch(): Promise<BatchResponse> {
@@ -117,6 +118,15 @@ export async function undoDeleteBatchItem(
 ): Promise<BatchResponse> {
   return api.post<BatchResponse>(
     `/ingestion-batches/${batchId}/items/${itemId}/undo-delete`,
+    undefined,
+  );
+}
+
+export async function submitBatch(
+  batchId: string,
+): Promise<SubmitSummaryResponse> {
+  return api.post<SubmitSummaryResponse>(
+    `/ingestion-batches/${batchId}/submit`,
     undefined,
   );
 }

--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -14,6 +14,11 @@ const mocks = vi.hoisted(() => ({
   commitImage: vi.fn<() => Promise<BatchResponse>>(),
   deleteImage: vi.fn<() => Promise<BatchResponse>>(),
   startBatchExtraction: vi.fn<() => Promise<BatchResponse>>(),
+  submitBatch: vi.fn<() => Promise<{ submitSummary: { batchId: string; status: string; items: unknown[] } }>>(),
+  retryItem: vi.fn<() => Promise<BatchResponse>>(),
+  deleteBatchItem: vi.fn<() => Promise<BatchResponse>>(),
+  undoDeleteBatchItem: vi.fn<() => Promise<BatchResponse>>(),
+  updateItemDraft: vi.fn<() => Promise<BatchResponse>>(),
 }));
 
 vi.mock("@/api/bulkIngestion", () => ({
@@ -26,6 +31,11 @@ vi.mock("@/api/bulkIngestion", () => ({
   commitImage: mocks.commitImage,
   deleteImage: mocks.deleteImage,
   startBatchExtraction: mocks.startBatchExtraction,
+  submitBatch: mocks.submitBatch,
+  retryItem: mocks.retryItem,
+  deleteBatchItem: mocks.deleteBatchItem,
+  undoDeleteBatchItem: mocks.undoDeleteBatchItem,
+  updateItemDraft: mocks.updateItemDraft,
 }));
 
 function makeBatch(overrides: Partial<BulkBatch> = {}): BulkBatch {
@@ -649,5 +659,305 @@ describe("BulkIngestionWizard", () => {
         "english",
       );
     });
+  });
+
+  it("advances to submit step when all items are ready", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "ready",
+            order: 0,
+            draft: {
+              text: "What is 2+2?",
+              problemType: "short-answer",
+              correctAnswer: "4",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("bulk-submit-button")).not.toBeDisabled();
+  });
+
+  it("submits the batch and refreshes to show results", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "ready",
+            order: 0,
+            draft: {
+              text: "What is 2+2?",
+              problemType: "short-answer",
+              correctAnswer: "4",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.submitBatch.mockResolvedValue({
+      submitSummary: {
+        batchId: "batch-1",
+        status: "completed",
+        items: [
+          {
+            itemId: "item-1",
+            status: "submitted",
+            submittedProblemId: "problem-1",
+            failureCode: null,
+            failureMessage: null,
+          },
+        ],
+      },
+    });
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({
+        status: "completed",
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "submitted",
+            order: 0,
+            draft: {
+              text: "What is 2+2?",
+              problemType: "short-answer",
+              correctAnswer: "4",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: { submittedProblemId: "problem-1" },
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-submit-button"));
+
+    await waitFor(() => {
+      expect(mocks.submitBatch).toHaveBeenCalledWith("batch-1");
+    });
+    await waitFor(() => {
+      expect(mocks.getBatch).toHaveBeenCalledWith("batch-1");
+    });
+  });
+
+  it("stays on submit step when submission has partial failures", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "ready",
+            order: 0,
+            draft: {
+              text: "What is 2+2?",
+              problemType: "short-answer",
+              correctAnswer: "4",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+          {
+            itemId: "item-2",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "ready",
+            order: 1,
+            draft: {
+              text: "What is 3+3?",
+              problemType: "short-answer",
+              correctAnswer: "6",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: {},
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.submitBatch.mockResolvedValue({
+      submitSummary: {
+        batchId: "batch-1",
+        status: "active",
+        items: [
+          {
+            itemId: "item-1",
+            status: "submitted",
+            submittedProblemId: "problem-1",
+            failureCode: null,
+            failureMessage: null,
+          },
+          {
+            itemId: "item-2",
+            status: "submit-failed",
+            submittedProblemId: null,
+            failureCode: "VALIDATION_ERROR",
+            failureMessage: "Invalid draft",
+          },
+        ],
+      },
+    });
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "committed",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+        items: [
+          {
+            itemId: "item-1",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "submitted",
+            order: 0,
+            draft: {
+              text: "What is 2+2?",
+              problemType: "short-answer",
+              correctAnswer: "4",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: { submittedProblemId: "problem-1" },
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+          {
+            itemId: "item-2",
+            imageId: "img-1",
+            batchId: "batch-1",
+            status: "submit-failed",
+            order: 1,
+            draft: {
+              text: "What is 3+3?",
+              problemType: "short-answer",
+              correctAnswer: "6",
+            },
+            extraction: {},
+            retryCount: 0,
+            submit: { failureMessage: "Invalid draft" },
+            origin: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-submit-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-submit-summary")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("bulk-submit-retry-item-2"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("bulk-submit-delete-item-2"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -280,14 +280,9 @@ export function BulkIngestionWizard({
   const handleSubmit = useCallback(
     async (batchId: string) => {
       setError("");
-      try {
-        await submitBatch(batchId);
-        const response = await getBatch(batchId);
-        setBatchAndStep(response.batch);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to submit batch");
-        throw err;
-      }
+      await submitBatch(batchId);
+      const response = await getBatch(batchId);
+      setBatchAndStep(response.batch);
     },
     [setBatchAndStep],
   );

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -11,6 +11,7 @@ import {
   retryItem,
   saveImageBoxes,
   startBatchExtraction,
+  submitBatch,
   undoDeleteBatchItem,
   updateItemDraft,
   uploadBatchImages,
@@ -24,6 +25,7 @@ import type {
 import { BulkUploadStep } from "./BulkUploadStep";
 import { BulkDetectStep } from "./BulkDetectStep";
 import { BulkReviewStep } from "./BulkReviewStep";
+import { BulkSubmitStep } from "./BulkSubmitStep";
 
 export type { BulkWizardStep };
 
@@ -51,13 +53,16 @@ function deriveStep(batch: BulkBatch): BulkWizardStep {
       (item) =>
         item.status === "queued" ||
         item.status === "extracting" ||
-        item.status === "failed" ||
-        item.status === "submit-failed",
+        item.status === "failed",
     )
   ) {
     return "review";
   }
-  if (batch.items.some((item) => item.status === "ready")) {
+  if (
+    batch.items.some(
+      (item) => item.status === "ready" || item.status === "submit-failed",
+    )
+  ) {
     return "submit";
   }
   return "complete";
@@ -272,6 +277,21 @@ export function BulkIngestionWizard({
     [batch, setBatchAndStep],
   );
 
+  const handleSubmit = useCallback(
+    async (batchId: string) => {
+      setError("");
+      try {
+        await submitBatch(batchId);
+        const response = await getBatch(batchId);
+        setBatchAndStep(response.batch);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to submit batch");
+        throw err;
+      }
+    },
+    [setBatchAndStep],
+  );
+
   useEffect(() => {
     if (step !== "review" || !batch || batch.status !== "active") return;
     const batchId = batch.id;
@@ -461,11 +481,14 @@ export function BulkIngestionWizard({
           />
         )}
 
-        {step === "submit" && (
-          <div data-testid="bulk-wizard-submit-step">
-            <h2>Submit items</h2>
-            <p>Submit UI will be added in a later step.</p>
-          </div>
+        {step === "submit" && batch && (
+          <BulkSubmitStep
+            batch={batch}
+            isLoading={isLoading}
+            onSubmit={handleSubmit}
+            onRetry={handleRetryItem}
+            onDelete={handleDeleteItem}
+          />
         )}
       </div>
 

--- a/frontend/src/components/BulkSubmitStep.test.tsx
+++ b/frontend/src/components/BulkSubmitStep.test.tsx
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { BulkSubmitStep } from "./BulkSubmitStep";
+import type { BulkBatch, BulkItem } from "@/types/bulkIngestion";
+
+function makeItem(itemId: string, overrides: Partial<BulkItem> = {}): BulkItem {
+  return {
+    itemId,
+    imageId: `img-${itemId}`,
+    batchId: "batch-1",
+    status: "ready",
+    order: 0,
+    draft: {
+      text: "What is 2+2?",
+      problemType: "short-answer",
+      graphDsl: "",
+      correctAnswer: "4",
+      tags: [],
+      subject: "math",
+    },
+    extraction: {},
+    retryCount: 0,
+    submit: {},
+    origin: {},
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeBatch(overrides: Partial<BulkBatch> = {}): BulkBatch {
+  return {
+    id: "batch-1",
+    userId: "user-1",
+    status: "active",
+    images: [],
+    items: [],
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    expiresAt: "2026-07-04T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("BulkSubmitStep", () => {
+  const handlers = {
+    onSubmit: vi.fn(),
+    onRetry: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    Object.values(handlers).forEach((fn) => fn.mockReset());
+  });
+
+  it("renders the submit queue", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-submit-queue")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-submit-item-item-1")).toBeInTheDocument();
+  });
+
+  it("enables submit when all active items are ready with required fields", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).not.toBeDisabled();
+  });
+
+  it("disables submit when an item is missing text", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { draft: { correctAnswer: "4", problemType: "short-answer" } })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(
+      screen.getByTestId("bulk-submit-item-reasons-item-1"),
+    ).toHaveTextContent("Question text is required");
+  });
+
+  it("disables submit when an item is missing problemType", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              draft: { text: "What is 2+2?", correctAnswer: "4" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(
+      screen.getByTestId("bulk-submit-item-reasons-item-1"),
+    ).toHaveTextContent("Problem type is required");
+  });
+
+  it("disables submit when an item is missing correctAnswer", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              draft: { text: "What is 2+2?", problemType: "short-answer" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(
+      screen.getByTestId("bulk-submit-item-reasons-item-1"),
+    ).toHaveTextContent("Correct answer is required");
+  });
+
+  it("disables submit when an item is not ready", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { status: "extracting" })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(
+      screen.getByTestId("bulk-submit-item-reasons-item-1"),
+    ).toHaveTextContent("Item is not ready");
+  });
+
+  it("ignores deleted items when computing the submit gate", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", {
+              order: 1,
+              status: "deleted",
+              draft: { correctAnswer: "", problemType: "", text: "" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).not.toBeDisabled();
+  });
+
+  it("calls onSubmit when clicking the submit button", async () => {
+    handlers.onSubmit.mockResolvedValue(undefined);
+
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("bulk-submit-button"));
+    });
+
+    await waitFor(() => {
+      expect(handlers.onSubmit).toHaveBeenCalledWith("batch-1");
+    });
+  });
+
+  it("disables the submit button while submitting", async () => {
+    let resolveSubmit: () => void = () => undefined;
+    handlers.onSubmit.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        }),
+    );
+
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("bulk-submit-button"));
+    });
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(screen.getByTestId("bulk-submit-button")).toHaveTextContent(
+      "Submitting...",
+    );
+
+    await act(async () => {
+      resolveSubmit();
+    });
+  });
+
+  it("renders the result summary after partial submission", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              order: 0,
+              status: "submitted",
+              submit: { submittedProblemId: "problem-1" },
+            }),
+            makeItem("item-2", {
+              order: 1,
+              status: "submit-failed",
+              submit: { failureMessage: "Validation error" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-summary")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-submit-summary-total")).toHaveTextContent("Total: 2");
+    expect(screen.getByTestId("bulk-submit-summary-submitted")).toHaveTextContent(
+      "Submitted: 1",
+    );
+    expect(screen.getByTestId("bulk-submit-summary-failed")).toHaveTextContent(
+      "Failed: 1",
+    );
+    expect(
+      screen.getByTestId("bulk-submit-item-failure-item-2"),
+    ).toHaveTextContent("Validation error");
+  });
+
+  it("renders submitted problem ids", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              order: 0,
+              status: "submitted",
+              submit: { submittedProblemId: "problem-1" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(
+      screen.getByTestId("bulk-submit-item-problem-item-1"),
+    ).toHaveTextContent("problem-1");
+  });
+
+  it("calls onRetry for submit-failed items", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              order: 0,
+              status: "submit-failed",
+              submit: { failureMessage: "Validation error" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("bulk-submit-retry-item-1"));
+    expect(handlers.onRetry).toHaveBeenCalledWith("item-1");
+  });
+
+  it("calls onDelete for submit-failed items", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              order: 0,
+              status: "submit-failed",
+              submit: { failureMessage: "Validation error" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("bulk-submit-delete-item-1"));
+    expect(handlers.onDelete).toHaveBeenCalledWith("item-1");
+  });
+
+  it("shows an error message when submission fails", async () => {
+    handlers.onSubmit.mockRejectedValue(new Error("Network error"));
+
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("bulk-submit-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-submit-error")).toHaveTextContent(
+        "Network error",
+      );
+    });
+  });
+
+  it("shows disabled reasons when there are no items", () => {
+    render(
+      <BulkSubmitStep batch={makeBatch()} isLoading={false} {...handlers} />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(screen.getByTestId("bulk-submit-disabled-reasons")).toHaveTextContent(
+      "No items to submit",
+    );
+  });
+});

--- a/frontend/src/components/BulkSubmitStep.test.tsx
+++ b/frontend/src/components/BulkSubmitStep.test.tsx
@@ -161,6 +161,40 @@ describe("BulkSubmitStep", () => {
     ).toHaveTextContent("Item is not ready");
   });
 
+  it("disables submit when an item failed extraction", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { status: "failed" })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(
+      screen.getByTestId("bulk-submit-item-reasons-item-1"),
+    ).toHaveTextContent("Item is not ready");
+  });
+
+  it("disables submit when an item failed submission", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [makeItem("item-1", { status: "submit-failed" })],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-submit-button")).toBeDisabled();
+    expect(
+      screen.getByTestId("bulk-submit-item-reasons-item-1"),
+    ).toHaveTextContent("Item is not ready");
+  });
+
   it("ignores deleted items when computing the submit gate", () => {
     render(
       <BulkSubmitStep
@@ -309,6 +343,39 @@ describe("BulkSubmitStep", () => {
 
     fireEvent.click(screen.getByTestId("bulk-submit-retry-item-1"));
     expect(handlers.onRetry).toHaveBeenCalledWith("item-1");
+  });
+
+  it("keeps submitted items visible when retrying a submit-failed sibling", () => {
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", {
+              order: 0,
+              status: "submitted",
+              submit: { submittedProblemId: "problem-1" },
+            }),
+            makeItem("item-2", {
+              order: 1,
+              status: "submit-failed",
+              submit: { failureMessage: "Validation error" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("bulk-submit-retry-item-2"));
+
+    expect(handlers.onRetry).toHaveBeenCalledWith("item-2");
+    expect(
+      screen.getByTestId("bulk-submit-item-problem-item-1"),
+    ).toHaveTextContent("problem-1");
+    expect(
+      screen.getByTestId("bulk-submit-item-status-item-1"),
+    ).toHaveTextContent("Submitted");
   });
 
   it("calls onDelete for submit-failed items", () => {

--- a/frontend/src/components/BulkSubmitStep.tsx
+++ b/frontend/src/components/BulkSubmitStep.tsx
@@ -1,0 +1,266 @@
+import { useMemo, useState } from "react";
+import type { BulkBatch, BulkItem } from "@/types/bulkIngestion";
+
+export interface BulkSubmitStepProps {
+  batch: BulkBatch;
+  isLoading: boolean;
+  onSubmit: (batchId: string) => void | Promise<void>;
+  onRetry: (itemId: string) => void | Promise<void>;
+  onDelete: (itemId: string) => void | Promise<void>;
+}
+
+function statusLabel(status: string): string {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "extracting":
+      return "Extracting...";
+    case "ready":
+      return "Ready to submit";
+    case "failed":
+      return "Extraction failed";
+    case "submit-failed":
+      return "Submit failed";
+    case "deleted":
+      return "Deleted";
+    case "submitted":
+      return "Submitted";
+    default:
+      return status;
+  }
+}
+
+function itemDisabledReasons(item: BulkItem): string[] {
+  const reasons: string[] = [];
+  if (item.status !== "ready") {
+    reasons.push("Item is not ready");
+  }
+  if (!item.draft.text || item.draft.text.trim() === "") {
+    reasons.push("Question text is required");
+  }
+  if (!item.draft.problemType) {
+    reasons.push("Problem type is required");
+  }
+  if (!item.draft.correctAnswer || item.draft.correctAnswer.trim() === "") {
+    reasons.push("Correct answer is required");
+  }
+  return reasons;
+}
+
+function isItemSubmittable(item: BulkItem): boolean {
+  return itemDisabledReasons(item).length === 0;
+}
+
+export function BulkSubmitStep({
+  batch,
+  isLoading,
+  onSubmit,
+  onRetry,
+  onDelete,
+}: BulkSubmitStepProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string>("");
+
+  const items = useMemo(
+    () => [...batch.items].sort((a, b) => a.order - b.order),
+    [batch.items],
+  );
+
+  const activeItems = useMemo(
+    () => items.filter((item) => item.status !== "deleted"),
+    [items],
+  );
+
+  const submittableItems = useMemo(
+    () => activeItems.filter(isItemSubmittable),
+    [activeItems],
+  );
+
+  const canSubmit = activeItems.length > 0 && activeItems.length === submittableItems.length;
+
+  const summary = useMemo(() => {
+    return {
+      total: activeItems.length,
+      submitted: activeItems.filter((item) => item.status === "submitted").length,
+      failed: activeItems.filter((item) => item.status === "submit-failed").length,
+      ready: activeItems.filter((item) => item.status === "ready").length,
+    };
+  }, [activeItems]);
+
+  const hasAttemptedSubmit = summary.submitted > 0 || summary.failed > 0;
+
+  const handleSubmit = async () => {
+    if (!canSubmit || isSubmitting) return;
+    setIsSubmitting(true);
+    setSubmitError("");
+    try {
+      await onSubmit(batch.id);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Submit failed");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const disabledReasons = useMemo(() => {
+    const reasons: string[] = [];
+    if (activeItems.length === 0) {
+      reasons.push("No items to submit");
+    }
+    activeItems.forEach((item) => {
+      const itemReasons = itemDisabledReasons(item);
+      if (itemReasons.length > 0) {
+        reasons.push(`Item ${item.order + 1}: ${itemReasons.join(", ")}`);
+      }
+    });
+    return reasons;
+  }, [activeItems]);
+
+  return (
+    <div data-testid="bulk-wizard-submit-step">
+      <h2>Submit items</h2>
+
+      {submitError && (
+        <div
+          data-testid="bulk-submit-error"
+          style={{ color: "var(--color-error, #dc2626)", marginBottom: "16px" }}
+        >
+          {submitError}
+        </div>
+      )}
+
+      {hasAttemptedSubmit && (
+        <div
+          data-testid="bulk-submit-summary"
+          style={{
+            marginBottom: "16px",
+            padding: "12px",
+            borderRadius: "8px",
+            backgroundColor: "var(--color-surface-muted)",
+          }}
+        >
+          <div data-testid="bulk-submit-summary-total">Total: {summary.total}</div>
+          <div data-testid="bulk-submit-summary-submitted">
+            Submitted: {summary.submitted}
+          </div>
+          <div data-testid="bulk-submit-summary-failed">Failed: {summary.failed}</div>
+          {summary.failed === 0 && summary.ready === 0 && (
+            <div data-testid="bulk-submit-summary-complete">All items submitted</div>
+          )}
+        </div>
+      )}
+
+      <ul
+        data-testid="bulk-submit-queue"
+        style={{ listStyle: "none", padding: 0, marginBottom: "16px" }}
+      >
+        {activeItems.map((item) => {
+          const reasons = itemDisabledReasons(item);
+          const isSubmittable = reasons.length === 0;
+          return (
+            <li
+              key={item.itemId}
+              data-testid={`bulk-submit-item-${item.itemId}`}
+              style={{
+                padding: "12px",
+                marginBottom: "8px",
+                border: "1px solid var(--color-border)",
+                borderRadius: "8px",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <span data-testid={`bulk-submit-item-status-${item.itemId}`}>
+                  Item {item.order + 1}: {statusLabel(item.status)}
+                </span>
+                {item.status === "submit-failed" && (
+                  <div style={{ display: "flex", gap: "8px" }}>
+                    <button
+                      type="button"
+                      data-testid={`bulk-submit-retry-${item.itemId}`}
+                      onClick={() => onRetry(item.itemId)}
+                      disabled={isLoading || isSubmitting}
+                    >
+                      Retry
+                    </button>
+                    <button
+                      type="button"
+                      data-testid={`bulk-submit-delete-${item.itemId}`}
+                      onClick={() => onDelete(item.itemId)}
+                      disabled={isLoading || isSubmitting}
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+              {!isSubmittable && (
+                <ul
+                  data-testid={`bulk-submit-item-reasons-${item.itemId}`}
+                  style={{
+                    color: "var(--color-error, #dc2626)",
+                    fontSize: "0.9em",
+                    marginTop: "8px",
+                    marginBottom: 0,
+                    paddingLeft: "20px",
+                  }}
+                >
+                  {reasons.map((reason) => (
+                    <li key={reason}>{reason}</li>
+                  ))}
+                </ul>
+              )}
+              {item.submit.failureMessage && (
+                <div
+                  data-testid={`bulk-submit-item-failure-${item.itemId}`}
+                  style={{
+                    color: "var(--color-error, #dc2626)",
+                    fontSize: "0.9em",
+                    marginTop: "8px",
+                  }}
+                >
+                  {item.submit.failureMessage}
+                </div>
+              )}
+              {item.submit.submittedProblemId && (
+                <div
+                  data-testid={`bulk-submit-item-problem-${item.itemId}`}
+                  style={{ fontSize: "0.9em", marginTop: "8px" }}
+                >
+                  Problem {item.submit.submittedProblemId}
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {!canSubmit && disabledReasons.length > 0 && (
+        <div
+          data-testid="bulk-submit-disabled-reasons"
+          style={{ marginBottom: "16px", fontSize: "0.9em" }}
+        >
+          {disabledReasons.map((reason) => (
+            <div key={reason} data-testid="bulk-submit-disabled-reason">
+              {reason}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <button
+        type="button"
+        data-testid="bulk-submit-button"
+        onClick={handleSubmit}
+        disabled={!canSubmit || isLoading || isSubmitting}
+      >
+        {isSubmitting ? "Submitting..." : "Submit all items"}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/types/bulkIngestion.ts
+++ b/frontend/src/types/bulkIngestion.ts
@@ -127,12 +127,22 @@ export interface BatchResponse {
   batch: BulkBatch;
 }
 
-export interface SubmitSummary {
-  total: number;
-  submitted: number;
-  failed: number;
-  deleted: number;
-  pending: number;
+export interface BulkSubmitItemResult {
+  itemId: string;
+  status: string;
+  submittedProblemId?: string | null;
+  failureCode?: string | null;
+  failureMessage?: string | null;
+}
+
+export interface BulkSubmitSummary {
+  batchId: string;
+  status: string;
+  items: BulkSubmitItemResult[];
+}
+
+export interface SubmitSummaryResponse {
+  submitSummary: BulkSubmitSummary;
 }
 
 export type BulkWizardStep =


### PR DESCRIPTION
## Summary

This PR implements the submit step of the unified bulk ingestion workflow. It adds a submit gate that blocks submission until every non-deleted item is ready and has the required fields, calls the backend submit endpoint, renders a per-item success/failure summary, and provides retry/delete actions for submit-failed items.

## Linked Issue

Closes #370

## Issue Alignment

This PR implements the issue by:

- Computing and displaying submit disabled reasons for active items.
- Enabling submit only when every non-deleted item is `ready` and has `text`, `problemType`, and `correctAnswer`.
- Calling the `/ingestion-batches/{id}/submit` API and handling in-flight state.
- Rendering a per-item submit success/failure summary.
- Providing retry and delete actions for submit-failed items.
- Preserving already submitted item outcomes when retrying failures (backend retry resets submit-failed to queued; re-submit relies on backend idempotency).

Scope covered:

- Frontend submit gate, action, summary, retry, and delete UI.
- Frontend API client and type updates for submit.
- Backend fix so the item retry endpoint accepts `submit-failed` state, matching the domain model transition.

Out of scope / intentionally not included:

- Routing the main ingestion page to the unified flow (handled by #372).
- Resume/expiry/completed UX beyond rendering returned submit states (handled by #371).
- Box editor and draft field controls (already in BulkReviewStep).

## Implementation Notes

- Added `BulkSubmitStep` component with per-item disabled reasons, summary counts, and retry/delete controls.
- Updated `BulkIngestionWizard.deriveStep` so `submit-failed` items stay on the submit step instead of returning to review.
- Added `submitBatch` to the API client and replaced the unused `SubmitSummary` type with the backend `SubmitSummaryResponse` shape.
- Extended `reset_item_for_retry` to reset `submit-failed` items back to `queued`, which the domain model already allows.

## Tests

Commands run:

- `cd frontend && npm test -- --run` — passed (418 tests)
- `cd frontend && npm run build` — passed
- `cd backend && uv run pytest tests/api/test_bulk_ingestion.py tests/infrastructure/test_ingestion_persistence.py tests/domain/test_bulk_ingestion_state.py -q` — passed (95 tests)

Automated tests added or updated:

- `frontend/src/components/BulkSubmitStep.test.tsx` — 15 new tests covering gate, disabled reasons, submit action, summary, retry, delete, and error handling.
- `frontend/src/components/BulkIngestionWizard.test.tsx` — added tests for advancing to submit step, submitting, and partial failure handling.
- `frontend/src/api/bulkIngestion.test.ts` — added test for `submitBatch`.
- `backend/tests/api/test_bulk_ingestion.py` — added test for retrying a submit-failed item.

Manual verification:

- Verified frontend build succeeds and all existing related tests continue to pass.

## Deviations From Issue Plan

The issue was frontend-only and listed backend submit implementation as a dependency. During implementation it became clear that the existing backend retry endpoint did not reset `submit-failed` items, even though the domain model allows that transition. A minimal one-condition backend change was added so the frontend retry action works end-to-end. This is explained in the implementation notes and tested.

## Follow-Up Work

None.
