### PR TITLE
Fix flaky ProblemsPage test using findByRole for folder button

### DIFF
--- a/frontend/src/pages/ProblemsPage.test.tsx
+++ b/frontend/src/pages/ProblemsPage.test.tsx
@@ -336,7 +336,7 @@ describe("ProblemsPage", () => {
     expect(screen.getByRole("option", { name: "Add date" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Last test date" })).toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.click(await screen.findByRole("button", { name: "Select folder Section 1" }));
     await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
     await user.selectOptions(screen.getByLabelText("Sort by:"), "selectionScore");
     await user.selectOptions(screen.getByLabelText("Order:"), "asc");


### PR DESCRIPTION
## Summary

- Fixed a flaky test in `ProblemsPage.test.tsx` that used synchronous `screen.getByRole` for an asynchronously-rendered folder button, causing intermittent CI failures.
- Changed `getByRole` to `await findByRole` at line 339, matching the pattern already used at lines 215 and 409 in the same file.

## Linked Issue

Closes #406

## Issue Alignment

This PR implements the issue by:

- Converting the `screen.getByRole("button", { name: "Select folder Section 1" })` call at `ProblemsPage.test.tsx:339` to `await screen.findByRole(...)`.

Scope covered:

- Fix the single flaky `getByRole` call at line 339 in the "sends sort parameters with existing filters" test.

Out of scope / intentionally not included:

- Changes to other tests in the file (lines 188, 237, 283, 299, 401 also use `getByRole` for the same button, but those tests did not flake in CI and the issue explicitly scopes out changes to other tests).
- Changes to ProblemsPage component logic.
- Changes to folder rendering logic.

## Implementation Notes

- The test `"sends sort parameters with existing filters"` (line 328) awaited only `findByText("What is 2+2?")` at line 333 before using synchronous `getByRole` at line 339. Since the folder sidebar renders asynchronously after the problem list loads, `getByRole` (which throws immediately if the element is not present) could race with the async folder rendering.
- The fix adds `await` and changes `getByRole` to `findByRole`, which retries until the element appears or times out. This matches the established pattern at lines 215 and 409.
- Single-line change, no new imports or dependencies.

## Tests

Commands run:

- `npm test -- ProblemsPage.test --run` — passed (32 tests)
- `npm test -- --run` — passed (456 tests, 32 files)

Automated tests added or updated:

- None (the fix is to an existing test; no new tests needed).

Manual verification:

- Verified the diff is a single-line change matching the pattern at lines 215 and 409.

## Deviations From Issue Plan

None.

## Follow-Up Work

- Lines 188, 237, 283, 299, and 401 in the same file also use `getByRole` for the same folder button. These tests did not flake in CI and the issue explicitly scopes out changes to other tests, but they could potentially flake in the future. If they do, a separate issue can be created to convert them as well.
