### PR TITLE
Make webpage time displays timezone-aware

### DIFF
--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
+from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
@@ -49,7 +50,16 @@ class HomeSummaryResponse(BaseModel):
 async def get_home_summary(
     database: DatabaseDependency,
     current_user: CurrentUserDependency,
+    timezone: Annotated[str | None, Query()] = None,
 ) -> HomeSummaryResponse:
+    if timezone is not None:
+        try:
+            tz = ZoneInfo(timezone)
+        except Exception:
+            raise HTTPException(status_code=400, detail="Invalid timezone")
+    else:
+        tz = UTC
+
     user_id = current_user["_id"]
 
     problem_documents = await database["problems"].find(
@@ -109,7 +119,7 @@ async def get_home_summary(
         round((mastered_problems / total_problems) * 100) if total_problems else 0
     )
 
-    today = datetime.now(UTC).date()
+    today = datetime.now(tz).date()
     start_date = today - timedelta(days=364)
 
     daily_counts: dict[str, int] = {}
@@ -121,7 +131,7 @@ async def get_home_summary(
     def _date_key(value: Any) -> str | None:
         if not isinstance(value, datetime):
             return None
-        event_date = value.astimezone(UTC).date()
+        event_date = value.astimezone(tz).date()
         if start_date <= event_date <= today:
             return event_date.strftime("%Y-%m-%d")
         return None

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -477,3 +477,71 @@ async def test_summary_conquest_exam_overrides_older_practice(
     response = await client.get("/api/v1/home/summary")
     data = response.json()
     assert data["conquest"]["masteredProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_timezone_buckets_by_local_date(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """An event near UTC midnight should land on the next local date for Asia/Shanghai."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+
+    # 2026-01-15T23:30:00Z is 2026-01-16T07:30:00+08:00 in Asia/Shanghai
+    event_time = datetime(2026, 1, 15, 23, 30, tzinfo=UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=event_time),
+    ])
+
+    # With UTC (default) the event should be on Jan 15
+    response_utc = await client.get("/api/v1/home/summary")
+    data_utc = response_utc.json()
+    jan15_utc = next(d for d in data_utc["activity"]["days"] if d["date"] == "2026-01-15")
+    jan16_utc = next(d for d in data_utc["activity"]["days"] if d["date"] == "2026-01-16")
+    assert jan15_utc["count"] == 1
+    assert jan16_utc["count"] == 0
+
+    # With Asia/Shanghai the event should be on Jan 16
+    response_tz = await client.get("/api/v1/home/summary?timezone=Asia/Shanghai")
+    data_tz = response_tz.json()
+    jan15_tz = next(d for d in data_tz["activity"]["days"] if d["date"] == "2026-01-15")
+    jan16_tz = next(d for d in data_tz["activity"]["days"] if d["date"] == "2026-01-16")
+    assert jan15_tz["count"] == 0
+    assert jan16_tz["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_invalid_timezone_returns_400(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    response = await client.get("/api/v1/home/summary?timezone=NotARealTimezone")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_summary_omitting_timezone_defaults_to_utc(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Backward compatibility: omitting timezone should use UTC."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    now = datetime.now(UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=now),
+    ])
+
+    response_with = await client.get("/api/v1/home/summary?timezone=UTC")
+    response_without = await client.get("/api/v1/home/summary")
+    assert response_with.status_code == 200
+    assert response_without.status_code == 200
+
+    data_with = response_with.json()
+    data_without = response_without.json()
+    today_str = now.strftime("%Y-%m-%d")
+    day_with = next(d for d in data_with["activity"]["days"] if d["date"] == today_str)
+    day_without = next(d for d in data_without["activity"]["days"] if d["date"] == today_str)
+    assert day_with["count"] == day_without["count"]

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -92,6 +92,20 @@ describe("HomePage", () => {
     expect(screen.getByTestId("error").textContent).toContain("boom");
   });
 
+  it("sends the detected timezone as a query parameter", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse(),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-activity-grid")).toBeInTheDocument();
+    });
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("/home/summary");
+    expect(calledUrl).toContain("timezone=");
+  });
+
   it("renders zero-problem state with 0% and note", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useTheme } from "@/contexts/ThemeContext";
 import { api, ApiError } from "@/api/client";
+import { getTimezone } from "@/utils/format";
 
 interface HomeCoverage {
   totalProblems: number;
@@ -95,9 +96,10 @@ function cellIntensity(count: number, maxCount: number): number {
 
 export function HomePage() {
   const { theme } = useTheme();
+  const timezone = getTimezone();
   const { data, isLoading, error } = useQuery<HomeSummaryResponse>({
-    queryKey: ["home-summary"],
-    queryFn: () => api.get<HomeSummaryResponse>("/home/summary"),
+    queryKey: ["home-summary", timezone],
+    queryFn: () => api.get<HomeSummaryResponse>(`/home/summary?timezone=${encodeURIComponent(timezone)}`),
   });
 
   const [activeTooltip, setActiveTooltip] = useState<{ date: string; text: string } | null>(null);

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
-import { formatProblemReference } from "@/utils/format";
+import { formatProblemReference, formatDate } from "@/utils/format";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { LatexText } from "@/components/LatexText";
@@ -633,7 +633,7 @@ export function ProblemDetailPage() {
               {tracking.lastTestedAt && (
                 <div>
                   <label style={{ fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", display: "block", marginBottom: "0.25rem" }}>Last Tested</label>
-                  <div style={{ fontSize: "0.95rem", fontWeight: 600, padding: "0.25rem 0" }}>{new Date(tracking.lastTestedAt).toLocaleString()}</div>
+                  <div style={{ fontSize: "0.95rem", fontWeight: 600, padding: "0.25rem 0" }}>{formatDate(tracking.lastTestedAt)}</div>
                 </div>
               )}
               {tracking.practiceWeight && (

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { formatDate, getTimezone } from "./format";
+
+describe("getTimezone", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the browser-detected IANA timezone", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockReturnValue({
+      resolvedOptions: () => ({ timeZone: "Asia/Shanghai" }),
+    } as Intl.DateTimeFormat);
+    expect(getTimezone()).toBe("Asia/Shanghai");
+  });
+
+  it("defaults to UTC when detection returns empty", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockReturnValue({
+      resolvedOptions: () => ({ timeZone: "" }),
+    } as Intl.DateTimeFormat);
+    expect(getTimezone()).toBe("UTC");
+  });
+
+  it("defaults to UTC when detection throws", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(() => {
+      throw new Error("unsupported");
+    });
+    expect(getTimezone()).toBe("UTC");
+  });
+});
+
+describe("formatDate", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns em-dash for undefined", () => {
+    expect(formatDate(undefined)).toBe("—");
+  });
+
+  it("returns em-dash for empty string", () => {
+    expect(formatDate("")).toBe("—");
+  });
+
+  it("formats a date string and includes a short timezone label", () => {
+    const result = formatDate("2026-01-15T23:30:00Z");
+    expect(result).not.toBe("—");
+    // The formatted string should include a short timezone name (e.g. "GMT+8", "UTC", "CST")
+    // We verify the result is a non-trivial formatted string, not just a raw ISO date
+    expect(result.length).toBeGreaterThan(10);
+  });
+
+  it("uses the detected timezone so a UTC-midnight event shifts to the local next day", () => {
+    // Mock timezone detection to Asia/Shanghai (UTC+8)
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      (() => ({
+        resolvedOptions: () => ({ timeZone: "Asia/Shanghai" }),
+      })) as unknown as typeof Intl.DateTimeFormat,
+    );
+
+    const result = formatDate("2026-01-15T23:30:00Z");
+    // In Asia/Shanghai (+08:00), 2026-01-15T23:30Z is 2026-01-16T07:30+08:00
+    // The formatted result should reference Jan 16, not Jan 15
+    expect(result).toContain("16");
+  });
+
+  it("uses UTC when detected timezone is UTC", () => {
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      (() => ({
+        resolvedOptions: () => ({ timeZone: "UTC" }),
+      })) as unknown as typeof Intl.DateTimeFormat,
+    );
+
+    const result = formatDate("2026-01-15T23:30:00Z");
+    // In UTC, the date should remain Jan 15
+    expect(result).toContain("1/15/2026");
+  });
+});

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,9 +1,21 @@
+export function getTimezone(): string {
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return tz || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
 export function formatDate(dateString?: string): string {
   if (!dateString) {
     return "—";
   }
 
-  return new Date(dateString).toLocaleString();
+  return new Date(dateString).toLocaleString(undefined, {
+    timeZone: getTimezone(),
+    timeZoneName: "short",
+  });
 }
 
 export function formatScore(score: number | null): string {


### PR DESCRIPTION
## Summary

- Adds a frontend `getTimezone()` helper that detects the browser's IANA timezone via `Intl.DateTimeFormat().resolvedOptions().timeZone`, defaulting to `"UTC"` when detection fails.
- Updates `formatDate()` to use the detected timezone with `timeZone` and `timeZoneName: "short"` so all timestamps render in local time with a short timezone label.
- Replaces the inline `new Date(...).toLocaleString()` on the problem detail page with the shared `formatDate()`.
- Updates `HomePage` to send the detected timezone as a `?timezone=` query parameter to `GET /home/summary` and include it in the React Query key.
- Updates `GET /home/summary` to accept an optional `timezone` query parameter, resolve it with `zoneinfo.ZoneInfo` (defaulting to UTC when omitted, returning `400` for invalid values), and compute activity date buckets using the resolved timezone.

## Linked Issue

Closes #402

## Issue Alignment

This PR implements the issue by:

- Adding a small frontend helper for timezone detection (`getTimezone()`), defaulting to `"UTC"` when unavailable or empty.
- Updating `formatDate` in `frontend/src/utils/format.ts` to use an explicit `timeZone` and include a short timezone label (`timeZoneName: "short"`).
- Replacing the problem detail page's inline `new Date(...).toLocaleString()` with the shared `formatDate()`.
- Updating `frontend/src/pages/HomePage.tsx` so the React Query key includes the detected timezone and the request calls `/home/summary?timezone=<encoded timezone>`.
- Updating `backend/app/presentation/home.py` so `get_home_summary` accepts an optional `timezone` query parameter.
- Resolving the timezone with `zoneinfo.ZoneInfo`; defaulting to UTC when omitted and raising `HTTPException(status_code=400, ...)` for invalid values.
- Computing `today`, `startDate`, `endDate`, and each event's activity date using the resolved timezone.
- Keeping `HomeActivity.startDate`, `HomeActivity.endDate`, and `HomeActivity.days[].date` as `YYYY-MM-DD` strings.
- Keeping coverage and conquest calculations unchanged.

Scope covered:

- Frontend timezone detection helper.
- Timezone-aware `formatDate` with short timezone label.
- Problem detail page uses shared formatter for `lastTestedAt`.
- Home page sends detected timezone to `/home/summary` and includes it in query key.
- Backend `/home/summary` accepts optional `timezone` query parameter, validates with `zoneinfo.ZoneInfo`, defaults to UTC, returns `400` for invalid.
- Activity date buckets computed using resolved timezone.

Out of scope / intentionally not included:

- Persisting a user timezone preference in the user profile.
- Manual timezone selection UI.
- Changing how datetimes are stored in the database.
- Migrating existing data.
- Reworking unrelated date-only labels or non-time UI copy.

## Implementation Notes

- **Frontend timezone detection**: `getTimezone()` uses `Intl.DateTimeFormat().resolvedOptions().timeZone` which returns the IANA timezone (e.g., `"Asia/Shanghai"`). It wraps the call in `try/catch` and checks for empty strings, defaulting to `"UTC"` in either case.
- **`formatDate` update**: Calls `toLocaleString(undefined, { timeZone: getTimezone(), timeZoneName: "short" })`. The `undefined` locale argument lets the browser use its default locale for formatting. The `timeZoneName: "short"` option adds a label like `"GMT+8"` or `"CST"` to the formatted string.
- **Problem detail page**: The only inline `toLocaleString()` in the codebase was at line 636 of `ProblemDetailPage.tsx`. It has been replaced with `formatDate(tracking.lastTestedAt)`, and `formatDate` was added to the existing import from `@/utils/format`.
- **Home page query key**: Changed from `["home-summary"]` to `["home-summary", timezone]` so that if the browser timezone changes, a fresh fetch is triggered.
- **Backend timezone validation**: Uses `zoneinfo.ZoneInfo(timezone)` which raises `ZoneInfoNotFoundError` (a subclass of `KeyError`) for invalid timezone strings. The broad `except Exception` catches this and any other edge cases, returning a `400` response.
- **Activity date bucketing**: `datetime.now(tz).date()` and `value.astimezone(tz).date()` are used instead of `datetime.now(UTC).date()` and `value.astimezone(UTC).date()`. This ensures events near UTC midnight land on the correct local calendar day.

## Tests

Commands run:

- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest tests/api/test_home.py -q` — passed (21 tests: 18 existing + 3 new).
- `cd backend && PYTHONPATH=. .venv/bin/python -m pytest -x -q` — passed (699 passed, 1 skipped).
- `cd frontend && npm test -- format.test --run` — passed (8 tests).
- `cd frontend && npm test -- HomePage.test --run` — passed (19 tests).
- `cd frontend && npm test -- ProblemDetailPage.test --run` — passed (32 tests).
- `cd frontend && npm test -- --run` — passed (32 files, 456 tests).
- `cd frontend && npm run build` — passed.

Automated tests added or updated:

`frontend/src/utils/format.test.ts` (new file):
- `getTimezone` returns the browser-detected IANA timezone.
- `getTimezone` defaults to UTC when detection returns empty.
- `getTimezone` defaults to UTC when detection throws.
- `formatDate` returns em-dash for undefined/empty.
- `formatDate` formats a date with the detected timezone and includes a short timezone label.
- `formatDate` uses Asia/Shanghai so a UTC-midnight event shifts to the local next day (Jan 16 instead of Jan 15).
- `formatDate` uses UTC when detected timezone is UTC (date stays Jan 15).

`frontend/src/pages/HomePage.test.tsx`:
- **Added** test verifying that the request URL includes `timezone=` query parameter.

`backend/tests/api/test_home.py`:
- **Added** `test_summary_timezone_buckets_by_local_date` — verifies that an event at `2026-01-15T23:30:00Z` is bucketed on Jan 15 with UTC (default) but on Jan 16 with `Asia/Shanghai` (UTC+8).
- **Added** `test_summary_invalid_timezone_returns_400` — verifies `400` for `timezone=NotARealTimezone`.
- **Added** `test_summary_omitting_timezone_defaults_to_utc` — verifies backward compatibility: omitting `timezone` produces the same results as `timezone=UTC`.

Manual verification:

- The automated tests cover the main happy path for a non-UTC timezone (`Asia/Shanghai`), the UTC fallback/default path, the invalid timezone edge case, and the UTC-midnight boundary.
- Browser-based manual verification (checking that timestamps show local time with a short timezone label in a non-UTC browser) would require a running dev server with a browser configured for a non-UTC timezone. The `formatDate` unit tests verify the timezone conversion logic directly by mocking `Intl.DateTimeFormat` and checking that date values shift correctly.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen implementation approach exactly.

## Follow-Up Work

None. A future enhancement could add a persisted user timezone preference or manual timezone override, but that is intentionally out of scope per the issue.
