### PR TITLE
Add solution state filter to Problems page

### DIFF
--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -121,8 +121,56 @@ class BulkSetFolderResponse(BaseModel):
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 ProblemSortBy = Literal["selectionScore", "addDate", "lastTestDate"]
 ProblemSortOrder = Literal["asc", "desc"]
+SolutionState = Literal["none", "pending", "generating", "ready", "failed"]
 
 
+async def _solution_state_problem_ids(
+    database: Any,
+    user_id: Any,
+    solution_state: str,
+) -> list[ObjectId] | None:
+    """Return problem ``_id``s whose effective solution state matches ``solution_state``.
+
+    A ``None`` return value means no ``_id`` filter is needed (all of the user's
+    problems match the requested state). Effective status precedence mirrors
+    ``GET /api/v1/problems/{id}/solution-status``: a canonical solution means
+    ``ready`` even when a stale task also exists; otherwise the task status wins;
+    otherwise the status is ``none``.
+    """
+    user_id_str = str(user_id)
+    solutions = database["canonical_solutions"]
+    tasks = database["solution_generation_tasks"]
+
+    ready_docs = await solutions.find({"user_id": user_id_str}).to_list(length=None)
+    ready_ids = {str(doc["problem_id"]) for doc in ready_docs}
+
+    if solution_state == "ready":
+        return [ObjectId(pid) for pid in ready_ids]
+
+    task_docs = await tasks.find({"user_id": user_id_str}).to_list(length=None)
+
+    if solution_state in ("pending", "generating", "failed"):
+        return [
+            ObjectId(doc["problem_id"])
+            for doc in task_docs
+            if str(doc.get("status", "pending")) == solution_state
+            and str(doc["problem_id"]) not in ready_ids
+        ]
+
+    # solution_state == "none": problems with neither a canonical solution nor a task.
+    task_ids = {str(doc["problem_id"]) for doc in task_docs}
+    has_state_ids = ready_ids | task_ids
+    if not has_state_ids:
+        return None
+
+    problem_docs = await database["problems"].find(
+        {"userId": user_id, "isDeleted": False}
+    ).to_list(length=None)
+    return [
+        doc["_id"]
+        for doc in problem_docs
+        if str(doc["_id"]) not in has_state_ids
+    ]
 
 
 def _serialize_tracking(problem: dict[str, Any]) -> TrackingPayload:
@@ -261,6 +309,7 @@ async def list_problems(
     folder_id: str | None = Query(default=None, alias="folderId"),
     sort_by: ProblemSortBy | None = Query(default=None, alias="sortBy"),
     sort_order: ProblemSortOrder | None = Query(default=None, alias="sortOrder"),
+    solution_state: SolutionState | None = Query(default=None, alias="solutionState"),
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
 ) -> ProblemListResponse:
@@ -291,6 +340,11 @@ async def list_problems(
             descendant_ids = await get_all_descendant_folder_ids(database, folder_oid)
             all_folder_ids = {folder_oid} | descendant_ids
             query["folderId"] = {"$in": [str(fid) for fid in all_folder_ids]}
+
+    if solution_state is not None:
+        matching_ids = await _solution_state_problem_ids(database, user_id, solution_state)
+        if matching_ids is not None:
+            query["_id"] = {"$in": matching_ids}
 
     total = await database["problems"].count_documents(query)
     skip = (page - 1) * page_size

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -125,6 +125,31 @@ def make_problem(
     }
 
 
+def make_solution_task(
+    problem: dict[str, Any], user_id: ObjectId, *, status: str
+) -> dict[str, Any]:
+    return {
+        "_id": ObjectId(),
+        "problem_id": str(problem["_id"]),
+        "user_id": str(user_id),
+        "status": status,
+        "created_at": datetime.now(UTC),
+    }
+
+
+def make_canonical_solution(
+    problem: dict[str, Any], user_id: ObjectId
+) -> dict[str, Any]:
+    return {
+        "_id": ObjectId(),
+        "problem_id": str(problem["_id"]),
+        "user_id": str(user_id),
+        "steps_markdown": "step 1",
+        "final_answer": "4",
+        "math_level_classification": "basic",
+    }
+
+
 @pytest_asyncio.fixture
 async def problems_app() -> FastAPI:
     application = create_app()
@@ -505,6 +530,167 @@ async def test_solution_status(problems_app: FastAPI, client: AsyncClient) -> No
     database["problems"].seed(other_problem)
     response = await client.get(f"/api/v1/problems/{str(other_problem['_id'])}/solution-status")
     assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_solution_state_filter_failed(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    failed_problem = make_problem(user_id, text="Failed problem")
+    ready_problem = make_problem(user_id, text="Ready problem")
+    none_problem = make_problem(user_id, text="None problem")
+    database["problems"].seed(failed_problem, ready_problem, none_problem)
+    database["solution_generation_tasks"].seed(
+        make_solution_task(failed_problem, user_id, status="failed"),
+    )
+    database["canonical_solutions"].seed(
+        make_canonical_solution(ready_problem, user_id),
+    )
+
+    response = await client.get("/api/v1/problems", params={"solutionState": "failed"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["id"] == str(failed_problem["_id"])
+
+
+@pytest.mark.asyncio
+async def test_solution_state_filter_each_state(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    pending_problem = make_problem(user_id, text="Pending")
+    generating_problem = make_problem(user_id, text="Generating")
+    ready_problem = make_problem(user_id, text="Ready")
+    none_problem = make_problem(user_id, text="None")
+    database["problems"].seed(
+        pending_problem, generating_problem, ready_problem, none_problem
+    )
+    database["solution_generation_tasks"].seed(
+        make_solution_task(pending_problem, user_id, status="pending"),
+        make_solution_task(generating_problem, user_id, status="generating"),
+    )
+    database["canonical_solutions"].seed(
+        make_canonical_solution(ready_problem, user_id),
+    )
+
+    for state, expected in [
+        ("pending", pending_problem),
+        ("generating", generating_problem),
+        ("ready", ready_problem),
+        ("none", none_problem),
+    ]:
+        response = await client.get("/api/v1/problems", params={"solutionState": state})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["total"] == 1, state
+        assert body["items"][0]["id"] == str(expected["_id"]), state
+
+
+@pytest.mark.asyncio
+async def test_solution_state_ready_precedence_over_stale_failed_task(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id, text="Has solution and stale failed task")
+    database["problems"].seed(problem)
+    # Stale failed task that should be shadowed by the canonical solution.
+    database["solution_generation_tasks"].seed(
+        make_solution_task(problem, user_id, status="failed"),
+    )
+    database["canonical_solutions"].seed(make_canonical_solution(problem, user_id))
+
+    ready_response = await client.get("/api/v1/problems", params={"solutionState": "ready"})
+    assert ready_response.status_code == 200
+    ready_body = ready_response.json()
+    assert ready_body["total"] == 1
+    assert ready_body["items"][0]["id"] == str(problem["_id"])
+
+    failed_response = await client.get("/api/v1/problems", params={"solutionState": "failed"})
+    assert failed_response.status_code == 200
+    assert failed_response.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_solution_state_composes_with_other_filters(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    matching = make_problem(
+        user_id, text="Matching failed problem", tags=["algebra"], problem_type="short-answer"
+    )
+    other_failed = make_problem(
+        user_id, text="Other failed", tags=["geometry"], problem_type="single-choice"
+    )
+    database["problems"].seed(matching, other_failed)
+    database["solution_generation_tasks"].seed(
+        make_solution_task(matching, user_id, status="failed"),
+        make_solution_task(other_failed, user_id, status="failed"),
+    )
+
+    response = await client.get(
+        "/api/v1/problems",
+        params={
+            "solutionState": "failed",
+            "tag": "algebra",
+            "type": "short-answer",
+            "q": "matching",
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["id"] == str(matching["_id"])
+
+
+@pytest.mark.asyncio
+async def test_solution_state_invalid_returns_422(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    response = await client.get("/api/v1/problems", params={"solutionState": "bogus"})
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_solution_state_isolates_other_users(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    other_user_id = problems_app.state.secondary_user["_id"]
+
+    own_problem = make_problem(user_id, text="Own none problem")
+    database["problems"].seed(own_problem)
+
+    # Another user has a failed task and a ready solution, but for their own problems.
+    other_failed_problem = make_problem(other_user_id, text="Other user failed")
+    other_ready_problem = make_problem(other_user_id, text="Other user ready")
+    database["problems"].seed(other_failed_problem, other_ready_problem)
+    database["solution_generation_tasks"].seed(
+        make_solution_task(other_failed_problem, other_user_id, status="failed"),
+    )
+    database["canonical_solutions"].seed(
+        make_canonical_solution(other_ready_problem, other_user_id),
+    )
+
+    none_response = await client.get("/api/v1/problems", params={"solutionState": "none"})
+    assert none_response.status_code == 200
+    none_body = none_response.json()
+    assert none_body["total"] == 1
+    assert none_body["items"][0]["id"] == str(own_problem["_id"])
+
+    failed_response = await client.get("/api/v1/problems", params={"solutionState": "failed"})
+    assert failed_response.status_code == 200
+    assert failed_response.json()["total"] == 0
+
+    ready_response = await client.get("/api/v1/problems", params={"solutionState": "ready"})
+    assert ready_response.status_code == 200
+    assert ready_response.json()["total"] == 0
 
 
 async def test_search_by_text(

--- a/frontend/src/pages/ProblemsPage.test.tsx
+++ b/frontend/src/pages/ProblemsPage.test.tsx
@@ -792,4 +792,105 @@ describe("ProblemsPage", () => {
     // Move selected should be disabled
     expect(screen.getByRole("button", { name: "Move selected" })).toBeDisabled();
   });
+
+  it("renders the Solution state filter with all required options", async () => {
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    expect(screen.getByLabelText("Solution state:")).toBeInTheDocument();
+    for (const label of ["All", "Not Started", "Pending", "Generating", "Generated", "Failed"]) {
+      expect(screen.getByRole("option", { name: label })).toBeInTheDocument();
+    }
+  });
+
+  it("selecting Failed sends solutionState=failed together with existing filters", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
+    await user.selectOptions(screen.getByLabelText("Solution state:"), "failed");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("solutionState=failed");
+      expect(lastUrl).toContain("tag=algebra");
+      expect(lastUrl).toContain("page=1");
+    });
+  });
+
+  it("remembers the selected solution state across remounts", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    const { unmount } = renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.selectOptions(screen.getByLabelText("Solution state:"), "failed");
+    await waitFor(() => {
+      expect(problemRequestUrls().at(-1) ?? "").toContain("solutionState=failed");
+    });
+
+    unmount();
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await waitFor(() => {
+      expect(problemRequestUrls().at(-1) ?? "").toContain("solutionState=failed");
+    });
+    expect(screen.getByLabelText("Solution state:")).toHaveValue("failed");
+  });
+
+  it("reset helper clears the solution-state preference", async () => {
+    const user = userEvent.setup();
+    installApiMock();
+
+    const { unmount } = renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await user.selectOptions(screen.getByLabelText("Solution state:"), "failed");
+    await waitFor(() => {
+      expect(problemRequestUrls().at(-1) ?? "").toContain("solutionState=failed");
+    });
+
+    unmount();
+    _resetProblemsPagePreferencesForTests();
+    renderProblemsPage();
+    await screen.findByText("What is 2+2?");
+
+    await waitFor(() => {
+      expect(problemRequestUrls().at(-1) ?? "").not.toContain("solutionState=");
+    });
+    expect(screen.getByLabelText("Solution state:")).toHaveValue("");
+  });
+
+  it("changing solution state resets requests to page 1 and exits selection mode", async () => {
+    const user = userEvent.setup();
+    installApiMock({ problems: [problem({ id: "p1" }), problem({ id: "p2", text: "Second problem" })], total: 25 });
+
+    renderProblemsPage();
+    await screen.findByText("Second problem");
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    const card = screen.getByText("What is 2+2?").closest("div")!;
+    fireEvent.pointerDown(card);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+    });
+    fireEvent.pointerUp(card);
+    await screen.findByRole("checkbox", { name: "Select problem p1" });
+
+    await user.selectOptions(screen.getByLabelText("Solution state:"), "failed");
+
+    await waitFor(() => {
+      const lastUrl = problemRequestUrls().at(-1) ?? "";
+      expect(lastUrl).toContain("solutionState=failed");
+      expect(lastUrl).toContain("page=1");
+    });
+    expect(screen.queryByLabelText("Bulk actions")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -30,6 +30,15 @@ const SORT_ORDER_OPTIONS: Array<{ value: ProblemSortOrder; label: string }> = [
   { value: "asc", label: "Ascending" },
 ];
 
+const SOLUTION_STATE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "", label: "All" },
+  { value: "none", label: "Not Started" },
+  { value: "pending", label: "Pending" },
+  { value: "generating", label: "Generating" },
+  { value: "ready", label: "Generated" },
+  { value: "failed", label: "Failed" },
+];
+
 type ProblemsPagePreferences = {
   selectedFolderId: string;
   selectedTag: string;
@@ -37,6 +46,7 @@ type ProblemsPagePreferences = {
   searchQuery: string;
   sortBy: ProblemSortBy;
   sortOrder: ProblemSortOrder;
+  solutionState: string;
 };
 
 const DEFAULT_PREFERENCES: ProblemsPagePreferences = {
@@ -46,6 +56,7 @@ const DEFAULT_PREFERENCES: ProblemsPagePreferences = {
   searchQuery: "",
   sortBy: "",
   sortOrder: "desc",
+  solutionState: "",
 };
 
 let problemsPagePreferences: ProblemsPagePreferences = { ...DEFAULT_PREFERENCES };
@@ -104,6 +115,7 @@ export function ProblemsPage() {
   const [searchQuery, setSearchQuery] = useState<string>(problemsPagePreferences.searchQuery);
   const [sortBy, setSortBy] = useState<ProblemSortBy>(problemsPagePreferences.sortBy);
   const [sortOrder, setSortOrder] = useState<ProblemSortOrder>(problemsPagePreferences.sortOrder);
+  const [solutionState, setSolutionState] = useState<string>(problemsPagePreferences.solutionState);
   const [selectedProblemIds, setSelectedProblemIds] = useState<Set<string>>(new Set());
   const [isSelectionMode, setIsSelectionMode] = useState(false);
   const [bulkTarget, setBulkTarget] = useState<string>(UNFILED_FOLDER_ID);
@@ -120,7 +132,7 @@ export function ProblemsPage() {
   const pageSize = 20;
 
   const { data: problemsData, isLoading: isLoadingProblems } = useQuery({
-    queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery, selectedFolderId, sortBy, sortOrder],
+    queryKey: ["problems", page, selectedTag, selectedProblemType, searchQuery, selectedFolderId, sortBy, sortOrder, solutionState],
     queryFn: async () => {
       const params = new URLSearchParams({
         page: String(page),
@@ -130,6 +142,7 @@ export function ProblemsPage() {
       if (selectedProblemType) params.append("type", selectedProblemType);
       if (searchQuery.trim()) params.append("q", searchQuery.trim());
       if (selectedFolderId) params.append("folderId", selectedFolderId);
+      if (solutionState) params.append("solutionState", solutionState);
       if (sortBy) {
         params.append("sortBy", sortBy);
         params.append("sortOrder", sortOrder);
@@ -645,6 +658,35 @@ export function ProblemsPage() {
               }}
             >
               {PROBLEM_TYPE_FILTER_OPTIONS.map((option) => (
+                <option key={option.value || "all"} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="solution-state-filter" style={{ fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", display: "block", marginBottom: "0.375rem" }}>Solution state: </label>
+            <select
+              id="solution-state-filter"
+              value={solutionState}
+              onChange={(e) => {
+                setSolutionState(e.target.value);
+                problemsPagePreferences.solutionState = e.target.value;
+                setPage(1);
+                exitSelectionMode();
+              }}
+              style={{
+                padding: "0.5rem 0.75rem",
+                borderRadius: "var(--radius-md)",
+                border: "1px solid var(--color-border)",
+                backgroundColor: "var(--color-surface-muted)",
+                color: "var(--color-text)",
+                fontSize: "0.875rem",
+                minWidth: "150px",
+                outline: "none"
+              }}
+            >
+              {SOLUTION_STATE_OPTIONS.map((option) => (
                 <option key={option.value || "all"} value={option.value}>
                   {option.label}
                 </option>


### PR DESCRIPTION
## Summary

- Adds a server-backed `solutionState` filter to `GET /api/v1/problems` so the Problems page can find problems by canonical solution generation status (e.g. `Solution Failed`).
- Adds a `Solution state` select to the Problems page that composes with existing folder/tag/type/search/sort/pagination controls.
- Effective solution-state precedence matches the existing single-problem `GET /api/v1/problems/{id}/solution-status` endpoint: a canonical solution means `ready` even when a stale task also exists.

## Linked Issue

Closes #394

## Issue Alignment

This PR implements the issue by:

- Adding a typed optional `solutionState` query parameter to `GET /api/v1/problems` accepting `none`, `pending`, `generating`, `ready`, `failed` (invalid values return `422`).
- Implementing server-side filtering by collecting matching problem `_id`s from `canonical_solutions` and `solution_generation_tasks` and constraining the existing problems query with `_id: {$in: ...}`.
- Adding a `Solution state` select with options `All / Not Started / Pending / Generating / Generated / Failed` to the Problems page beside existing list controls.
- Including the selection in the React Query key, request params (omitted when `All`), and the in-memory page preferences.
- Resetting pagination to page 1 and exiting selection mode when the solution-state filter changes (matching existing filter behavior).

Scope covered:

- Backend `solutionState` query param + server-side filtering for all five states.
- Ready-precedence: problems with a canonical solution match `ready` and never match a stale task status.
- Ownership isolation: solutions/tasks are scoped to the current user.
- Frontend filter control, request param, query-key, persistence, page reset, selection-mode exit.
- Backend and frontend automated tests.

Out of scope / intentionally not included:

- Retrying/regenerating/repairing failed solution generation tasks.
- Solution-state badges/metadata on problem cards (control is filter-only).
- Writing filter state to browser URL search params.
- Any database migration or broad refactor.

## Implementation Notes

- The helper `_solution_state_problem_ids` returns `list[ObjectId] | None`. `None` signals that no `_id` filter is needed (only happens for `none` when the user has no solutions or tasks at all, so every problem is in the `none` state). An empty list means "match nothing" (e.g. `failed` when there are no failed tasks), which is handled correctly by the `$in` filter.
- `problem_id` is stored as a string in `canonical_solutions`/`solution_generation_tasks`, so collected IDs are converted back to `ObjectId` to match the problems collection `_id`.
- For `none`, the user's problem `_id`s are fetched once to compute the complement of "has solution or task"; this is only done for the `none` state. The result still composes with the existing folder/tag/type/search filters via the shared `_id` constraint.
- Solutions and tasks are filtered by `user_id` (string) so other users' records never contribute IDs; the existing `userId` filter on the problems query provides a second layer of ownership isolation.

## Tests

Commands run:

- `cd backend && uv run --extra dev pytest tests/api/test_problems.py` — passed (40 passed).
- `cd backend && uv run --extra dev pytest` — passed (679 passed, 1 pre-existing skip).
- `cd frontend && npm test -- ProblemsPage.test.tsx --run` — passed (32 passed).
- `cd frontend && npm run build` — fails, but **pre-existing on unmodified `master`** due to missing type declarations for `katex`/`react-markdown`/`remark-*`/`rehype-katex` (confirmed identical on master). No errors reference the files changed in this PR.

Automated tests added or updated:

- Backend (`backend/tests/api/test_problems.py`):
  - `test_solution_state_filter_failed` — `solutionState=failed` returns only the failed-task problem.
  - `test_solution_state_filter_each_state` — `pending`, `generating`, `ready`, `none` each return the right problem.
  - `test_solution_state_ready_precedence_over_stale_failed_task` — a problem with both a canonical solution and a stale `failed` task matches `ready` and not `failed`.
  - `test_solution_state_composes_with_other_filters` — `solutionState=failed` composes with `tag`, `type`, and `q`.
  - `test_solution_state_invalid_returns_422` — an invalid value returns `422`.
  - `test_solution_state_isolates_other_users` — another user's solutions/tasks do not appear in the current user's `none`/`failed`/`ready` results.
- Frontend (`frontend/src/pages/ProblemsPage.test.tsx`):
  - Renders the `Solution state` select with all required options.
  - Selecting `Failed` sends `solutionState=failed` together with existing filters.
  - The selected solution-state filter is remembered across remounts.
  - The reset helper clears the solution-state preference.
  - Changing solution state resets requests to page 1 and exits selection mode.

Manual verification:

- Not separately performed; automated backend API tests and frontend component tests cover the required behavior per the issue's `Tests Required` and `Manual Verification / Self-Check` sections.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (server-backed filter, ready precedence, filter-only frontend control, in-memory preference persistence).

## Follow-Up Work

None required. A future issue could add retry/regeneration tooling for failed solution generation tasks, but that is intentionally out of scope here (per the issue).
