### PR TITLE
Update failure component of problem selection score

### DIFF
--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -69,11 +69,16 @@ def compute_score_breakdown(
         recency_score = 1.0
 
     # Failure score
-    diff = problem.tracking.failedCount - problem.tracking.correctCount
-    if diff == 0:
-        failure_score = 0.0
+    failed_count = problem.tracking.failedCount
+    correct_count = problem.tracking.correctCount
+    if failed_count > correct_count and correct_count > 0:
+        failure_score = failed_count / correct_count
     else:
-        failure_score = math.copysign(math.sqrt(abs(diff)), diff)
+        diff = failed_count - correct_count
+        if diff == 0:
+            failure_score = 0.0
+        else:
+            failure_score = math.copysign(math.sqrt(abs(diff)), diff)
 
     # Last wrong score
     if problem.tracking.lastTestedAt is None:

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime, timedelta
 import random
 
+import pytest
+
 from app.domain.models import CorrectAnswer, Problem, Tracking
 from app.domain.practice_selection import (
     PracticeSelectionConfig,
@@ -398,15 +400,16 @@ def test_compute_problem_weight_breakdown_all_components():
     # lastWrong = 2.0 * 1.5 = 3.0
     assert breakdown.lastWrong == 3.0
 
-    # diff = 7 - 3 = 4, failure_score = sqrt(4) = 2.0, failure = 2.0 * 2.0 = 4.0
-    assert breakdown.failure == 4.0
+    # failedCount=7 > correctCount=3 and correctCount>0 => ratio: 7/3
+    # failure = (7/3) * 2.0 ≈ 4.6666666667
+    assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
 
     # days_since = 30, recency_score = 1.0 + 30/30 = 2.0
     # recency = 2.0 * 1.0 = 2.0
     assert breakdown.recency == 2.0
 
-    assert breakdown.total == 9.0
-    assert breakdown.total == breakdown.lastWrong + breakdown.failure + breakdown.recency
+    assert breakdown.total == pytest.approx(3.0 + (7 / 3) * 2.0 + 2.0)
+    assert breakdown.total == pytest.approx(breakdown.lastWrong + breakdown.failure + breakdown.recency)
 
 
 def test_compute_problem_weight_breakdown_never_tested():

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -1,4 +1,7 @@
 from datetime import datetime, timedelta, timezone
+
+import pytest
+
 from app.domain import (
     Problem,
     CorrectAnswer,
@@ -198,6 +201,51 @@ def test_failure_score_weighted_multiplier():
     assert breakdown.failure == 4.0
 
 
+def test_failure_score_ratio_when_more_failed_than_correct():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=6, failed_count=4, correct_count=2)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 2.0
+
+
+def test_failure_score_ratio_with_weight():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=10, failed_count=7, correct_count=3)
+    config = ProblemSelectionConfig(failure_rate_weight=2.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
+
+
+def test_failure_score_more_failed_than_correct_zero_correct_uses_sqrt():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem("p1", exposure_count=4, failed_count=4, correct_count=0)
+    config = ProblemSelectionConfig(failure_rate_weight=1.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 2.0
+
+
+def test_failure_score_ratio_total_positive():
+    now = datetime.now(timezone.utc)
+    problem = create_test_problem(
+        "p1",
+        last_tested_at=now - timedelta(days=30),
+        last_attempt_correct=False,
+        exposure_count=6,
+        failed_count=4,
+        correct_count=2,
+    )
+    config = ProblemSelectionConfig(
+        recency_weight=1.0,
+        failure_rate_weight=1.0,
+        last_wrong_weight=1.0,
+    )
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.failure == 2.0
+    assert breakdown.total == pytest.approx(breakdown.recency + breakdown.failure + breakdown.last_wrong)
+    assert breakdown.total > 0
+
+
 def test_last_wrong_never_tested():
     now = datetime.now(timezone.utc)
     problem = create_test_problem("p1", last_tested_at=None)
@@ -249,12 +297,13 @@ def test_weighted_total_equals_component_sum():
     breakdown = compute_score_breakdown(problem, config, now)
     # recency_score = 1.0 + 30/30 = 2.0, recency = 2.0 * 1.0 = 2.0
     assert breakdown.recency == 2.0
-    # diff = 7 - 3 = 4, failure_score = sqrt(4) = 2.0, failure = 2.0 * 2.0 = 4.0
-    assert breakdown.failure == 4.0
+    # failedCount=7 > correctCount=3 and correctCount>0 => ratio: 7/3
+    # failure = (7/3) * 2.0 ≈ 4.6666666667
+    assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
     # last_wrong_score = 2.0, last_wrong = 2.0 * 1.5 = 3.0
     assert breakdown.last_wrong == 3.0
-    assert breakdown.total == 9.0
-    assert breakdown.total == breakdown.recency + breakdown.failure + breakdown.last_wrong
+    assert breakdown.total == pytest.approx(2.0 + (7 / 3) * 2.0 + 3.0)
+    assert breakdown.total == pytest.approx(breakdown.recency + breakdown.failure + breakdown.last_wrong)
 
 
 def test_total_score_capped_at_zero():


### PR DESCRIPTION
## Summary

- Updates the shared problem-selection failure score formula so that when `failedCount > correctCount` and `correctCount > 0`, the unweighted failure component uses the ratio `failedCount / correctCount` instead of the square-root-difference formula.
- All other cases (equal counts, more-correct-than-failed, zero-correct-count with more-failed) retain the existing square-root-difference behavior.
- The `failure_rate_weight` multiplier and total score capping (`max(0.0, ...)`) are unchanged.
- Practice weight breakdown delegates to the same shared `compute_score_breakdown`, so both selection sorting and practice weight use the updated formula automatically.

## Linked Issue

Closes #401

## Issue Alignment

This PR implements the issue by:

- Adding the ratio branch to `compute_score_breakdown` in `backend/app/domain/selection.py` before falling back to the existing square-root-difference logic.
- Keeping `failure_rate_weight` applied after the unweighted score.
- Keeping total score capping unchanged.
- Updating exact-value expectations in two affected tests (`test_weighted_total_equals_component_sum` and `test_compute_problem_weight_breakdown_all_components`), both of which use `failedCount=7, correctCount=3`.
- Adding new tests covering the new ratio branch and the unchanged fallback branches.
- Not touching any tracking, recency, last-wrong, or API schema code.

Scope covered:

- Updating the shared backend failure score formula in `selection.py`.
- Updating affected exact-value expectations in `test_selection.py` and `test_practice_selection.py`.
- Adding new tests for the ratio branch and verifying fallback branches are preserved.

Out of scope / intentionally not included:

- Data migrations, new config flags, tracking changes, recency scoring changes, last-wrong scoring changes, frontend UI redesign, API schema changes.

## Implementation Notes

- The change is localized to `compute_score_breakdown` in `backend/app/domain/selection.py`. The `practice_selection.py` module delegates to this shared function via `compute_problem_weight_breakdown`, so no changes were needed there.
- The new branch checks `failed_count > correct_count and correct_count > 0` first. When true, `failure_score = failed_count / correct_count`. Otherwise, the existing `diff`-based logic runs unchanged.
- The issue's pseudocode uses `math.copysign(math.sqrt(abs(diff)), diff)` for the fallback; the existing code already does this, so no change was needed there.
- Tests use `pytest.approx` for the ratio-based assertions to avoid floating-point precision issues.

## Tests

Commands run:

- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest tests/domain/test_selection.py tests/domain/test_practice_selection.py -q` — passed (61 tests).
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest tests/api/test_problems.py tests/api/test_exams.py -q` — passed (65 tests).
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest -x -q` — passed (696 passed, 1 skipped).

Automated tests added or updated:

`backend/tests/domain/test_selection.py`:
- **Updated** `test_weighted_total_equals_component_sum` — failure changed from `sqrt(4)*2.0=4.0` to `(7/3)*2.0≈4.6667`; total updated accordingly; uses `pytest.approx`.
- **Added** `test_failure_score_ratio_when_more_failed_than_correct` — `failedCount=4, correctCount=2, weight=1.0` → `failure=2.0`.
- **Added** `test_failure_score_ratio_with_weight` — `failedCount=7, correctCount=3, weight=2.0` → `failure≈4.6667`.
- **Added** `test_failure_score_more_failed_than_correct_zero_correct_uses_sqrt` — `failedCount=4, correctCount=0` → `failure=2.0` (sqrt fallback, avoids division by zero).
- **Added** `test_failure_score_ratio_total_positive` — verifies total equals `recency + failure + last_wrong` and is positive when using the ratio branch.

`backend/tests/domain/test_practice_selection.py`:
- **Updated** `test_compute_problem_weight_breakdown_all_components` — failure changed from `sqrt(4)*2.0=4.0` to `(7/3)*2.0≈4.6667`; total updated; uses `pytest.approx`.

Existing tests that verify unchanged behavior (all still green):
- `test_failure_score_no_attempts` — `failed=0, correct=0` → `failure=0.0`
- `test_failure_score_more_correct_than_failed` — `failed=0, correct=4` → `failure=-2.0` (negative sqrt)
- `test_failure_score_more_failed_than_correct` — `failed=4, correct=0` → `failure=2.0` (sqrt, no division by zero)
- `test_failure_score_equal_failed_and_correct` — `failed=5, correct=5` → `failure=0.0`
- `test_failure_score_large_difference` — `failed=9, correct=0` → `failure=3.0`
- `test_failure_score_weighted_multiplier` — `failed=4, correct=0, weight=2.0` → `failure=4.0`
- `test_total_score_capped_at_zero` — negative failure still caps total at 0.0
- `test_compute_problem_weight_breakdown_uses_same_total_as_selection` — practice and selection share the same formula
- `test_compute_problem_weight_breakdown_never_tested` — no attempts → `failure=0.0`

Manual verification:

- Inspected the changed formula to confirm the ratio branch only applies when `failedCount > correctCount and correctCount > 0`.
- All API tests with exact score assertions (`test_problem_tracking_includes_practice_weight_with_exact_values`, `test_problem_workflow_e2e`) pass unchanged because their tracking data does not trigger the ratio branch (`correctCount=0, failedCount=0` and `correctCount=2, failedCount=1` respectively).

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach exactly.

## Follow-Up Work

None.
