### PR TITLE
Support optional correctAnswer from English ingestion VLM

### DIFF
--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -105,6 +105,7 @@ class _ExtractionProviderPayload(BaseModel):
     text: str
     problem_type: ProblemType = Field(alias="problemType")
     graph_dsl: str | None = Field(default=None, alias="graphDsl")
+    correct_answer: str | None = Field(default=None, alias="correctAnswer")
     provider_metadata: dict[str, Any] = Field(default_factory=dict, alias="providerMetadata")
 
 
@@ -149,6 +150,7 @@ class ExtractionResult(BaseModel):
     text: str
     problem_type: ProblemType | None
     graph_dsl: str | None
+    correct_answer: str | None = None
     provider_metadata: dict[str, Any]
     raw_provider_response: dict[str, Any]
 
@@ -191,6 +193,7 @@ class VLMClient(BaseVLMClient):
         timeout_seconds: float,
         http_client: httpx.AsyncClient | None = None,
         extraction_system_prompt: str = MATH_EXTRACTION_SYSTEM_PROMPT,
+        request_correct_answer: bool = False,
     ) -> None:
         super().__init__(
             endpoint=endpoint,
@@ -201,6 +204,7 @@ class VLMClient(BaseVLMClient):
             error_factory=VLMError,
         )
         self._extraction_system_prompt = extraction_system_prompt
+        self._request_correct_answer = request_correct_answer
 
     @property
     def model(self) -> str:
@@ -212,6 +216,14 @@ class VLMClient(BaseVLMClient):
         image_url: str | None = None,
         image_base64: str | None = None,
     ) -> ExtractionResult:
+        properties: dict[str, Any] = {
+            "text": {"type": "string"},
+            "problemType": {"type": "string"},
+            "graphDsl": {"type": ["string", "null"]},
+            "providerMetadata": {"type": "object"},
+        }
+        if self._request_correct_answer:
+            properties["correctAnswer"] = {"type": ["string", "null"]}
         request = ExtractionRequest(
             model=self._model,
             prompt=self._extraction_system_prompt,
@@ -220,12 +232,7 @@ class VLMClient(BaseVLMClient):
             expectedResponseSchema={
                 "type": "object",
                 "required": ["text", "problemType"],
-                "properties": {
-                    "text": {"type": "string"},
-                    "problemType": {"type": "string"},
-                    "graphDsl": {"type": ["string", "null"]},
-                    "providerMetadata": {"type": "object"},
-                },
+                "properties": properties,
             },
         )
         raw_provider_response = await self._send_request(request)
@@ -236,6 +243,7 @@ class VLMClient(BaseVLMClient):
             text=payload.text,
             problem_type=payload.problem_type,
             graph_dsl=payload.graph_dsl,
+            correct_answer=payload.correct_answer,
             provider_metadata=payload.provider_metadata,
             raw_provider_response=raw_provider_response,
         )
@@ -380,8 +388,7 @@ class VLMClient(BaseVLMClient):
                 raw_provider_response=raw_provider_response,
             ) from exc
 
-    @staticmethod
-    def _build_chat_completion_payload(request: _RequestBase) -> dict[str, Any]:
+    def _build_chat_completion_payload(self, request: _RequestBase) -> dict[str, Any]:
         if isinstance(request, GradingRequest):
             user_prompt = build_grading_user_prompt(
                 problem_text=request.problem_text,
@@ -401,6 +408,7 @@ class VLMClient(BaseVLMClient):
         else:
             user_prompt = build_extraction_user_prompt(
                 expected_response_schema=request.expected_response_schema,
+                include_correct_answer=self._request_correct_answer,
             )
 
         content: list[_ChatMessageContentText | _ChatMessageContentImageUrl] = [

--- a/backend/app/infrastructure/vlm/prompts.py
+++ b/backend/app/infrastructure/vlm/prompts.py
@@ -347,6 +347,9 @@ Fields:
 - problemType: one of single-choice, multi-choice, fill-in-the-blank, short-answer.
 - graphDsl: nullable string. Use this only when the problem contains a geometry or coordinate-style diagram
   that can be reconstructed with the supported JSXGraph elements below. Otherwise return null.
+- correctAnswer: nullable string. If the image visibly shows the expected answer (for example an answer key,
+  a printed answer, or a clearly indicated correct option), put that answer here as plain text. If no answer is
+  visible in the image, return null. Do not solve the problem or infer an answer that is not shown.
 - providerMetadata: optional object. Omit it unless the caller explicitly requires provider-specific metadata.
 
 ## Core extraction rules
@@ -581,10 +584,18 @@ Fields:
 """
 
 
-def build_extraction_user_prompt(*, expected_response_schema: dict[str, Any]) -> str:
+def build_extraction_user_prompt(
+    *,
+    expected_response_schema: dict[str, Any],
+    include_correct_answer: bool = False,
+) -> str:
+    if include_correct_answer:
+        keys_clause = '"text", "problemType", "graphDsl", nullable "correctAnswer", and optional "providerMetadata"'
+    else:
+        keys_clause = '"text", "problemType", "graphDsl", and optional "providerMetadata"'
     return (
         "Extract the study problem from the attached image.\n"
-        'Return only JSON with keys "text", "problemType", "graphDsl", and optional "providerMetadata".\n'
+        f"Return only JSON with keys {keys_clause}.\n"
         "Expected JSON schema:\n"
         f"{json.dumps(expected_response_schema, ensure_ascii=False)}"
     )

--- a/backend/app/infrastructure/worker/extraction_worker.py
+++ b/backend/app/infrastructure/worker/extraction_worker.py
@@ -261,7 +261,7 @@ async def process_item(
             "text": result.text,
             "problemType": result.problem_type,
             "graphDsl": result.graph_dsl,
-            "correctAnswer": None,
+            "correctAnswer": result.correct_answer,
             "tags": [],
             "subject": subject,
         },

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -58,6 +58,7 @@ async def _run_extraction_worker_with_logging(database, storage, settings, stop_
             api_key=settings.english_ingestion_vlm_api_key,
             timeout_seconds=settings.english_ingestion_vlm_timeout_seconds,
             extraction_system_prompt=ENGLISH_EXTRACTION_SYSTEM_PROMPT,
+            request_correct_answer=True,
         )
         await run_extraction_worker(
             database,

--- a/backend/app/presentation/deps.py
+++ b/backend/app/presentation/deps.py
@@ -162,6 +162,7 @@ def create_english_ingestion_vlm_client(
         api_key=settings.english_ingestion_vlm_api_key,
         timeout_seconds=settings.english_ingestion_vlm_timeout_seconds,
         extraction_system_prompt=ENGLISH_EXTRACTION_SYSTEM_PROMPT,
+        request_correct_answer=True,
     )
 
 

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -159,6 +159,158 @@ async def test_vlm_extraction_prompt_includes_expected_response_schema() -> None
     assert result.text == "Find $x$ when $x+1=2$"
 
 
+def _build_english_client(handler) -> VLMClient:
+    transport = httpx.MockTransport(handler)
+    http_client = httpx.AsyncClient(
+        transport=transport,
+        base_url="https://vlm.example/api",
+        timeout=5,
+        headers={"Authorization": "Bearer demo", "Content-Type": "application/json"},
+    )
+    return VLMClient(
+        endpoint="https://vlm.example/api",
+        model="demo",
+        api_key="demo",
+        timeout_seconds=5,
+        http_client=http_client,
+        extraction_system_prompt=ENGLISH_EXTRACTION_SYSTEM_PROMPT,
+        request_correct_answer=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_vlm_extraction_math_does_not_request_correct_answer() -> None:
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads((await request.aread()).decode())
+        captured["user_prompt"] = payload["messages"][1]["content"][0]["text"]
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {"text": "x", "problemType": "short-answer", "graphDsl": None}
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_client(handler)
+    await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert '"correctAnswer"' not in captured["user_prompt"]
+    assert "nullable \"correctAnswer\"" not in captured["user_prompt"]
+
+
+@pytest.mark.asyncio
+async def test_vlm_extraction_english_requests_correct_answer() -> None:
+    captured: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads((await request.aread()).decode())
+        captured["user_prompt"] = payload["messages"][1]["content"][0]["text"]
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "text": "I go to school by ___.",
+                                    "problemType": "fill-in-the-blank",
+                                    "graphDsl": None,
+                                    "correctAnswer": "bus",
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_english_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert '"correctAnswer": {"type": ["string", "null"]}' in captured["user_prompt"]
+    assert 'nullable "correctAnswer"' in captured["user_prompt"]
+    assert result.correct_answer == "bus"
+
+
+@pytest.mark.asyncio
+async def test_vlm_extraction_parses_null_correct_answer() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "text": "Write a sentence.",
+                                    "problemType": "short-answer",
+                                    "graphDsl": None,
+                                    "correctAnswer": None,
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_english_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert result.correct_answer is None
+
+
+@pytest.mark.asyncio
+async def test_vlm_extraction_tolerates_omitted_correct_answer() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": json.dumps(
+                                {
+                                    "text": "Write a sentence.",
+                                    "problemType": "short-answer",
+                                    "graphDsl": None,
+                                }
+                            ),
+                        },
+                    }
+                ],
+            },
+        )
+
+    client = _build_english_client(handler)
+    result = await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert result.correct_answer is None
+
+
 @pytest.mark.asyncio
 async def test_vlm_extraction_prompt_includes_keepaspectratio_guidance() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
@@ -557,6 +709,15 @@ def test_english_extraction_prompt_allows_diagram_dsl() -> None:
 def test_english_extraction_prompt_contains_english_guidance() -> None:
     assert "multi-choice" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
     assert "passage" in ENGLISH_EXTRACTION_SYSTEM_PROMPT.lower() or "text" in ENGLISH_EXTRACTION_SYSTEM_PROMPT.lower()
+
+
+def test_english_extraction_prompt_documents_correct_answer() -> None:
+    assert "correctAnswer" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+    assert "nullable string" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+
+
+def test_math_extraction_prompt_does_not_request_correct_answer() -> None:
+    assert "correctAnswer" not in MATH_EXTRACTION_SYSTEM_PROMPT
 
 
 def test_math_extraction_prompt_scopes_javascript_to_graph_dsl_field() -> None:

--- a/backend/tests/worker/test_extraction_worker.py
+++ b/backend/tests/worker/test_extraction_worker.py
@@ -68,12 +68,14 @@ def make_extraction_result(
     text: str = "What is 2+2?",
     problem_type: str = "short-answer",
     graph_dsl: str | None = None,
+    correct_answer: str | None = None,
     model: str = "fake-ingestion-vlm",
 ) -> ExtractionResult:
     raw = {
         "text": text,
         "problemType": problem_type,
         "graphDsl": graph_dsl,
+        "correctAnswer": correct_answer,
         "providerMetadata": {"provider": "fake"},
     }
     return ExtractionResult(
@@ -82,6 +84,7 @@ def make_extraction_result(
         text=text,
         problem_type=problem_type,
         graph_dsl=graph_dsl,
+        correct_answer=correct_answer,
         provider_metadata=raw["providerMetadata"],
         raw_provider_response=raw,
     )
@@ -303,6 +306,7 @@ async def test_process_item_success_math(
     assert stored_item["status"] == ItemState.READY.value
     assert stored_item["draft"]["text"] == "math problem"
     assert stored_item["draft"]["subject"] == "math"
+    assert stored_item["draft"]["correctAnswer"] is None
     assert stored_item["extraction"]["success"] is True
     assert stored_item["extraction"]["model"] == "math-model"
     assert stored_item["crop"] is not None
@@ -342,6 +346,83 @@ async def test_process_item_routes_to_english_client(
     assert len(english_client.calls) == 1
     refreshed = await get_batch(database, batch_id, batch["userId"])
     assert refreshed["items"][0]["extraction"]["model"] == "english-model"
+
+
+@pytest.mark.asyncio
+async def test_process_item_persists_english_correct_answer(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="english",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+    english_client.responses.append(
+        make_extraction_result(
+            text="english problem",
+            correct_answer="bus",
+            model="english-model",
+        )
+    )
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    stored_item = refreshed["items"][0]
+    assert stored_item["status"] == ItemState.READY.value
+    assert stored_item["draft"]["correctAnswer"] == "bus"
+
+
+@pytest.mark.asyncio
+async def test_process_item_leaves_answer_empty_when_correct_answer_null(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="english",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+    english_client.responses.append(
+        make_extraction_result(text="english problem", correct_answer=None, model="english-model")
+    )
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    stored_item = refreshed["items"][0]
+    assert stored_item["draft"]["correctAnswer"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a nullable `correctAnswer` output field to the English ingestion VLM contract (system prompt, expected JSON schema, and user-prompt return-key instruction).
- Parse the optional `correctAnswer` into the extraction result as `correct_answer` (tolerant of null/omitted).
- Persist `result.correct_answer` into ingestion drafts for all subjects instead of hardcoding `None`.
- Math ingestion keeps its current prompt/schema and does not request `correctAnswer`.

## Linked Issue

Closes #408

## Issue Alignment

This PR implements the issue by:

- Adding `correctAnswer` documentation to `ENGLISH_EXTRACTION_SYSTEM_PROMPT` explaining when to populate it vs return `null`.
- Extending `_ExtractionProviderPayload` and `ExtractionResult` with optional `correct_answer` mapped from JSON `correctAnswer` (defaults to `None`).
- Adding a `request_correct_answer` flag to `VLMClient`; only the English ingestion client (`deps.py`, `main.py`) sets it to `True`.
- Updating the extraction worker to write `"correctAnswer": result.correct_answer` into the draft for all subjects.

Scope covered:

- English ingestion prompt/schema/user-prompt includes nullable `correctAnswer`.
- Extraction result parsing carries optional `correct_answer`.
- Worker persists `result.correct_answer` for all subject types.
- Backend tests for English answer prefill, null/omitted behavior, and Math non-regression.

Out of scope / intentionally not included:

- Adding `correctAnswer` to the Math ingestion prompt/schema.
- Frontend UI changes.
- Answer normalization or final problem creation semantics.
- Migrations or stored problem schema changes.

## Implementation Notes

- `VLMClient.extract()` now builds the `properties` dict conditionally: it adds `"correctAnswer": {"type": ["string", "null"]}` only when `self._request_correct_answer` is `True`. Math clients keep the exact original schema/properties.
- `build_extraction_user_prompt` gained an `include_correct_answer` flag. When `False` (Math/default) the return-key instruction is byte-for-byte identical to the previous wording; when `True` (English) it inserts `nullable "correctAnswer"` before `and optional "providerMetadata"`.
- `_ExtractionProviderPayload` uses `extra="allow"` and a defaulted `correct_answer` field, so provider responses that omit `correctAnswer` (existing Math responses and fakes) continue to parse without error.
- The English ingestion VLM client factories (`create_english_ingestion_vlm_client` in `deps.py` and the worker bootstrap in `main.py`) pass `request_correct_answer=True`.

## Tests

Commands run:

- `cd backend && uv run pytest tests/infrastructure/test_vlm.py tests/worker/test_extraction_worker.py -q` — passed (75 passed). *(Executed via the shared project venv: `PYTHONPATH=. <venv>/python -m pytest ...` because `uv run` was syncing a fresh worktree venv and exceeded the shell timeout; results are identical.)*
- `cd backend && uv run pytest -q` (full backend suite) — passed (707 passed, 1 skipped).

Automated tests added or updated:

- `test_vlm_extraction_math_does_not_request_correct_answer` — Math schema/user-prompt does not mention `correctAnswer`.
- `test_vlm_extraction_english_requests_correct_answer` — English schema includes `"correctAnswer": {"type": ["string", "null"]}` and the return-key instruction mentions `nullable "correctAnswer"`; `result.correct_answer == "bus"`.
- `test_vlm_extraction_parses_null_correct_answer` — explicit `null` parses to `None`.
- `test_vlm_extraction_tolerates_omitted_correct_answer` — omitted field parses to `None`.
- `test_english_extraction_prompt_documents_correct_answer` / `test_math_extraction_prompt_does_not_request_correct_answer` — prompt-content assertions.
- `test_process_item_persists_english_correct_answer` — non-null `correct_answer` prefills `draft["correctAnswer"]`.
- `test_process_item_leaves_answer_empty_when_correct_answer_null` — null `correct_answer` leaves draft answer `None`.
- `test_process_item_success_math` updated to assert `draft["correctAnswer"] is None` (Math non-regression).
- `make_extraction_result` helper updated to carry `correct_answer`.

Manual verification:

- Inspected mock English and Math VLM request payloads with a captured `httpx.MockTransport`:
  - English: `correctAnswer` present in the expected schema as `{"type": ["string", "null"]}` and the return-key instruction reads `... "graphDsl", nullable "correctAnswer", and optional "providerMetadata"`.
  - Math: `correctAnswer` absent from both the schema and the return-key instruction; the Math user-prompt wording is unchanged (`"text", "problemType", "graphDsl", and optional "providerMetadata"`).
- A non-null parsed `correct_answer` (`"bus"`) is persisted into the ingestion draft; a null value leaves the draft answer blank (covered by the worker tests above).

## Deviations From Issue Plan

- `_build_chat_completion_payload` was converted from a `@staticmethod` to an instance method so it can read `self._request_correct_answer` when building the extraction user prompt. It was already only invoked as `self._build_chat_completion_payload(request)`, so behavior is preserved; no other call sites exist. This is the minimal way to thread the per-client flag into prompt construction without coupling the request model.

## Follow-Up Work

None.