### PR TITLE
Show current-batch recent tag shortcuts during ingestion review

### DIFF
--- a/frontend/src/components/BulkReviewStep.test.tsx
+++ b/frontend/src/components/BulkReviewStep.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react";
 import { BulkReviewStep } from "./BulkReviewStep";
 import type { BulkBatch, BulkItem } from "@/types/bulkIngestion";
 
@@ -783,5 +783,183 @@ describe("BulkReviewStep", () => {
         screen.queryByTestId("bulk-review-save-status"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("adds a tag to one draft and reuses it on another draft via the recent chip", async () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    // Add "calculus" to item-1.
+    const firstTagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(firstTagInput, { target: { value: "calculus" } });
+    fireEvent.keyDown(firstTagInput, { key: "Enter", code: "Enter" });
+
+    // Switch to item-2; the recent chip should appear and add the tag on click.
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    const chip = screen.getByTestId("bulk-review-recent-tag-calculus");
+    fireEvent.click(chip);
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    await waitFor(() => {
+      expect(handlers.onUpdateDraft).toHaveBeenCalledWith(
+        "item-2",
+        expect.objectContaining({ tags: ["math", "calculus"] }),
+      );
+    });
+  });
+
+  it("hides recent tags already selected on the current draft", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    // Add "calculus" to item-1; it is now selected, so the chip is hidden.
+    const tagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(tagInput, { target: { value: "calculus" } });
+    fireEvent.keyDown(tagInput, { key: "Enter", code: "Enter" });
+
+    expect(
+      screen.queryByTestId("bulk-review-recent-tag-calculus"),
+    ).not.toBeInTheDocument();
+
+    // Switch to item-2 (does not have "calculus"); the chip now appears.
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    expect(
+      screen.getByTestId("bulk-review-recent-tag-calculus"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders at most 5 recent tag chips", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    // Add 7 distinct tags to item-1 via comma-separated input.
+    const tagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(tagInput, { target: { value: "t1,t2,t3,t4,t5,t6,t7" } });
+    fireEvent.keyDown(tagInput, { key: "Enter", code: "Enter" });
+
+    // Switch to item-2 (only has "math"); recent chips should be capped at 5.
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    const chips = within(
+      screen.getByTestId("bulk-review-recent-tags"),
+    ).getAllByRole("button");
+    expect(chips).toHaveLength(5);
+  });
+
+  it("does not add tags from recent chips when review fields are disabled", async () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1, status: "deleted" }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    // Add "physics" to item-1.
+    const tagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(tagInput, { target: { value: "physics" } });
+    fireEvent.keyDown(tagInput, { key: "Enter", code: "Enter" });
+
+    // Switch to the deleted item-2 (fields disabled); chip is disabled.
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    const chip = screen.getByTestId("bulk-review-recent-tag-physics");
+    expect(chip).toBeDisabled();
+
+    fireEvent.click(chip);
+
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+
+    // item-2's tags must remain unchanged.
+    expect(handlers.onUpdateDraft).not.toHaveBeenCalledWith(
+      "item-2",
+      expect.objectContaining({ tags: expect.arrayContaining(["physics"]) }),
+    );
+  });
+
+  it("adds each tag from comma-separated multi-tag input to recent tags", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    const tagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(tagInput, { target: { value: "alpha,beta" } });
+    fireEvent.keyDown(tagInput, { key: "Enter", code: "Enter" });
+
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    expect(screen.getByTestId("bulk-review-recent-tag-alpha")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-review-recent-tag-beta")).toBeInTheDocument();
+  });
+
+  it("adds each tag from semicolon-separated input to recent tags", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    const tagInput = screen.getByTestId("bulk-review-tags-field");
+    fireEvent.change(tagInput, { target: { value: "gamma" } });
+    fireEvent.keyDown(tagInput, { key: ";" });
+    fireEvent.change(tagInput, { target: { value: "delta" } });
+    fireEvent.keyDown(tagInput, { key: "Enter", code: "Enter" });
+
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    expect(screen.getByTestId("bulk-review-recent-tag-gamma")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-review-recent-tag-delta")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -107,6 +107,7 @@ export function BulkReviewStep({
   const [dirtyItems, setDirtyItems] = useState<Set<string>>(new Set());
   const [savingItems, setSavingItems] = useState<Set<string>>(new Set());
   const [saveFailures, setSaveFailures] = useState<Record<string, number>>({});
+  const [recentTags, setRecentTags] = useState<string[]>([]);
   const draftRefs = useRef<Record<string, BulkDraft>>({});
   const dirtyRefs = useRef<Set<string>>(new Set());
   const saveFailuresRef = useRef<Record<string, number>>({});
@@ -163,6 +164,31 @@ export function BulkReviewStep({
       });
     },
     [],
+  );
+
+  const handleTagsChange = useCallback(
+    (itemId: string, nextTags: string[], prevTags: string[]) => {
+      const prevSet = new Set(prevTags);
+      const added = nextTags.filter((tag) => !prevSet.has(tag));
+      if (added.length > 0) {
+        setRecentTags((prev) => {
+          const next = [...prev];
+          const seen = new Set(prev);
+          for (const tag of added) {
+            if (seen.has(tag)) {
+              const index = next.indexOf(tag);
+              if (index >= 0) next.splice(index, 1);
+            } else {
+              seen.add(tag);
+            }
+            next.unshift(tag);
+          }
+          return next.slice(0, 5);
+        });
+      }
+      updateDraft(itemId, { tags: nextTags });
+    },
+    [updateDraft],
   );
 
   useEffect(() => {
@@ -365,6 +391,16 @@ export function BulkReviewStep({
     continueDisabledReasons.push("Draft save failed, retrying");
   }
   const canContinue = continueDisabledReasons.length === 0;
+
+  const currentTagSet = new Set(currentDraft.tags ?? []);
+  const visibleRecentTags = recentTags.filter((tag) => !currentTagSet.has(tag));
+
+  const handleRecentTagClick = (tag: string) => {
+    if (isFieldDisabled) return;
+    const currentTags = currentDraft.tags ?? [];
+    if (currentTags.includes(tag)) return;
+    handleTagsChange(selectedItem.itemId, [...currentTags, tag], currentTags);
+  };
 
   return (
     <div data-testid="bulk-wizard-review-step">
@@ -683,10 +719,53 @@ export function BulkReviewStep({
               </div>
             )}
 
+            {visibleRecentTags.length > 0 && (
+              <div
+                data-testid="bulk-review-recent-tags"
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  gap: "6px",
+                  alignItems: "center",
+                  marginBottom: "8px",
+                }}
+              >
+                <span
+                  style={{
+                    fontSize: "0.85em",
+                    fontWeight: 600,
+                    color: "var(--color-text-muted)",
+                  }}
+                >
+                  Recent tags:
+                </span>
+                {visibleRecentTags.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    data-testid={`bulk-review-recent-tag-${tag}`}
+                    disabled={isFieldDisabled}
+                    onClick={() => handleRecentTagClick(tag)}
+                    style={{
+                      padding: "2px 8px",
+                      border: "1px solid var(--color-border)",
+                      borderRadius: "4px",
+                      backgroundColor: "var(--color-surface)",
+                      color: "var(--color-text)",
+                      fontSize: "0.8em",
+                      cursor: isFieldDisabled ? "not-allowed" : "pointer",
+                    }}
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            )}
+
             <TagInput
               tags={currentDraft.tags ?? []}
               onChange={(tags) =>
-                updateDraft(selectedItem.itemId, { tags })
+                handleTagsChange(selectedItem.itemId, tags, currentDraft.tags ?? [])
               }
               suggestions={reviewTagSuggestions}
               placeholder="Add a tag..."


### PR DESCRIPTION
## Summary

- Adds current-batch recent tag shortcuts to the ingestion review step so users can quickly reuse tags by clicking chips instead of retyping them.
- Tracks tags newly added during the current bulk review session and renders up to 5 as clickable `Recent tags` chips near each draft's `Tags` input.

## Linked Issue

Closes #395

## Issue Alignment

This PR implements the issue by:

- Adding session-scoped `recentTags` state in `BulkReviewStep` (newest first, deduplicated, capped to 5).
- Deriving newly added tags from the existing `TagInput` `onChange` path via a `handleTagsChange` wrapper that updates the recent list before routing through the existing `updateDraft` — `TagInput` itself is unchanged, so other consumers are unaffected.
- Rendering a compact `Recent tags` chip row near the `TagInput` that hides tags already selected on the current draft, respects disabled field state, and adds the clicked tag only to the currently selected draft via the same update path (moving it to the front of the recent list).

Scope covered:

- Frontend-only tracking of current-batch recent tag usage in `BulkReviewStep`.
- `Recent tags` row with at most 5 clickable chips, newest first, deduplicated.
- Hiding chips for tags already on the current draft.
- Adding a clicked chip only to the current draft (no duplicates).
- Respecting disabled/read-only field state.
- Multi-tag entry via comma or semicolon feeds each newly added tag into the recent list (via the existing `TagInput.addTag` split logic).

Out of scope / intentionally not included:

- Backend API changes, persisted recency, or migrations.
- Changes to the Tags management page, problem filtering/search, or `TagInput` autocomplete redesign.
- Treating initial/extracted draft tags as recent before the user actually uses them during review.
- Changes to `TagInput` (no new public API was needed).

## Implementation Notes

- New tags are detected by diffing the incoming `onChange` tags array against the draft's previous tags (`prevTags`), so comma/semicolon multi-tag entry is handled automatically because `TagInput.addTag` already splits, trims, and dedupes segments before calling `onChange`.
- `recentTags` is capped to the newest 5; `visibleRecentTags` further excludes tags already present on the currently selected draft.
- Clicking a recent chip calls the same `handleTagsChange` path, which both adds the tag to the current draft and moves it to the front of the recent list.
- The recent-chip row and its handlers are placed after the existing early-return guard, so they only apply when a selected item exists; `handleTagsChange` is a `useCallback` declared before the guard to keep hook order stable.

## Tests

Commands run:

- `cd frontend && npm test -- BulkReviewStep.test.tsx --run` — passed (29 passed: 23 existing + 6 new).
- `cd frontend && npm test -- TagInput.test.tsx --run` — passed (33 passed; `TagInput` was not modified).
- `cd frontend && npm test -- --run` — passed (30 files, 432 tests).
- `cd frontend && npm run build` — passed (TypeScript type-check + Vite build).

Automated tests added (`frontend/src/components/BulkReviewStep.test.tsx`):

- Adds a tag to one draft and reuses it on another draft via the recent chip (cross-draft reuse + click adds to current draft).
- Hides recent tags already selected on the current draft.
- Renders at most 5 recent tag chips.
- Does not add tags from recent chips when review fields are disabled.
- Adds each tag from comma-separated multi-tag input to recent tags.
- Adds each tag from semicolon-separated input to recent tags.

Manual verification:

- Automated component tests cover the required behavior per the issue's `Tests Required` and `Manual Verification / Self-Check` sections. The happy path (add a tag, switch items, click the chip) and the disabled/limit/hide cases are all asserted.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (frontend-only, derive newly added tags from the existing `TagInput` `onChange` path, in-session state). The optional `onTagsAdded` callback on `TagInput` mentioned in the issue was not needed because diffing in the `onChange` handler is sufficient and avoids changing `TagInput`.

## Follow-Up Work

None required. Potential future work noted in the issue (persisted cross-session recency, a `lastUsedAt`/usage-history model, reuse outside ingestion review) is intentionally out of scope here.
