### PR TITLE
feat(frontend): resume, completion, and expiry UX for bulk ingestion

### DIFF
--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { BulkIngestionWizard } from "./BulkIngestionWizard";
 import { ApiError } from "@/api/client";
-import type { BatchResponse, BulkBatch } from "@/types/bulkIngestion";
+import type { BatchResponse, BulkBatch, BulkImage, BulkItem } from "@/types/bulkIngestion";
 
 const mocks = vi.hoisted(() => ({
   getActiveBatch: vi.fn<() => Promise<BatchResponse>>(),
@@ -48,6 +48,82 @@ function makeBatch(overrides: Partial<BulkBatch> = {}): BulkBatch {
     createdAt: "2026-07-03T00:00:00Z",
     updatedAt: "2026-07-03T00:00:00Z",
     expiresAt: "2026-07-04T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function committedImage(overrides: Partial<BulkImage> = {}): BulkImage {
+  return {
+    imageId: "img-1",
+    status: "committed",
+    order: 0,
+    sourceImage: { bucket: "b", objectKey: "k" },
+    boxes: [],
+    detection: {},
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function queuedItem(overrides: Partial<BulkItem> = {}): BulkItem {
+  return {
+    itemId: "item-1",
+    imageId: "img-1",
+    batchId: "batch-1",
+    status: "queued",
+    order: 0,
+    draft: {},
+    extraction: {},
+    retryCount: 0,
+    submit: {},
+    origin: {},
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function readyItem(overrides: Partial<BulkItem> = {}): BulkItem {
+  return {
+    itemId: "item-1",
+    imageId: "img-1",
+    batchId: "batch-1",
+    status: "ready",
+    order: 0,
+    draft: {
+      text: "What is 2+2?",
+      problemType: "short-answer",
+      correctAnswer: "4",
+    },
+    extraction: {},
+    retryCount: 0,
+    submit: {},
+    origin: {},
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function submittedItem(overrides: Partial<BulkItem> = {}): BulkItem {
+  return {
+    itemId: "item-1",
+    imageId: "img-1",
+    batchId: "batch-1",
+    status: "submitted",
+    order: 0,
+    draft: {
+      text: "What is 2+2?",
+      problemType: "short-answer",
+      correctAnswer: "4",
+    },
+    extraction: {},
+    retryCount: 0,
+    submit: { submittedProblemId: "problem-1" },
+    origin: {},
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
     ...overrides,
   };
 }
@@ -959,5 +1035,216 @@ describe("BulkIngestionWizard", () => {
     expect(
       screen.getByTestId("bulk-submit-delete-item-2"),
     ).toBeInTheDocument();
+  });
+
+  it("resumes an unexpired batch at the review step via initialBatchId", async () => {
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({
+        id: "batch-resume",
+        images: [committedImage()],
+        items: [queuedItem()],
+      }),
+    });
+    mocks.startBatchExtraction.mockResolvedValue({
+      batch: makeBatch({
+        id: "batch-resume",
+        images: [committedImage()],
+        items: [queuedItem()],
+      }),
+    });
+
+    render(<BulkIngestionWizard initialBatchId="batch-resume" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+    expect(mocks.getBatch).toHaveBeenCalledWith("batch-resume");
+  });
+
+  it("restores the submit step from a server-backed ready batch", async () => {
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({
+        id: "batch-resume",
+        images: [committedImage()],
+        items: [readyItem()],
+      }),
+    });
+
+    render(<BulkIngestionWizard initialBatchId="batch-resume" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+  });
+
+  it("transitions to expired UX when a review poll returns BATCH_EXPIRED", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [committedImage()],
+        items: [queuedItem()],
+      }),
+    });
+    mocks.startBatchExtraction.mockResolvedValue({
+      batch: makeBatch({
+        images: [committedImage()],
+        items: [queuedItem()],
+      }),
+    });
+    let getBatchCalls = 0;
+    mocks.getBatch.mockImplementation(() => {
+      getBatchCalls++;
+      if (getBatchCalls === 1) {
+        return Promise.reject(
+          new ApiError("Batch has expired", 409, "BATCH_EXPIRED"),
+        );
+      }
+      return Promise.resolve({ batch: makeBatch({ status: "expired" }) });
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-expired")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/has expired/i)).toBeInTheDocument();
+
+    vi.useRealTimers();
+  });
+
+  it("transitions to expired UX when a submit-step poll returns BATCH_EXPIRED", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [committedImage()],
+        items: [readyItem()],
+      }),
+    });
+    let getBatchCalls = 0;
+    mocks.getBatch.mockImplementation(() => {
+      getBatchCalls++;
+      if (getBatchCalls === 1) {
+        return Promise.reject(
+          new ApiError("Batch has expired", 409, "BATCH_EXPIRED"),
+        );
+      }
+      return Promise.resolve({ batch: makeBatch({ status: "expired" }) });
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-expired")).toBeInTheDocument();
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("transitions to expired UX when a mutation returns BATCH_EXPIRED", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [committedImage()],
+        items: [readyItem()],
+      }),
+    });
+    mocks.submitBatch.mockRejectedValue(
+      new ApiError("Batch has expired", 409, "BATCH_EXPIRED"),
+    );
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({ status: "expired" }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-submit-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-expired")).toBeInTheDocument();
+    });
+  });
+
+  it("renders completed batch state with summary and start-new-batch control", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        status: "completed",
+        images: [committedImage()],
+        items: [submittedItem()],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-complete")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Batch completed/i)).toBeInTheDocument();
+    expect(
+      screen.getByTestId("bulk-wizard-complete-count"),
+    ).toHaveTextContent("1 problem(s) created");
+    expect(
+      screen.getByTestId("bulk-wizard-start-new"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onComplete when the finish button is clicked", async () => {
+    const onComplete = vi.fn();
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        status: "completed",
+        images: [committedImage()],
+        items: [submittedItem()],
+      }),
+    });
+
+    render(<BulkIngestionWizard onComplete={onComplete} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-complete")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-wizard-finish"));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("starts a new batch from the completed state", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        status: "completed",
+        images: [committedImage()],
+        items: [submittedItem()],
+      }),
+    });
+    mocks.createBatch.mockResolvedValue({
+      batch: makeBatch({ id: "batch-new", status: "active" }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-complete")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-wizard-start-new"));
+
+    await waitFor(() => {
+      expect(mocks.createBatch).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-upload-input")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -29,6 +29,17 @@ import { BulkSubmitStep } from "./BulkSubmitStep";
 
 export type { BulkWizardStep };
 
+const BATCH_EXPIRED_STATUS = 409;
+const BATCH_EXPIRED_CODE = "BATCH_EXPIRED";
+
+function isBatchExpiredError(err: unknown): err is ApiError {
+  return (
+    err instanceof ApiError &&
+    err.status === BATCH_EXPIRED_STATUS &&
+    err.code === BATCH_EXPIRED_CODE
+  );
+}
+
 interface BulkIngestionWizardProps {
   initialBatchId?: string;
   onComplete?: () => void;
@@ -84,6 +95,20 @@ export function BulkIngestionWizard({
     setBatch(nextBatch);
     setStep(deriveStep(nextBatch));
   }, []);
+
+  const handleExpiredBatch = useCallback(async () => {
+    if (!batch) {
+      setError("This batch has expired.");
+      return;
+    }
+    try {
+      const response = await getBatch(batch.id);
+      setBatchAndStep(response.batch);
+      setError("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "This batch has expired.");
+    }
+  }, [batch, setBatchAndStep]);
 
   useEffect(() => {
     let cancelled = false;
@@ -142,9 +167,13 @@ export function BulkIngestionWizard({
         const response = await uploadBatchImages(batch.id, fileArray);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setUploadError(
-          err instanceof Error ? err.message : "Failed to upload images",
-        );
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setUploadError(
+            err instanceof Error ? err.message : "Failed to upload images",
+          );
+        }
       } finally {
         setIsLoading(false);
       }
@@ -160,10 +189,14 @@ export function BulkIngestionWizard({
         const response = await detectImageBoxes(batch.id, imageId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to detect boxes");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to detect boxes");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleSaveBoxes = useCallback(
@@ -174,10 +207,14 @@ export function BulkIngestionWizard({
         const response = await saveImageBoxes(batch.id, imageId, boxes, subject);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to save boxes");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to save boxes");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleCommit = useCallback(
@@ -188,10 +225,14 @@ export function BulkIngestionWizard({
         const response = await commitImage(batch.id, imageId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to commit image");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to commit image");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleDeleteImage = useCallback(
@@ -202,10 +243,14 @@ export function BulkIngestionWizard({
         const response = await deleteImage(batch.id, imageId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to delete image");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to delete image");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleRefreshBatch = useCallback(
@@ -214,10 +259,13 @@ export function BulkIngestionWizard({
         const response = await getBatch(batchId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to refresh batch");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        }
+        // Polling failures are intentionally not surfaced as blocking errors.
       }
     },
-    [setBatchAndStep],
+    [handleExpiredBatch, setBatchAndStep],
   );
 
   const handleUpdateItemDraft = useCallback(
@@ -227,10 +275,14 @@ export function BulkIngestionWizard({
         const response = await updateItemDraft(batch.id, itemId, draft);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to save draft");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to save draft");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleRetryItem = useCallback(
@@ -241,10 +293,14 @@ export function BulkIngestionWizard({
         const response = await retryItem(batch.id, itemId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to retry item");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to retry item");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleDeleteItem = useCallback(
@@ -255,10 +311,14 @@ export function BulkIngestionWizard({
         const response = await deleteBatchItem(batch.id, itemId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to delete item");
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(err instanceof Error ? err.message : "Failed to delete item");
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleUndoDeleteItem = useCallback(
@@ -269,18 +329,31 @@ export function BulkIngestionWizard({
         const response = await undoDeleteBatchItem(batch.id, itemId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        setError(
-          err instanceof Error ? err.message : "Failed to restore item",
-        );
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+        } else {
+          setError(
+            err instanceof Error ? err.message : "Failed to restore item",
+          );
+        }
       }
     },
-    [batch, setBatchAndStep],
+    [batch, handleExpiredBatch, setBatchAndStep],
   );
 
   const handleSubmit = useCallback(
     async (batchId: string) => {
       setError("");
-      await submitBatch(batchId);
+      try {
+        await submitBatch(batchId);
+      } catch (err) {
+        if (isBatchExpiredError(err)) {
+          const response = await getBatch(batchId);
+          setBatchAndStep(response.batch);
+          return;
+        }
+        throw err;
+      }
       const response = await getBatch(batchId);
       setBatchAndStep(response.batch);
     },
@@ -302,18 +375,21 @@ export function BulkIngestionWizard({
           if (!cancelled) setBatchAndStep(response.batch);
         }
       } catch (err) {
-        if (!cancelled) {
-          setError(
-            err instanceof Error ? err.message : "Failed to start extraction",
-          );
+        if (cancelled) return;
+        if (isBatchExpiredError(err)) {
+          await handleExpiredBatch();
+          return;
         }
+        setError(
+          err instanceof Error ? err.message : "Failed to start extraction",
+        );
       }
     }
     kickoff();
     return () => {
       cancelled = true;
     };
-  }, [step, batch?.id]);
+  }, [step, batch?.id, handleExpiredBatch]);
 
   if (isLoading) {
     return (
@@ -349,6 +425,9 @@ export function BulkIngestionWizard({
     return (
       <div data-testid="bulk-wizard-expired" style={{ padding: "24px", textAlign: "center" }}>
         <p>This batch has expired.</p>
+        <p style={{ fontSize: "0.9em", color: "var(--color-text-muted)" }}>
+          Your work could not be saved. Start a new ingestion session.
+        </p>
         <button type="button" onClick={handleCreateBatch} style={{ marginTop: "16px" }}>
           Start a new batch
         </button>
@@ -357,14 +436,27 @@ export function BulkIngestionWizard({
   }
 
   if (batch?.status === "completed" || step === "complete") {
+    const submittedCount =
+      batch?.items.filter((item) => item.status === "submitted").length ?? 0;
     return (
       <div data-testid="bulk-wizard-complete" style={{ padding: "24px", textAlign: "center" }}>
-        <p>All done.</p>
-        {onComplete && (
-          <button type="button" onClick={onComplete} style={{ marginTop: "16px" }}>
-            Finish
+        <p>{batch?.status === "completed" ? "Batch completed." : "All items submitted."}</p>
+        <p
+          data-testid="bulk-wizard-complete-count"
+          style={{ fontSize: "0.9em", color: "var(--color-text-muted)" }}
+        >
+          {submittedCount} problem(s) created
+        </p>
+        <div style={{ display: "flex", gap: "12px", justifyContent: "center", marginTop: "16px" }}>
+          <button type="button" onClick={handleCreateBatch} data-testid="bulk-wizard-start-new">
+            Start a new batch
           </button>
-        )}
+          {onComplete && (
+            <button type="button" onClick={onComplete} data-testid="bulk-wizard-finish">
+              Finish
+            </button>
+          )}
+        </div>
       </div>
     );
   }
@@ -481,6 +573,7 @@ export function BulkIngestionWizard({
             batch={batch}
             isLoading={isLoading}
             onSubmit={handleSubmit}
+            onRefresh={handleRefreshBatch}
             onRetry={handleRetryItem}
             onDelete={handleDeleteItem}
           />

--- a/frontend/src/components/BulkSubmitStep.test.tsx
+++ b/frontend/src/components/BulkSubmitStep.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { BulkSubmitStep } from "./BulkSubmitStep";
 import type { BulkBatch, BulkItem } from "@/types/bulkIngestion";
@@ -417,6 +417,61 @@ describe("BulkSubmitStep", () => {
         "Network error",
       );
     });
+  });
+
+  it("polls onRefresh while the batch is active", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onRefresh = vi.fn();
+
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({ items: [makeItem("item-1", { order: 0 })] })}
+        isLoading={false}
+        onRefresh={onRefresh}
+        {...handlers}
+      />,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(2500);
+    });
+
+    await waitFor(() => {
+      expect(onRefresh).toHaveBeenCalledWith("batch-1");
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("does not poll onRefresh when the batch is completed", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onRefresh = vi.fn();
+
+    render(
+      <BulkSubmitStep
+        batch={makeBatch({
+          status: "completed",
+          items: [
+            makeItem("item-1", {
+              order: 0,
+              status: "submitted",
+              submit: { submittedProblemId: "problem-1" },
+            }),
+          ],
+        })}
+        isLoading={false}
+        onRefresh={onRefresh}
+        {...handlers}
+      />,
+    );
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(onRefresh).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
   });
 
   it("shows disabled reasons when there are no items", () => {

--- a/frontend/src/components/BulkSubmitStep.tsx
+++ b/frontend/src/components/BulkSubmitStep.tsx
@@ -1,10 +1,13 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import type { BulkBatch, BulkItem } from "@/types/bulkIngestion";
+
+const POLL_INTERVAL_MS = 2500;
 
 export interface BulkSubmitStepProps {
   batch: BulkBatch;
   isLoading: boolean;
   onSubmit: (batchId: string) => void | Promise<void>;
+  onRefresh?: (batchId: string) => void | Promise<void>;
   onRetry: (itemId: string) => void | Promise<void>;
   onDelete: (itemId: string) => void | Promise<void>;
 }
@@ -55,11 +58,22 @@ export function BulkSubmitStep({
   batch,
   isLoading,
   onSubmit,
+  onRefresh,
   onRetry,
   onDelete,
 }: BulkSubmitStepProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string>("");
+
+  useEffect(() => {
+    if (batch.status !== "active" || !onRefresh) return;
+
+    const id = window.setInterval(() => {
+      onRefresh(batch.id);
+    }, POLL_INTERVAL_MS);
+
+    return () => window.clearInterval(id);
+  }, [batch.id, batch.status, onRefresh]);
 
   const items = useMemo(
     () => [...batch.items].sort((a, b) => a.order - b.order),


### PR DESCRIPTION
## Summary

Builds the frontend behavior for resuming an unexpired server-backed batch, handling completed batches, and gracefully transitioning to an expired state when a batch expires mid-session.

## Linked Issue

Closes #371

## Issue Alignment

This PR implements the issue by:

- Resuming unexpired batch state after reload by fetching server batch detail (`getBatch` via `initialBatchId` or `getActiveBatch`).
- Restoring the current workflow step from server batch/image/item states via the existing `deriveStep` helper.
- Rendering a dedicated expired batch state and disabling editing/submitting.
- Detecting mid-session expiry from polling (`BulkReviewStep` and `BulkSubmitStep` pollers) and from any batch mutation API error that returns `409 BATCH_EXPIRED`.
- Rendering a completed batch state with a submitted-problem count summary and preventing further editing.
- Providing a "Start a new batch" control after expiry/completion to clear the active client-side batch selection.
- Continuing to avoid durable browser-only draft/batch persistence (no localStorage usage).

Scope covered:

- Resume/step restoration on initial load.
- Mid-session expiry detection during review, submit, and mutation operations.
- Completed batch UX and active-cache clearing.
- Frontend tests and TypeScript build.

Out of scope / intentionally not included:

- Backend resume/expiry implementation (already delivered by dependencies).
- Cross-device resume guarantee.
- Submit UI beyond reacting to completed state (covered by #370).
- Box editor and draft field controls (out of scope per issue).

## Implementation Notes

- Added a small `isBatchExpiredError` helper that checks for `ApiError` with status `409` and code `BATCH_EXPIRED`, matching the backend contract.
- Centralized expiry handling in `handleExpiredBatch`, which refetches the batch so the server state (now `expired`) drives the UI.
- Wired expiry detection into `handleUploadFiles`, `handleDetect`, `handleSaveBoxes`, `handleCommit`, `handleDeleteImage`, `handleRefreshBatch`, `handleUpdateItemDraft`, `handleRetryItem`, `handleDeleteItem`, `handleUndoDeleteItem`, `handleSubmit`, and the auto-start extraction effect.
- Added optional `onRefresh` polling to `BulkSubmitStep` (mirroring `BulkReviewStep`) so expiry is detected while the user is on the submit step.
- Replaced the bare expired/completed placeholders with richer UX that explains the state and offers a clear next action.

## Tests

Commands run:

- `cd frontend && npm test -- --run` — 431 passed
- `cd frontend && npm run build` — passed

Automated tests added or updated:

- `frontend/src/components/BulkIngestionWizard.test.tsx`
  - Resume unexpired batch at review step via `initialBatchId`.
  - Restore submit step from a server-backed ready batch.
  - Transition to expired UX when a review poll returns `BATCH_EXPIRED`.
  - Transition to expired UX when a submit-step poll returns `BATCH_EXPIRED`.
  - Transition to expired UX when a mutation (`submitBatch`) returns `BATCH_EXPIRED`.
  - Render completed batch state with summary and start-new-batch control.
  - Call `onComplete` when the finish button is clicked.
  - Start a new batch from the completed state.
- `frontend/src/components/BulkSubmitStep.test.tsx`
  - Poll `onRefresh` while the batch is active.
  - Do not poll `onRefresh` when the batch is completed.

Manual verification:

- Existing "does not persist batch state in localStorage" test still proves durable browser-only persistence is not required.

## Deviations From Issue Plan

None.

## Follow-Up Work

None. Issue #372 (E2E coverage and retiring the old single-flow entry) is unblocked once this PR merges.
