### PR TITLE
Canonicalize backend FastAPI dependency aliases

### DIFF
--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any, NamedTuple
 
-from fastapi import APIRouter, Depends, File, UploadFile
+from fastapi import APIRouter, File, UploadFile
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
@@ -49,14 +49,14 @@ from app.infrastructure.ingestion.repository import (
     update_item_draft,
 )
 from app.infrastructure.storage.mongo import Document
-from app.infrastructure.storage.s3 import S3StorageAdapter, StorageObjectNotFoundError
+from app.infrastructure.storage.s3 import StorageObjectNotFoundError
 from app.infrastructure.vlm.base_client import BaseVLMError
 from app.presentation.deps import (
+    CurrentUserDependency,
     DatabaseDependency,
     HelperVLMDependency,
-    get_app_settings,
-    get_current_user,
-    get_s3_storage,
+    SettingsDependency,
+    StorageDependency,
 )
 from app.presentation.errors import ApiError
 from app.presentation.helpers import (
@@ -69,10 +69,6 @@ from app.presentation.problem_creation import create_problem_from_draft
 from app.presentation.schemas import SourceImagePayload
 
 router = APIRouter(prefix="/ingestion-batches", tags=["bulk-ingestion"])
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
-StorageDependency = Annotated[S3StorageAdapter, Depends(get_s3_storage)]
-SettingsDependency = Annotated[Settings, Depends(get_app_settings)]
 
 
 class DetectionResponse(BaseModel):

--- a/backend/app/presentation/coaching.py
+++ b/backend/app/presentation/coaching.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator
-from typing import Annotated, Any
+from typing import Annotated
 
 from bson import ObjectId
 from fastapi import APIRouter, Depends
@@ -9,18 +9,14 @@ from pydantic import BaseModel, Field
 
 from app.domain.models import CoachingConversation
 from app.domain.coaching.service import CoachingService, CoachingError
-from app.infrastructure.config.settings import Settings
 from app.presentation.deps import (
+    CurrentUserDependency,
     DatabaseDependency,
-    get_current_user,
-    get_app_settings,
+    SettingsDependency,
 )
 from app.presentation.errors import ApiError
 
 router = APIRouter(prefix="/coaching", tags=["coaching"])
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
-SettingsDependency = Annotated[Settings, Depends(get_app_settings)]
 
 class CoachingMessageRequest(BaseModel):
     message: str = Field(min_length=1, max_length=5000)

--- a/backend/app/presentation/deps.py
+++ b/backend/app/presentation/deps.py
@@ -182,6 +182,8 @@ async def get_grading_vlm_client(
 
 
 StorageDependency = Annotated[S3StorageAdapter, Depends(get_s3_storage)]
+SettingsDependency = Annotated[Settings, Depends(get_app_settings)]
+CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 HelperVLMDependency = Annotated[VLMClient, Depends(create_helper_vlm_client)]
 MathIngestionVLMDependency = Annotated[VLMClient, Depends(create_math_ingestion_vlm_client)]
 EnglishIngestionVLMDependency = Annotated[VLMClient, Depends(create_english_ingestion_vlm_client)]

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 from copy import deepcopy
 from datetime import UTC, datetime
 from random import Random
-from typing import Annotated, Any
+from typing import Any
 
 from bson import ObjectId
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Query
 
 from app.domain.models import ExamState, GradingStatus, ProblemType, SelectionPolicyConfig
 from app.domain.selection import ProblemSelectionConfig, select_problems
 from app.domain.state import transition_exam_state
-from app.infrastructure.config.settings import Settings, get_settings
 from app.presentation.exam_grading import build_tracking_update, grade_item
 from app.presentation.exam_helpers import (
     build_exam_summary,
@@ -22,10 +21,11 @@ from app.presentation.exam_helpers import (
 )
 from app.presentation.deps import (
     AdapterDependency,
+    CurrentUserDependency,
     DatabaseDependency,
     GradingVLMDependency,
+    SettingsDependency,
     StorageDependency,
-    get_current_user,
 )
 from app.presentation.errors import ApiError
 from app.presentation.exam_serialization import (
@@ -44,10 +44,6 @@ from app.presentation.exam_serialization import (
 )
 
 router = APIRouter(prefix="/exams", tags=["exams"])
-
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
-SettingsDependency = Annotated[Settings, Depends(get_settings)]
 
 
 @router.post("", response_model=CreateExamResponse, status_code=201)

--- a/backend/app/presentation/folders.py
+++ b/backend/app/presentation/folders.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import re
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Any
 
 from bson import ObjectId
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
-from app.presentation.deps import DatabaseDependency, get_current_user
+from app.presentation.deps import CurrentUserDependency, DatabaseDependency
 from app.presentation.errors import ApiError
 from app.presentation.helpers import (
     get_all_descendant_folder_ids,
@@ -17,8 +17,6 @@ from app.presentation.helpers import (
 )
 
 router = APIRouter(prefix="/folders", tags=["folders"])
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 
 MAX_FOLDER_NAME_LENGTH = 200
 

--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -4,15 +4,13 @@ from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
-from app.presentation.deps import DatabaseDependency, get_current_user
+from app.presentation.deps import CurrentUserDependency, DatabaseDependency
 
 router = APIRouter(prefix="/home", tags=["home"])
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 
 _MASTERY_STATUSES = {GradingStatus.CORRECT.value, GradingStatus.INCORRECT.value}
 

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -14,19 +14,17 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from app.domain import IngestionPreviewStatus, ProblemSubject, ProblemType
-from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
-from app.infrastructure.vlm.client import VLMClient, VLMError
+from app.infrastructure.vlm.client import VLMError
 from app.presentation.deps import (
+    CurrentUserDependency,
     DatabaseDependency,
+    EnglishIngestionVLMDependency,
+    HelperVLMDependency,
+    MathIngestionVLMDependency,
+    SettingsDependency,
     StorageDependency,
-    create_english_ingestion_vlm_client,
-    create_helper_vlm_client,
-    create_math_ingestion_vlm_client,
-    get_app_settings,
-    get_current_user,
-    get_s3_storage,
 )
 from app.presentation.errors import ApiError
 from app.presentation.helpers import normalize_tags, parse_object_id
@@ -55,19 +53,12 @@ class PreviewDraftPatchRequest(BaseModel):
     subject: ProblemSubject | None = None
 
 
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
-SettingsDependency = Annotated[Settings, Depends(get_app_settings)]
-
-
 def get_preview_sync_wait_seconds() -> float:
     return DEFAULT_SYNC_WAIT_SECONDS
 
 
 S3Dependency = StorageDependency
 SyncWaitDependency = Annotated[float, Depends(get_preview_sync_wait_seconds)]
-HelperVLMDependency = Annotated[VLMClient, Depends(create_helper_vlm_client)]
-MathIngestionVLMDependency = Annotated[VLMClient, Depends(create_math_ingestion_vlm_client)]
-EnglishIngestionVLMDependency = Annotated[VLMClient, Depends(create_english_ingestion_vlm_client)]
 
 
 async def _get_owned_preview(

--- a/backend/app/presentation/media.py
+++ b/backend/app/presentation/media.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
 from io import BytesIO
-from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 
 from app.infrastructure.storage.s3 import StorageObjectNotFoundError
-from app.presentation.deps import DatabaseDependency, StorageDependency, get_current_user
+from app.presentation.deps import CurrentUserDependency, DatabaseDependency, StorageDependency
 from app.presentation.errors import ApiError
 from app.presentation.helpers import get_owned_problem
 
 router = APIRouter(tags=["media"])
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 
 
 @router.get("/problems/{problem_id}/image")

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -15,16 +15,16 @@ from app.domain.practice_selection import (
     get_eligible_practice_problems,
     select_practice_problem,
 )
-from app.infrastructure.config.settings import Settings, get_settings
+from app.infrastructure.config.settings import get_settings
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import S3StorageAdapter
 from app.infrastructure.vlm.client import VLMClient, VLMError
 from app.presentation.deps import (
+    CurrentUserDependency,
     DatabaseDependency,
-    get_app_settings,
-    get_current_user,
+    SettingsDependency,
+    StorageDependency,
     get_grading_vlm_client,
-    get_s3_storage,
 )
 from app.infrastructure.storage.s3 import load_source_image_base64
 from app.presentation.helpers import build_problem_image_url, parse_object_id
@@ -34,9 +34,6 @@ from app.presentation.errors import ApiError
 router = APIRouter(prefix="/practice", tags=["practice"])
 
 
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
-SettingsDependency = Annotated[Settings, Depends(get_app_settings)]
-StorageDependency = Annotated[S3StorageAdapter, Depends(get_s3_storage)]
 VLMDependency = Annotated[VLMClient, Depends(get_grading_vlm_client)]
 
 

--- a/backend/app/presentation/tags.py
+++ b/backend/app/presentation/tags.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Any
 
 from bson import ObjectId
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter
 from pydantic import BaseModel, Field
 from pymongo.asynchronous.database import AsyncDatabase
 
 from app.infrastructure.storage.mongo import Document
-from app.presentation.deps import DatabaseDependency, get_current_user
+from app.presentation.deps import CurrentUserDependency, DatabaseDependency
 from app.presentation.errors import ApiError
 from app.presentation.helpers import normalize_tags, parse_object_id
 
 router = APIRouter(prefix="/tags", tags=["tags"])
-
-CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
 
 
 class TagPayload(BaseModel):

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -14,9 +14,10 @@ from httpx import ASGITransport, AsyncClient
 
 from app.infrastructure.vlm.client import VLMError
 from app.main import create_app
-from app.infrastructure.config.settings import Settings, get_settings
+from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import get_mongo_adapter
 from app.presentation.deps import (
+    get_app_settings,
     get_current_user,
     get_database,
     get_grading_vlm_client,
@@ -181,7 +182,7 @@ async def exams_app() -> FastAPI:
     )
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
-    application.dependency_overrides[get_settings] = lambda: settings
+    application.dependency_overrides[get_app_settings] = lambda: settings
     application.dependency_overrides[get_mongo_adapter] = lambda: adapter
     application.dependency_overrides[get_s3_storage] = lambda: storage
     application.dependency_overrides[get_grading_vlm_client] = lambda: vlm
@@ -600,7 +601,7 @@ async def exams_app_with_min_age() -> FastAPI:
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
-    application.dependency_overrides[get_settings] = lambda: settings
+    application.dependency_overrides[get_app_settings] = lambda: settings
     application.dependency_overrides[get_mongo_adapter] = lambda: adapter
     application.dependency_overrides[get_s3_storage] = lambda: storage
     application.dependency_overrides[get_grading_vlm_client] = lambda: vlm
@@ -678,7 +679,7 @@ async def exams_app_with_custom_policy() -> FastAPI:
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_current_user] = lambda: deepcopy(user)
-    application.dependency_overrides[get_settings] = lambda: settings
+    application.dependency_overrides[get_app_settings] = lambda: settings
     application.dependency_overrides[get_mongo_adapter] = lambda: adapter
     application.dependency_overrides[get_s3_storage] = lambda: storage
     application.dependency_overrides[get_grading_vlm_client] = lambda: vlm

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -24,6 +24,7 @@ from app.presentation.deps import (
     create_math_ingestion_vlm_client,
     get_app_settings,
     get_database,
+    get_s3_storage,
 )
 from app.presentation import ingestion as ingestion_presentation
 from tests.api.conftest import FakeDatabase
@@ -250,10 +251,10 @@ async def ingestion_app() -> AsyncIterator[FastAPI]:
 
     application.dependency_overrides[get_database] = lambda: database
     application.dependency_overrides[get_app_settings] = lambda: settings
-    application.dependency_overrides[ingestion_presentation.get_s3_storage] = lambda: storage
-    application.dependency_overrides[ingestion_presentation.create_helper_vlm_client] = lambda: helper_vlm_client
-    application.dependency_overrides[ingestion_presentation.create_math_ingestion_vlm_client] = lambda: math_ingestion_vlm_client
-    application.dependency_overrides[ingestion_presentation.create_english_ingestion_vlm_client] = lambda: english_ingestion_vlm_client
+    application.dependency_overrides[get_s3_storage] = lambda: storage
+    application.dependency_overrides[create_helper_vlm_client] = lambda: helper_vlm_client
+    application.dependency_overrides[create_math_ingestion_vlm_client] = lambda: math_ingestion_vlm_client
+    application.dependency_overrides[create_english_ingestion_vlm_client] = lambda: english_ingestion_vlm_client
     application.dependency_overrides[ingestion_presentation.get_preview_sync_wait_seconds] = (
         lambda: application.state.sync_wait_seconds
     )

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -18,6 +18,9 @@ from app.main import create_app
 from app.presentation import ingestion as ingestion_presentation
 from app.infrastructure.storage.mongo import get_mongo_adapter
 from app.presentation.deps import (
+    create_english_ingestion_vlm_client,
+    create_helper_vlm_client,
+    create_math_ingestion_vlm_client,
     get_app_settings,
     get_database,
     get_grading_vlm_client,
@@ -290,10 +293,9 @@ async def app() -> AsyncIterator[FastAPI]:
     application.dependency_overrides[get_s3_storage] = lambda: storage
     application.dependency_overrides[get_mongo_adapter] = lambda: adapter
     application.dependency_overrides[get_grading_vlm_client] = lambda: grading_vlm
-    application.dependency_overrides[ingestion_presentation.get_s3_storage] = lambda: storage
-    application.dependency_overrides[ingestion_presentation.create_helper_vlm_client] = lambda: helper_vlm
-    application.dependency_overrides[ingestion_presentation.create_math_ingestion_vlm_client] = lambda: math_ingestion_vlm
-    application.dependency_overrides[ingestion_presentation.create_english_ingestion_vlm_client] = lambda: english_ingestion_vlm
+    application.dependency_overrides[create_helper_vlm_client] = lambda: helper_vlm
+    application.dependency_overrides[create_math_ingestion_vlm_client] = lambda: math_ingestion_vlm
+    application.dependency_overrides[create_english_ingestion_vlm_client] = lambda: english_ingestion_vlm
     application.dependency_overrides[ingestion_presentation.get_preview_sync_wait_seconds] = (
         lambda: application.state.sync_wait_seconds
     )


### PR DESCRIPTION
## Summary

- Centralizes duplicated FastAPI dependency aliases by adding the missing canonical `CurrentUserDependency` and `SettingsDependency` to `app.presentation.deps` and importing them across routers.
- Replaces router-local `CurrentUserDependency`, `SettingsDependency`, `StorageDependency`, and ingestion VLM dependency redefinitions in the 9 routers listed in the issue with imports from `app.presentation.deps`.
- Converts `exams.py` `SettingsDependency` from `Depends(get_settings)` to the canonical `Depends(get_app_settings)`. Runtime behavior is identical because `get_app_settings()` returns `get_settings()`.

## Linked Issue

Closes #410

## Issue Alignment

This PR implements the issue by:

- Adding missing canonical aliases `CurrentUserDependency` and `SettingsDependency` to `app.presentation.deps`.
- Replacing duplicated router-local aliases with imports from `app.presentation.deps` where safe, across the 9 routers enumerated in the issue's implementation plan (tags, ingestion, bulk_ingestion, practice, exams, coaching, folders, home, media).
- Removing router-local `StorageDependency` redefinitions in bulk_ingestion and practice.
- Removing ingestion router VLM dependency alias redefinitions (`HelperVLMDependency`, `MathIngestionVLMDependency`, `EnglishIngestionVLMDependency`).
- Converting `exams.py` direct `Depends(get_settings)` to the canonical settings dependency (step 7 of the issue plan).

Scope covered:

- Canonicalization of duplicated dependency aliases in the 9 enumerated routers.
- `exams.py` `Depends(get_settings)` → canonical `Depends(get_app_settings)` conversion (chosen over deferral because it achieves true canonicalization and is behavior-preserving).
- Test wiring updates required by the refactor (exams dependency overrides; ingestion test attribute-access overrides).

Out of scope / intentionally not included:

- `problems.py` was not in the issue's enumerated routers (step 3 lists 9 routers; problems.py is excluded). It also contains a duplicate `CurrentUserDependency` and direct `Depends(get_settings)` usage at two endpoints. These were left untouched per the issue's explicit scope and can be addressed in a follow-up if desired.
- Local aliases retained where they are not duplicates of canonical names: `practice.py` `VLMDependency` (a different name wrapping `get_grading_vlm_client`), and `ingestion.py` `S3Dependency`/`SyncWaitDependency` (local renames / local function).
- No endpoint parameter renames, response/persistence/error behavior changes, or broader presentation-layer reorganization.

## Implementation Notes

- `get_app_settings()` in `deps.py` is a thin wrapper that returns `get_settings()`, so converting `exams.py` from `Depends(get_settings)` to `Depends(get_app_settings)` is behavior-preserving at runtime.
- Test dependency overrides were updated where they referenced dependency functions via module attribute access on `app.presentation.ingestion` (`ingestion_presentation.get_s3_storage`, `ingestion_presentation.create_*_vlm_client`). These now import the functions directly from `app.presentation.deps` (same function objects), which is the equivalent override.
- `tests/api/test_exams.py` overrides were changed from `dependency_overrides[get_settings]` to `dependency_overrides[get_app_settings]` (3 sites) to match the converted exams dependency.
- Orphaned imports created by the refactor (e.g. `Annotated`, `Depends`, `Settings`, `S3StorageAdapter`, `VLMClient`) were removed from each edited router. Pre-existing unused imports (e.g. `practice.py` `get_settings`/`Document`, `test_exams.py` `cast`) were left untouched per surgical-changes policy.
- No new automated tests were added because this is a pure alias canonicalization with no new behavior; existing API tests plus the import check and OpenAPI diff verify behavior preservation.

## Tests

Commands run (using the repo venv; `uv run --frozen --extra dev` is the documented equivalent):

- `cd backend && python -c "from app.presentation.deps import DatabaseDependency, StorageDependency, HelperVLMDependency, CurrentUserDependency, SettingsDependency"` — passed.
- `cd backend && python -c "import app.presentation.tags, app.presentation.home, app.presentation.folders, app.presentation.coaching, app.presentation.media, app.presentation.practice, app.presentation.bulk_ingestion, app.presentation.ingestion, app.presentation.exams"` — passed (all routers import cleanly).
- `cd backend && ruff check <edited files>` — no new errors introduced; the 3 remaining ruff findings (`practice.py` `get_settings`/`Document`, `test_exams.py` `cast`) are pre-existing unused imports confirmed via `git show HEAD:`.
- `cd backend && pytest tests/api/test_exams.py tests/api/test_tags.py tests/api/test_bulk_ingestion.py tests/api/test_ingestion.py tests/api/test_practice.py tests/api/test_practice_submit.py tests/api/test_home.py tests/api/test_folders.py tests/api/test_coaching.py tests/api/test_problems.py tests/api/test_auth.py -q` — passed (242 passed).
- `cd backend && pytest -q` (full backend suite) — **707 passed, 1 skipped**.
- OpenAPI schema generated before and after the change and diffed — **no diff** (54 paths, unchanged schema).

Automated tests added or updated:

- No new tests added (pure refactor; existing tests verify behavior). Test wiring updated in `tests/api/test_exams.py`, `tests/api/test_ingestion.py`, and `tests/integration/conftest.py` to use canonical dependency references.

Manual verification:

- Confirmed OpenAPI schema is byte-for-byte identical before and after the change.
- Confirmed no endpoint parameter names changed (only alias definitions moved/replaced).

## Deviations From Issue Plan

None. The `exams.py` `Depends(get_settings)` was converted (rather than deferred) as explicitly allowed by step 7 of the issue plan; this achieves full canonicalization of `SettingsDependency`.

## Follow-Up Work

- `problems.py` still declares a local `CurrentUserDependency` duplicate and uses direct `Depends(get_settings)` at two endpoints. It was outside the issue's enumerated routers and is left for a possible follow-up.
