### PR TITLE
Add regenerate solution action to problem detail page

### DIFF
--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -19,6 +19,7 @@ from app.presentation.errors import ApiError
 from app.presentation.exam_helpers import problem_document_to_model
 from app.presentation.helpers import build_problem_image_url, get_all_descendant_folder_ids, get_owned_folder, get_owned_problem, normalize_tags, parse_object_id
 from app.presentation.schemas import CorrectAnswerPayload
+from app.presentation.solution_generation import regenerate_solution_task_for_problem
 from app.presentation.tags import _register_tags
 
 router = APIRouter(prefix="/problems", tags=["problems"])
@@ -541,6 +542,26 @@ async def get_solution_status(
         return SolutionStatusResponse(status=str(existing_task.get("status", "pending")))
         
     return SolutionStatusResponse(status="none")
+
+
+@router.post("/{problem_id}/solution-regeneration", response_model=SolutionStatusResponse)
+async def regenerate_solution(
+    problem_id: str,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+) -> SolutionStatusResponse:
+    problem = await get_owned_problem(
+        database,
+        problem_id,
+        current_user["_id"],
+        allow_deleted=False,
+    )
+    status = await regenerate_solution_task_for_problem(
+        database,
+        str(problem["_id"]),
+        str(current_user["_id"]),
+    )
+    return SolutionStatusResponse(status=status)
 
 
 @router.get("/{problem_id}/tracking", response_model=ProblemTrackingResponse)

--- a/backend/app/presentation/solution_generation.py
+++ b/backend/app/presentation/solution_generation.py
@@ -14,6 +14,7 @@ from app.infrastructure.storage.mongo import (
     SOLUTION_GENERATION_TASKS_COLLECTION,
 )
 from app.observability import log_solution_generation_event
+from app.presentation.errors import ApiError
 
 SOLUTION_BACKFILL_BATCH_SIZE = 100
 
@@ -116,3 +117,90 @@ async def backfill_solution_generation_tasks(
             log_solution_generation_event("enqueued", doc["problem_id"])
 
     return len(missing_documents)
+
+
+async def _reset_task_to_pending(
+    tasks_col: Any,
+    task_id: Any,
+    *,
+    now: datetime,
+) -> None:
+    """Reset an existing task to pending, clearing retry/failure state."""
+    await tasks_col.update_one(
+        {"_id": task_id},
+        {
+            "$set": {
+                "status": SolutionGenerationStatus.PENDING.value,
+                "retry_count": 0,
+                "failure_reason": None,
+                "started_at": None,
+                "process_after": now,
+                "updated_at": now,
+            }
+        },
+    )
+
+
+async def regenerate_solution_task_for_problem(
+    database: Any,
+    problem_id: str,
+    user_id: str,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Regenerate the canonical solution for a problem.
+
+    Eligible states:
+      - ``ready``: delete the existing canonical solution, then create or reset
+        a pending task.
+      - ``failed``: reset the failed task to pending.
+
+    Ineligible states (``none``, ``pending``, ``generating``) raise
+    ``ApiError(409)``.
+
+    Returns ``"pending"`` on success.
+    """
+    tasks = _safe_get_collection(database, SOLUTION_GENERATION_TASKS_COLLECTION)
+    solutions = _safe_get_collection(database, CANONICAL_SOLUTIONS_COLLECTION)
+    if tasks is None or solutions is None:
+        raise KeyError("solution generation collections are unavailable")
+
+    current_time = now or _utc_now()
+
+    existing_solution = await solutions.find_one({"problem_id": problem_id})
+    existing_task = await tasks.find_one({"problem_id": problem_id})
+
+    # Effective status "ready": a canonical solution takes precedence over any
+    # stale task.
+    if existing_solution is not None:
+        await solutions.delete_one({"problem_id": problem_id})
+        if existing_task is not None:
+            await _reset_task_to_pending(tasks, existing_task["_id"], now=current_time)
+        else:
+            await tasks.insert_one(
+                _build_solution_task_document(
+                    problem_id=problem_id,
+                    user_id=user_id,
+                    now=current_time,
+                )
+            )
+        log_solution_generation_event("regenerate", problem_id)
+        return SolutionGenerationStatus.PENDING.value
+
+    if existing_task is not None:
+        status = str(existing_task.get("status", "pending"))
+        if status == SolutionGenerationStatus.FAILED.value:
+            await _reset_task_to_pending(tasks, existing_task["_id"], now=current_time)
+            log_solution_generation_event("regenerate", problem_id)
+            return SolutionGenerationStatus.PENDING.value
+        raise ApiError(
+            409,
+            "SOLUTION_REGENERATION_CONFLICT",
+            "Solution is already pending or generating.",
+        )
+
+    raise ApiError(
+        409,
+        "SOLUTION_REGENERATION_CONFLICT",
+        "No solution to regenerate.",
+    )

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -533,6 +533,173 @@ async def test_solution_status(problems_app: FastAPI, client: AsyncClient) -> No
 
 
 @pytest.mark.asyncio
+async def test_regenerate_solution_when_ready_deletes_solution_and_enqueues_task(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    problem_id_str = str(problem["_id"])
+    database["problems"].seed(problem)
+
+    solution = make_canonical_solution(problem, user_id)
+    database["canonical_solutions"].seed(solution)
+
+    response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pending"}
+
+    # canonical solution deleted
+    remaining_solutions = await database["canonical_solutions"].find(
+        {"problem_id": problem_id_str}
+    ).to_list(length=None)
+    assert remaining_solutions == []
+
+    # pending task created
+    tasks = await database["solution_generation_tasks"].find(
+        {"problem_id": problem_id_str}
+    ).to_list(length=None)
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_solution_when_failed_resets_task_to_pending(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    problem_id_str = str(problem["_id"])
+    database["problems"].seed(problem)
+
+    failed_task = {
+        **make_solution_task(problem, user_id, status="failed"),
+        "retry_count": 3,
+        "failure_reason": "VLM timeout",
+        "started_at": datetime.now(UTC) - timedelta(hours=1),
+    }
+    database["solution_generation_tasks"].seed(failed_task)
+
+    response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pending"}
+
+    tasks = await database["solution_generation_tasks"].find(
+        {"problem_id": problem_id_str}
+    ).to_list(length=None)
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "pending"
+    assert tasks[0]["retry_count"] == 0
+    assert tasks[0]["failure_reason"] is None
+    assert tasks[0]["started_at"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["pending", "generating"])
+async def test_regenerate_solution_rejects_ineligible_active_states(
+    problems_app: FastAPI, client: AsyncClient, status: str
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    problem_id_str = str(problem["_id"])
+    database["problems"].seed(problem)
+
+    database["solution_generation_tasks"].seed(
+        make_solution_task(problem, user_id, status=status)
+    )
+
+    response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "SOLUTION_REGENERATION_CONFLICT"
+
+    # task unchanged
+    tasks = await database["solution_generation_tasks"].find(
+        {"problem_id": problem_id_str}
+    ).to_list(length=None)
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == status
+
+
+@pytest.mark.asyncio
+async def test_regenerate_solution_rejects_none_state(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    problem_id_str = str(problem["_id"])
+    database["problems"].seed(problem)
+
+    response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
+
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "SOLUTION_REGENERATION_CONFLICT"
+
+
+@pytest.mark.asyncio
+async def test_regenerate_solution_forbidden_for_other_user(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    other_user_id = problems_app.state.secondary_user["_id"]
+    other_problem = make_problem(other_user_id)
+    database["problems"].seed(other_problem)
+    database["canonical_solutions"].seed(make_canonical_solution(other_problem, other_user_id))
+
+    response = await client.post(
+        f"/api/v1/problems/{str(other_problem['_id'])}/solution-regeneration"
+    )
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_regenerate_solution_when_ready_with_stale_task_resets_task(
+    problems_app: FastAPI, client: AsyncClient
+) -> None:
+    """When both a canonical solution and a stale task exist (effective 'ready'),
+    regeneration deletes the solution and resets the existing task to pending
+    rather than creating a duplicate."""
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    problem_id_str = str(problem["_id"])
+    database["problems"].seed(problem)
+
+    stale_task = {
+        **make_solution_task(problem, user_id, status="ready"),
+        "retry_count": 2,
+        "failure_reason": "old failure",
+    }
+    database["solution_generation_tasks"].seed(stale_task)
+    database["canonical_solutions"].seed(make_canonical_solution(problem, user_id))
+
+    response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "pending"}
+
+    # solution deleted
+    remaining = await database["canonical_solutions"].find(
+        {"problem_id": problem_id_str}
+    ).to_list(length=None)
+    assert remaining == []
+
+    # exactly one task, reset to pending
+    tasks = await database["solution_generation_tasks"].find(
+        {"problem_id": problem_id_str}
+    ).to_list(length=None)
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "pending"
+    assert tasks[0]["retry_count"] == 0
+    assert tasks[0]["failure_reason"] is None
+
+
+@pytest.mark.asyncio
 async def test_solution_state_filter_failed(
     problems_app: FastAPI, client: AsyncClient
 ) -> None:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -142,6 +142,13 @@ export const api = {
     return this.get<{ status: string }>(`/problems/${problemId}/solution-status`);
   },
 
+  /**
+   * Regenerate the canonical solution for a problem.
+   */
+  async regenerateSolution(problemId: string): Promise<{ status: string }> {
+    return this.post<{ status: string }>(`/problems/${problemId}/solution-regeneration`, {});
+  },
+
   async get<T>(path: string): Promise<T> {
     const response = await fetch(`${API_BASE}${path}`, {
       credentials: "include",

--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("@/api/client", () => ({
     delete: vi.fn(),
     verifyTeacherPassword: vi.fn(),
     getSolutionStatus: vi.fn(),
+    regenerateSolution: vi.fn(),
   },
 }));
 
@@ -96,10 +97,12 @@ describe("ProblemDetailPage", () => {
     vi.mocked(api.delete).mockReset();
     vi.mocked(api.verifyTeacherPassword).mockReset();
     vi.mocked(api.getSolutionStatus).mockReset();
+    vi.mocked(api.regenerateSolution).mockReset();
     mockNavigate.mockReset();
 
     // Default: no solution status
     vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "none" });
+    vi.mocked(api.regenerateSolution).mockResolvedValue({ status: "pending" });
   });
 
   it("renders problem details", async () => {
@@ -717,5 +720,114 @@ describe("ProblemDetailPage", () => {
       expect(screen.getByTestId("solution-status")).toHaveTextContent("Solution Not Started");
     });
     expect(screen.queryByTestId("ai-explain-button")).not.toBeInTheDocument();
+  });
+
+  it("renders Re-generate solution button when status is ready", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "ready" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("regenerate-solution-button")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("regenerate-solution-button")).toHaveTextContent("Re-generate solution");
+  });
+
+  it("renders Re-generate solution button when status is failed", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "failed" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("regenerate-solution-button")).toBeInTheDocument();
+    });
+  });
+
+  it("does not render Re-generate solution button for none, pending, or generating", async () => {
+    for (const status of ["none", "pending", "generating"]) {
+      vi.mocked(api.get).mockReset();
+      vi.mocked(api.get)
+        .mockResolvedValueOnce({ problem: baseProblem })
+        .mockResolvedValueOnce(baseTracking);
+      vi.mocked(api.getSolutionStatus).mockResolvedValue({ status });
+
+      renderProblemDetailPage();
+
+      await waitFor(() => {
+        expect(screen.getByTestId("solution-status")).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId("regenerate-solution-button")).not.toBeInTheDocument();
+    }
+  });
+
+  it("calls regenerateSolution API and invalidates solution status on click", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "failed" });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("regenerate-solution-button")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("regenerate-solution-button"));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.regenerateSolution)).toHaveBeenCalledWith("abc123");
+    });
+    // After success, solution status is refetched (invalidated)
+    await waitFor(() => {
+      expect(vi.mocked(api.getSolutionStatus).mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  it("disables Re-generate button while mutation is pending", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "failed" });
+    // Never resolves so mutation stays pending
+    vi.mocked(api.regenerateSolution).mockReturnValue(new Promise(() => {}));
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("regenerate-solution-button")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("regenerate-solution-button"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("regenerate-solution-button")).toBeDisabled();
+    });
+    expect(screen.getByTestId("regenerate-solution-button")).toHaveTextContent("Regenerating...");
+  });
+
+  it("displays error when regeneration fails", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "failed" });
+    vi.mocked(api.regenerateSolution).mockRejectedValue(new Error("Server error"));
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("regenerate-solution-button")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("regenerate-solution-button"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Server error");
+    });
   });
 });

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -170,6 +170,17 @@ export function ProblemDetailPage() {
     },
   });
 
+  const regenerateMutation = useMutation({
+    mutationFn: () => api.regenerateSolution(problemId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["solution-status", problemId] });
+      setError(null);
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "Regeneration failed");
+    },
+  });
+
   const handleEdit = () => {
     if (problem) {
         setEditForm({
@@ -343,6 +354,23 @@ export function ProblemDetailPage() {
                 }}
               >
                 AI Explain
+              </button>
+            )}
+            {(solutionStatus === "failed" || solutionStatus === "ready") && (
+              <button
+                type="button"
+                onClick={() => regenerateMutation.mutate()}
+                disabled={regenerateMutation.isPending}
+                data-testid="regenerate-solution-button"
+                className="btn btn-secondary"
+                style={{
+                  padding: "0.4rem 0.75rem",
+                  borderRadius: "var(--radius-md)",
+                  fontSize: "0.8125rem",
+                  fontWeight: 700,
+                }}
+              >
+                {regenerateMutation.isPending ? "Regenerating..." : "Re-generate solution"}
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Adds a `POST /api/v1/problems/{problem_id}/solution-regeneration` endpoint that retries or refreshes canonical solution generation for eligible states (`failed` and `ready`).
- Adds a `Re-generate solution` button to the problem detail page, visible only when solution status is `failed` or `ready`.
- Refactors shared solution task logic into reusable helpers so both problem creation/backfill and the new regeneration endpoint share a service layer.

## Linked Issue

Closes #399

## Issue Alignment

This PR implements the issue by:

- Refactoring solution task enqueue logic into reusable helper functions (`_reset_task_to_pending`, `_build_solution_task_document`) in the existing `solution_generation` module, shared by creation/backfill and the new regeneration endpoint.
- Preserving existing behavior for problem creation/backfill: `enqueue_solution_generation_task_for_problem` still creates a pending task only when no task or solution exists.
- Adding `regenerate_solution_task_for_problem` service function that handles:
  - `ready`: deletes the existing canonical solution, then creates or resets a pending task.
  - `failed`: resets the failed task to `pending`, clearing `retry_count` to `0`, `failure_reason` to `None`, `started_at` to `None`, and setting `process_after`/`updated_at` to now.
  - `none`, `pending`, `generating`: rejects with `409 SOLUTION_REGENERATION_CONFLICT`.
- Adding `POST /api/v1/problems/{problem_id}/solution-regeneration` endpoint that validates ownership via `get_owned_problem` and returns `{ "status": "pending" }`.
- Adding a frontend API client method `regenerateSolution(problemId)`.
- Adding a `Re-generate solution` button near the solution status badge, visible only for `failed` and `ready` statuses.
- Disabling the button and showing "Regenerating..." while the mutation is pending.
- On success, invalidating `['solution-status', problemId]` so polling resumes and the UI updates.
- On error, displaying the error through the existing page error area.
- Keeping `AI Explain` visible only for `ready`; with immediate replacement on regenerate, it disappears after the status changes to `pending`.

Scope covered:

- Dedicated authenticated backend endpoint for regenerating a problem solution.
- Shared backend solution task-management logic reused by problem creation/backfill and the new endpoint.
- Frontend API client support for the new regenerate action.
- `Re-generate solution` button on the problem detail page.
- Backend and frontend tests for eligible and ineligible states.

Out of scope / intentionally not included:

- Bulk regeneration.
- List-page regeneration controls.
- Solution history/versioning.
- Preserving the old solution while a new solution is pending.
- Changes to VLM prompts or solution quality.
- Regeneration for `none`, `pending`, or `generating`.

## Implementation Notes

- **Shared service layer**: The `_reset_task_to_pending` helper resets an existing task to pending (clearing `retry_count`, `failure_reason`, `started_at`). The `_build_solution_task_document` helper (already used by `enqueue_solution_generation_task_for_problem` and `backfill_solution_generation_tasks`) is reused for creating new pending task documents. This ensures creation/backfill and regeneration share the same task construction logic.
- **Effective status precedence**: A canonical solution takes precedence over any stale task (mirrors `GET /solution-status`). When both exist (effective `ready`), regeneration deletes the solution and resets the existing stale task to pending rather than creating a duplicate.
- **Error handling**: Ineligible states (`none`, `pending`, `generating`) return `409` with `SOLUTION_REGENERATION_CONFLICT`. Cross-user access returns `403` via `get_owned_problem`.
- **Frontend polling**: After a successful regeneration, the solution-status query is invalidated, which triggers a refetch. The existing `refetchInterval` (2s for `pending`/`generating`) continues updating the UI.

## Tests

Commands run:

- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest tests/api/test_problems.py -q` — passed (47 tests: 40 existing + 7 new).
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest -x -q` — passed (692 passed, 1 skipped).
- `cd frontend && npm test -- ProblemDetailPage.test.tsx --run` — passed (32 tests).
- `cd frontend && npm test -- --run` — passed (31 files, 447 tests).
- `cd frontend && npm run build` — passed (TypeScript type-check + Vite build).

Automated tests added:

Backend (`backend/tests/api/test_problems.py`):
- `test_regenerate_solution_when_ready_deletes_solution_and_enqueues_task` — verifies solution is deleted and a pending task is created.
- `test_regenerate_solution_when_failed_resets_task_to_pending` — verifies task status becomes pending, `retry_count=0`, `failure_reason=None`, `started_at=None`.
- `test_regenerate_solution_rejects_ineligible_active_states` (parametrized: `pending`, `generating`) — verifies 409 conflict and task unchanged.
- `test_regenerate_solution_rejects_none_state` — verifies 409 conflict when no task or solution exists.
- `test_regenerate_solution_forbidden_for_other_user` — verifies 403 for cross-user access.
- `test_regenerate_solution_when_ready_with_stale_task_resets_task` — verifies that when both a canonical solution and a stale task exist (effective `ready`), regeneration deletes the solution and resets the existing task to pending (no duplicate task created).

Frontend (`frontend/src/pages/ProblemDetailPage.test.tsx`):
- `renders Re-generate solution button when status is ready`
- `renders Re-generate solution button when status is failed`
- `does not render Re-generate solution button for none, pending, or generating`
- `calls regenerateSolution API and invalidates solution status on click`
- `disables Re-generate button while mutation is pending`
- `displays error when regeneration fails`

Existing solution-status and AI Explain tests remain green.

Manual verification:

- Automated tests cover the required behavior per the issue's `Tests Required` and `Manual Verification / Self-Check` sections. All eligible states (`ready`, `failed`), all ineligible states (`none`, `pending`, `generating`), cross-user rejection, and the stale-task-plus-solution edge case are covered by backend tests. Frontend tests verify button visibility per status, API call on click, disabled state during mutation, and error display.
- The issue's suggested verification commands were run: `pytest tests/api/test_problems.py` (47 passed) and `npm test -- ProblemDetailPage.test.tsx` (32 passed).

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (dedicated HTTP endpoint, shared service/helper layer, immediate replacement for `ready`, task reset for `failed`, rejection for ineligible states, frontend button visible only for `failed`/`ready`).

## Follow-Up Work

None required. Potential future work noted in the issue (bulk regenerate from the Problems page, solution history/versioning, keeping old solution visible until replacement succeeds, retry/regeneration controls in practice or exam views) is intentionally out of scope.
