### PR TITLE
Support PDF uploads in ingestion batches

### DIFF
--- a/backend/app/infrastructure/ingestion/pdf.py
+++ b/backend/app/infrastructure/ingestion/pdf.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pymupdf
+
+# DPI used when rendering PDF pages to raster images.
+PDF_RENDER_DPI = 150
+
+
+class PdfRenderError(Exception):
+    """Raised when a PDF cannot be rendered to page images."""
+
+
+@dataclass(frozen=True)
+class RenderedPage:
+    bytes: bytes
+    width: int
+    height: int
+    content_type: str = "image/png"
+
+
+def render_pdf_pages(pdf_bytes: bytes) -> list[RenderedPage]:
+    """Render each page of *pdf_bytes* into a PNG image.
+
+    Raises :class:`PdfRenderError` when the PDF is empty, encrypted, or
+    cannot be parsed.
+    """
+    try:
+        document = pymupdf.open(stream=pdf_bytes, filetype="pdf")
+    except Exception as exc:
+        raise PdfRenderError(f"Could not open PDF: {exc}") from exc
+
+    try:
+        if document.is_encrypted:
+            raise PdfRenderError("PDF is encrypted")
+        if document.page_count == 0:
+            raise PdfRenderError("PDF has no pages")
+
+        pages: list[RenderedPage] = []
+        for page in document:
+            pixmap = page.get_pixmap(dpi=PDF_RENDER_DPI)
+            pages.append(
+                RenderedPage(
+                    bytes=pixmap.tobytes("png"),
+                    width=pixmap.width,
+                    height=pixmap.height,
+                )
+            )
+        return pages
+    finally:
+        document.close()

--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -5,7 +5,7 @@ import logging
 import mimetypes
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, NamedTuple
 
 from fastapi import APIRouter, Depends, File, UploadFile
 from fastapi.responses import StreamingResponse
@@ -29,6 +29,7 @@ from app.domain.models import ProblemSubject, ProblemType
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.ingestion.documents import build_source_image
 from app.infrastructure.ingestion.image_size import get_image_size
+from app.infrastructure.ingestion.pdf import PdfRenderError, render_pdf_pages
 from app.infrastructure.ingestion.repository import (
     add_source_image,
     commit_image_boxes,
@@ -290,24 +291,61 @@ async def _load_owned_batch_for_read(
     return batch
 
 
-async def _validate_image_upload(
-    image: UploadFile,
-    max_image_bytes: int,
-) -> tuple[bytes, str]:
-    content_type = image.content_type or ""
-    if not content_type.startswith("image/"):
-        raise ApiError(400, "INVALID_IMAGE", "Uploaded file must be an image")
+class _UploadPayload(NamedTuple):
+    image_bytes: bytes
+    content_type: str
+    width: int | None
+    height: int | None
+    extension: str
 
-    image_bytes = await image.read()
-    if not image_bytes:
-        raise ApiError(400, "INVALID_IMAGE", "Uploaded image is empty")
-    if len(image_bytes) > max_image_bytes:
-        raise ApiError(
-            400,
-            "IMAGE_TOO_LARGE",
-            f"Image exceeds maximum size of {max_image_bytes} bytes",
-        )
-    return image_bytes, content_type
+
+async def _expand_upload(
+    upload: UploadFile,
+    settings: Settings,
+) -> list[_UploadPayload]:
+    """Expand a single uploaded file into one or more image payloads.
+
+    Images pass through directly. PDFs are rendered to one PNG page image
+    per page. Unsupported files are rejected.
+    """
+    content_type = upload.content_type or ""
+    filename = (upload.filename or "").lower()
+
+    if content_type.startswith("image/"):
+        image_bytes = await upload.read()
+        if not image_bytes:
+            raise ApiError(400, "INVALID_IMAGE", "Uploaded image is empty")
+        if len(image_bytes) > settings.bulk_ingestion_max_image_bytes:
+            raise ApiError(
+                400,
+                "IMAGE_TOO_LARGE",
+                f"Image exceeds maximum size of {settings.bulk_ingestion_max_image_bytes} bytes",
+            )
+        width, height = get_image_size(image_bytes) or (None, None)
+        return [_UploadPayload(image_bytes, content_type, width, height, _guess_extension(upload))]
+
+    if content_type == "application/pdf" or filename.endswith(".pdf"):
+        pdf_bytes = await upload.read()
+        if not pdf_bytes:
+            raise ApiError(400, "INVALID_PDF", "Uploaded PDF is empty")
+        try:
+            rendered_pages = render_pdf_pages(pdf_bytes)
+        except PdfRenderError as exc:
+            raise ApiError(400, "INVALID_PDF", str(exc)) from exc
+        payloads: list[_UploadPayload] = []
+        for page in rendered_pages:
+            if len(page.bytes) > settings.bulk_ingestion_max_image_bytes:
+                raise ApiError(
+                    400,
+                    "IMAGE_TOO_LARGE",
+                    f"Rendered PDF page exceeds maximum size of {settings.bulk_ingestion_max_image_bytes} bytes",
+                )
+            payloads.append(
+                _UploadPayload(page.bytes, page.content_type, page.width, page.height, ".png")
+            )
+        return payloads
+
+    raise ApiError(400, "INVALID_IMAGE", "Uploaded file must be an image or PDF")
 
 
 @router.post("", response_model=BatchResponse, status_code=201)
@@ -346,7 +384,15 @@ async def upload_batch_images(
         raise ApiError(400, "INVALID_IMAGE", "No images provided")
 
     existing_count = len(batch.get("images", []))
-    if existing_count + len(images) > settings.bulk_ingestion_max_images:
+
+    # Expand all uploads (images pass through; PDFs render to page images)
+    # before enforcing the batch image limit, so partial storage is avoided
+    # on validation failures and the limit accounts for expanded pages.
+    payloads: list[_UploadPayload] = []
+    for upload in images:
+        payloads.extend(await _expand_upload(upload, settings))
+
+    if existing_count + len(payloads) > settings.bulk_ingestion_max_images:
         raise ApiError(
             409,
             "BATCH_IMAGE_LIMIT_EXCEEDED",
@@ -354,25 +400,23 @@ async def upload_batch_images(
         )
 
     now = datetime.now(UTC)
-    for offset, image in enumerate(images):
-        image_bytes, content_type = await _validate_image_upload(
-            image, settings.bulk_ingestion_max_image_bytes
-        )
+    for offset, payload in enumerate(payloads):
         object_key = s3_storage.build_object_key(
-            str(user["_id"]), _guess_extension(image), category="ingestion/batches"
+            str(user["_id"]), payload.extension, category="ingestion/batches"
         )
-        s3_storage.put_object(settings.s3_bucket, object_key, image_bytes, content_type)
+        s3_storage.put_object(
+            settings.s3_bucket, object_key, payload.image_bytes, payload.content_type
+        )
 
-        width, height = get_image_size(image_bytes) or (None, None)
         source_image = build_source_image(
             bucket=settings.s3_bucket,
             object_key=object_key,
-            content_type=content_type,
-            size_bytes=len(image_bytes),
-            sha256=hashlib.sha256(image_bytes).hexdigest(),
+            content_type=payload.content_type,
+            size_bytes=len(payload.image_bytes),
+            sha256=hashlib.sha256(payload.image_bytes).hexdigest(),
             uploaded_at=now,
-            width=width,
-            height=height,
+            width=payload.width,
+            height=payload.height,
         )
         await add_source_image(
             database,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "uvicorn>=0.30.0,<1.0.0",
   "python-multipart>=0.0.9",
   "pillow>=10.0.0,<11.0.0",
+  "pymupdf>=1.24.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/tests/api/test_bulk_ingestion.py
+++ b/backend/tests/api/test_bulk_ingestion.py
@@ -121,6 +121,19 @@ def make_valid_png_bytes(*, width: int = 10, height: int = 10) -> bytes:
     return buffer.getvalue()
 
 
+def make_pdf_bytes(num_pages: int = 1) -> bytes:
+    """Create a minimal multi-page PDF whose rendered pages fit the test image byte limit."""
+    import pymupdf
+
+    document = pymupdf.open()
+    for _ in range(num_pages):
+        document.new_page(width=1, height=1)
+    buffer = io.BytesIO()
+    document.save(buffer)
+    document.close()
+    return buffer.getvalue()
+
+
 def make_extraction_result(
     *,
     text: str = "What is 2+2?",
@@ -513,6 +526,155 @@ async def test_upload_enforces_ownership(
     stored = await database["ingestion_batches"].find_one({"_id": ObjectId(batch_id)})
     assert stored is not None
     assert stored["userId"] == owner["_id"]
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_creates_one_image_per_page(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("doc.pdf", make_pdf_bytes(num_pages=2), "application/pdf")},
+    )
+
+    assert response.status_code == 201
+    images = response.json()["batch"]["images"]
+    assert len(images) == 2
+    for index, image in enumerate(images):
+        assert image["order"] == index
+        assert image["status"] == "uploaded"
+        assert image["sourceImage"]["contentType"] == "image/png"
+        assert image["sourceImage"]["width"] is not None
+        assert image["sourceImage"]["height"] is not None
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_upload_multiple_pdfs_preserves_file_and_page_order(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    # The example case from the issue: two PDFs with 2 and 3 pages = 5 images.
+    # The default test fixture limits batches to 3 images, so override it.
+    base_settings = bulk_app.dependency_overrides[get_app_settings]()
+    bulk_app.dependency_overrides[get_app_settings] = lambda: base_settings.model_copy(
+        update={"bulk_ingestion_max_images": 10}
+    )
+
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files=[
+            ("images", ("first.pdf", make_pdf_bytes(num_pages=2), "application/pdf")),
+            ("images", ("second.pdf", make_pdf_bytes(num_pages=3), "application/pdf")),
+        ],
+    )
+
+    assert response.status_code == 201
+    images = response.json()["batch"]["images"]
+    assert len(images) == 5
+    assert [image["order"] for image in images] == [0, 1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_upload_mixed_image_and_pdf_preserves_order(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    image_bytes = make_png_bytes()
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files=[
+            ("images", ("photo.png", image_bytes, "image/png")),
+            ("images", ("doc.pdf", make_pdf_bytes(num_pages=2), "application/pdf")),
+        ],
+    )
+
+    assert response.status_code == 201
+    images = response.json()["batch"]["images"]
+    assert len(images) == 3
+    assert images[0]["sourceImage"]["contentType"] == "image/png"
+    assert images[1]["sourceImage"]["contentType"] == "image/png"
+    assert images[2]["sourceImage"]["contentType"] == "image/png"
+    assert [image["order"] for image in images] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_upload_pdf_page_count_included_in_image_limit(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    image_bytes = make_png_bytes()
+    first_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("photo.png", image_bytes, "image/png")},
+    )
+    assert first_response.status_code == 201
+
+    second_response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("doc.pdf", make_pdf_bytes(num_pages=3), "application/pdf")},
+    )
+
+    assert second_response.status_code == 409
+    assert second_response.json()["error"]["code"] == "BATCH_IMAGE_LIMIT_EXCEEDED"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_empty_pdf(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("empty.pdf", b"", "application/pdf")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_PDF"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_upload_rejects_invalid_pdf(
+    authenticated_bulk_client: AsyncClient,
+    bulk_app: FastAPI,
+) -> None:
+    create_response = await authenticated_bulk_client.post("/api/v1/ingestion-batches")
+    batch_id = create_response.json()["batch"]["id"]
+
+    response = await authenticated_bulk_client.post(
+        f"/api/v1/ingestion-batches/{batch_id}/images",
+        files={"images": ("corrupt.pdf", b"not a pdf", "application/pdf")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "INVALID_PDF"
+
+    storage: FakeStorage = bulk_app.state.fake_storage
+    assert len(storage.put_calls) == 0
 
 
 @pytest.mark.asyncio

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -233,6 +233,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pymongo" },
+    { name = "pymupdf" },
     { name = "python-multipart" },
     { name = "uvicorn" },
 ]
@@ -253,6 +254,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.7.0,<3.0.0" },
     { name = "pydantic-settings", extras = ["dotenv"], specifier = ">=2.3.0,<3.0.0" },
     { name = "pymongo", specifier = ">=4.8.0,<5.0.0" },
+    { name = "pymupdf", specifier = ">=1.24.0,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.2.0,<9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.7,<1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
@@ -392,6 +394,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/05/c952bac7db71c1942ea3559fcd308b49754cc5004b455935fb4000d1f37b/pymongo-4.17.0-cp311-cp311-win32.whl", hash = "sha256:c2292144505fb12156b981bd440f3dc994a883da06ac726c0c8692ccdbc1c510", size = 852621, upload-time = "2026-04-20T16:37:55.28Z" },
     { url = "https://files.pythonhosted.org/packages/11/c0/c04da9f4c0c6252404598f4e394b862a58a9e866822a70ae261c8a018fdf/pymongo-4.17.0-cp311-cp311-win_amd64.whl", hash = "sha256:2e190827834fce70ecdf9d46796c6dbc0ce08ea87dc2ff5bc6f3f5579b605cb9", size = 867852, upload-time = "2026-04-20T16:37:57.233Z" },
     { url = "https://files.pythonhosted.org/packages/1d/b2/c7b4870fbeef471e947d3e014676f5910d02e0197074d692ebcf24ec049a/pymongo-4.17.0-cp311-cp311-win_arm64.whl", hash = "sha256:a8f9c40a09bb7d4b9fc8b1da65ecf6efa79bda5cb2756f39d9b6940fac1d19ae", size = 855019, upload-time = "2026-04-20T16:37:58.983Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/e9/6d6c5d6c0a3551bffd47681a6240caf941727f195b45593cf20ab36f018f/pymupdf-1.28.0.tar.gz", hash = "sha256:e53f3567403a92da15caa9e7ae0164327fff48817e9f40175367fb9de524258d", size = 87637751, upload-time = "2026-06-29T09:08:47.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/b7/88043e38cc7529de070f0c9bd267fa258035cca0b4ad5260536b994594a7/pymupdf-1.28.0-cp310-abi3-macosx_10_15_x86_64.whl", hash = "sha256:892b89ba88e8f98b53133b62877a9dc9b5e7dc6a4aeb837b612db56a8d2e03ac", size = 24597385, upload-time = "2026-06-29T09:03:30.608Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f4/23775bbda0781b61fc398cc75079a2b0e64696d8fcf93271748883e9627e/pymupdf-1.28.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:4d692dcf44d3566ae96bc6f6346c6ad432274a29ba617bf7a9fe18009e24adb4", size = 23828292, upload-time = "2026-06-29T09:03:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f5/bf75fc7a415722f8b33662054f82d88520c0cbfd4c36d0e08aeaec605e49/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:47a5c29ed4eb0744de9c4e37bb49b1259b18d4d75fcc8a7c130f7c9fa15956f6", size = 25045507, upload-time = "2026-06-29T09:04:03.86Z" },
+    { url = "https://files.pythonhosted.org/packages/58/69/5d12c9f1f2d76f28383d6110a069c79fbfced5a4f97bb1ee6e8354f52bb7/pymupdf-1.28.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:44f0973f5e5edbaec95bc34b64e71d1959d4ee90b1328de1b4f4f5b4fa78673f", size = 25716599, upload-time = "2026-06-29T09:04:19.367Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b4/ec0e017bc42857cc86bd651441dbc41cc18be48d4698ecd27aac491e0c9a/pymupdf-1.28.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4d61ec323a706e153a12e262e51febfb43eeaa20977785ace135d18d48bcdc83", size = 25940489, upload-time = "2026-06-29T09:04:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/06/86/f831fef09013f33b3c9c09fb3923f2ff53e1e437f6ace14b8ae46392f558/pymupdf-1.28.0-cp310-abi3-win32.whl", hash = "sha256:caea2b3b67347fd79e5d15ed7929b0e886aac594ea228073b6d39de0078189da", size = 18489703, upload-time = "2026-06-29T20:50:30.599Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5d/1a03f53eb0449900469335fcfc742ca28e3ba159b7d650e0921d50b8b308/pymupdf-1.28.0-cp310-abi3-win_amd64.whl", hash = "sha256:e01e90fd86abfeb37ceb921eddb951f988a11d45ff6ce6b7664f2039849068ec", size = 19773102, upload-time = "2026-06-29T09:04:49.773Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/1e52ce243ca792254f6223b4017c5667194c146ce9b88baf37bc5eb3d1c9/pymupdf-1.28.0-cp313-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:74c6d00ba2a9aad3a635db73b07c15db462b480741d831a34a75a56535ebc22b", size = 18357011, upload-time = "2026-06-29T20:50:50.353Z" },
 ]
 
 [[package]]

--- a/frontend/src/api/bulkIngestion.test.ts
+++ b/frontend/src/api/bulkIngestion.test.ts
@@ -127,6 +127,28 @@ describe("bulk ingestion API client", () => {
       capturedBody = callArgs[1].body as FormData;
       expect(capturedBody.getAll("images")).toHaveLength(2);
     });
+
+    it("sends PDF files through the same multipart upload path", async () => {
+      const response = makeBatchResponse("batch-1");
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(response),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const files = [
+        new File(["pdf-bytes"], "doc.pdf", { type: "application/pdf" }),
+      ];
+
+      await uploadBatchImages("batch-1", files);
+
+      const callArgs = mockFetch.mock.calls[0] as [string, RequestInit];
+      const body = callArgs[1].body as FormData;
+      const uploaded = body.getAll("images");
+      expect(uploaded).toHaveLength(1);
+      expect((uploaded[0] as File).name).toBe("doc.pdf");
+      expect((uploaded[0] as File).type).toBe("application/pdf");
+    });
   });
 
   describe("detectImageBoxes", () => {

--- a/frontend/src/components/BulkUploadStep.test.tsx
+++ b/frontend/src/components/BulkUploadStep.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { BulkUploadStep } from "./BulkUploadStep";
+import type { BulkBatch } from "@/types/bulkIngestion";
+
+function makeBatch(): BulkBatch {
+  return {
+    id: "batch-1",
+    userId: "user-1",
+    status: "active",
+    images: [],
+    items: [],
+    createdAt: "2026-07-03T00:00:00Z",
+    updatedAt: "2026-07-03T00:00:00Z",
+    expiresAt: "2026-07-04T00:00:00Z",
+  };
+}
+
+describe("BulkUploadStep", () => {
+  it("accepts both images and PDFs", () => {
+    render(
+      <BulkUploadStep
+        batch={makeBatch()}
+        isLoading={false}
+        onCreateBatch={() => {}}
+        onUpload={() => {}}
+      />,
+    );
+
+    const input = screen.getByTestId("bulk-wizard-upload-input") as HTMLInputElement;
+    expect(input.accept).toContain("image/*");
+    expect(input.accept).toContain("application/pdf");
+    expect(input.accept).toContain(".pdf");
+  });
+
+  it("uses image-or-PDF wording in heading, description, and button", () => {
+    render(
+      <BulkUploadStep
+        batch={makeBatch()}
+        isLoading={false}
+        onCreateBatch={() => {}}
+        onUpload={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Upload images or PDFs")).toBeInTheDocument();
+    expect(screen.getByText("Add images or PDFs to your batch.")).toBeInTheDocument();
+    expect(screen.getByTestId("bulk-wizard-upload-button").textContent).toBe(
+      "Choose files",
+    );
+  });
+
+  it("calls onUpload with selected files", () => {
+    const onUpload = vi.fn();
+    render(
+      <BulkUploadStep
+        batch={makeBatch()}
+        isLoading={false}
+        onCreateBatch={() => {}}
+        onUpload={onUpload}
+      />,
+    );
+
+    const input = screen.getByTestId("bulk-wizard-upload-input") as HTMLInputElement;
+    const file = new File(["pdf"], "doc.pdf", { type: "application/pdf" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onUpload).toHaveBeenCalledTimes(1);
+    const passedFiles = onUpload.mock.calls[0][0] as FileList;
+    expect(passedFiles[0]).toBe(file);
+  });
+});

--- a/frontend/src/components/BulkUploadStep.tsx
+++ b/frontend/src/components/BulkUploadStep.tsx
@@ -20,7 +20,7 @@ export function BulkUploadStep({
 
   return (
     <div data-testid="bulk-wizard-upload-step">
-      <h2>Upload images</h2>
+      <h2>Upload images or PDFs</h2>
       {error && (
         <div
           data-testid="bulk-upload-error"
@@ -31,7 +31,7 @@ export function BulkUploadStep({
       )}
       {batch ? (
         <>
-          <p>Add images to your batch.</p>
+          <p>Add images or PDFs to your batch.</p>
           {batch.images.length > 0 && (
             <ul data-testid="bulk-upload-image-list">
               {batch.images.map((image) => (
@@ -42,7 +42,7 @@ export function BulkUploadStep({
           <input
             ref={inputRef}
             type="file"
-            accept="image/*"
+            accept="image/*,application/pdf,.pdf"
             multiple
             data-testid="bulk-wizard-upload-input"
             onChange={(event) => {
@@ -57,7 +57,7 @@ export function BulkUploadStep({
             onClick={() => inputRef.current?.click()}
             disabled={isLoading}
           >
-            Choose image files
+            Choose files
           </button>
         </>
       ) : (


### PR DESCRIPTION
## Summary

- Adds PDF upload support to ingestion batches: users can select image files, PDF files, or a mix of both from the upload step.
- The backend renders each PDF page to a PNG image and stores it as a normal batch image, so existing detection, review, extraction, and submit logic works unchanged.
- Existing image upload behavior remains fully compatible.

## Linked Issue

Closes #397

## Issue Alignment

This PR implements the issue by:

- Updating the frontend upload step to accept both images and PDFs (`accept="image/*,application/pdf,.pdf"`) and updating button/copy from image-only wording to image/PDF wording.
- Keeping the existing `uploadBatchImages(batchId, files)` request shape — files are still posted under the multipart `images` field, so no API client change is needed.
- Updating backend upload validation so supported uploads are image files (`image/*`) or PDFs. Unsupported files fail with `INVALID_IMAGE`; invalid/empty/encrypted PDFs fail with `INVALID_PDF`.
- Adding a PDF conversion helper (`render_pdf_pages`) that accepts PDF bytes and returns ordered rendered page images with bytes, width, height, and `image/png` content type, using PyMuPDF.
- Expanding uploaded files into a flat ordered list of image payloads before enforcing the batch image limit, so each PDF page counts as one batch image.
- Enforcing `bulk_ingestion_max_images` after expansion and `bulk_ingestion_max_image_bytes` on each rendered page.
- Storing each rendered PDF page as a normal source image with `image/png` content type.
- Preserving ordering so mixed uploads keep selected file order and PDF pages are inserted in page order.
- Avoiding partial storage: all uploads are expanded and validated before any storage occurs, so invalid files do not leave partial batch state.

Scope covered:

- Frontend upload UI accepts PDFs; updated copy and button text.
- Backend PDF-to-image conversion producing one stored batch image per page.
- Preserving image/PDF file ordering in the resulting batch image list.
- Applying existing image count and image size limits to expanded PDF pages.
- Backend and frontend tests for PDF upload behavior.

Out of scope / intentionally not included:

- A new ingestion workflow separate from the current batch flow.
- A new public API response shape (existing `BatchResponse` shape is reused).
- PDF-specific downstream detection, review, extraction, or submit logic.
- Persisted source metadata linking each generated image back to original PDF/page.
- OCR directly from PDF text layers.
- Progress UI for very large PDFs.
- Separate configurable PDF page/file limits.

## Implementation Notes

- **PDF rendering**: Uses PyMuPDF (`pymupdf`) at 150 DPI. Each page is rendered to PNG via `pixmap.tobytes("png")`, with width/height taken from the pixmap dimensions.
- **Expansion-first approach**: The `upload_batch_images` endpoint was refactored from a single validate-and-store loop into a two-phase approach: (1) expand all uploads into ordered `_UploadPayload` tuples, validating content type, size, and PDF renderability; (2) check the expanded count against the limit; (3) store all payloads. This ensures invalid files (including invalid PDFs) are rejected before any storage occurs, avoiding partial batch state.
- **PDF detection**: A file is treated as a PDF if `content_type == "application/pdf"` or the filename ends with `.pdf`, handling both content-type-based and extension-based detection.
- **Error codes**: Unsupported non-image/non-PDF files use `INVALID_IMAGE` (matching the existing validation style). Invalid/empty/encrypted PDFs use `INVALID_PDF`. Oversized rendered pages use the existing `IMAGE_TOO_LARGE`.
- **Object key extension**: PDF pages use `.png` as the extension; images use the existing `_guess_extension` logic.

## Tests

Commands run:

- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest tests/api/test_bulk_ingestion.py -q` — passed (65 tests: 59 existing + 6 new).
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest -x -q` — passed (685 passed, 1 skipped).
- `cd frontend && npm test -- BulkUploadStep.test.tsx bulkIngestion.test.ts --run` — passed (18 tests).
- `cd frontend && npm test -- --run` — passed (31 files, 441 tests).
- `cd frontend && npm run build` — passed (TypeScript type-check + Vite build).

Automated tests added:

Backend (`backend/tests/api/test_bulk_ingestion.py`):
- `test_upload_pdf_creates_one_image_per_page` — 2-page PDF creates 2 batch images, each `image/png` with width/height.
- `test_upload_multiple_pdfs_preserves_file_and_page_order` — two PDFs with 2 and 3 pages create 5 batch images in order (the issue's example case).
- `test_upload_mixed_image_and_pdf_preserves_order` — image + 2-page PDF creates 3 images in the correct order.
- `test_upload_pdf_page_count_included_in_image_limit` — after uploading 1 image, a 3-page PDF is rejected with `BATCH_IMAGE_LIMIT_EXCEEDED` (existing count + expanded pages exceed limit); no additional storage occurs.
- `test_upload_rejects_empty_pdf` — empty PDF bytes rejected with `INVALID_PDF`; no storage.
- `test_upload_rejects_invalid_pdf` — corrupt PDF bytes rejected with `INVALID_PDF`; no storage.

Frontend:
- `BulkUploadStep.test.tsx` — file input accepts `image/*`, `application/pdf`, `.pdf`; heading/description/button mention PDFs; `onUpload` called with selected files.
- `bulkIngestion.test.ts` — PDF `File` objects are sent through the multipart `images` field.

Existing image-only upload tests remain green.

Manual verification:

- Automated tests cover the required behavior per the issue's `Tests Required` and `Manual Verification / Self-Check` sections. The example case (two PDFs with 2 and 3 pages → 5 batch images) is covered by `test_upload_multiple_pdfs_preserves_file_and_page_order`. The mixed upload path, limit enforcement after expansion, and invalid/empty PDF rejection are all asserted. Existing image upload regression is covered by the existing test suite (all green).

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (backend PDF conversion via PyMuPDF, expansion before limit enforcement, existing upload endpoint and multipart field name preserved). The frontend does not render PDFs — it only selects and submits them.

## Follow-Up Work

None required. Potential future work noted in the issue (progress UI for large PDFs, persisted source metadata, separate PDF file/page limits, browser-side page count preview, OCR from PDF text layers) is intentionally out of scope.
