### PR TITLE
Move tag registration to a tags-owned persistence helper

### DIFF
--- a/backend/app/presentation/problem_creation.py
+++ b/backend/app/presentation/problem_creation.py
@@ -13,7 +13,7 @@ from app.domain import ProblemSubject, ProblemType, normalize_answer
 from app.presentation.errors import ApiError
 from app.presentation.helpers import normalize_tags
 from app.presentation.solution_generation import enqueue_solution_generation_task_for_problem
-from app.presentation.tags import _register_tags
+from app.presentation.tag_registration import _register_tags
 
 
 async def create_problem_from_draft(

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -20,7 +20,7 @@ from app.presentation.exam_helpers import problem_document_to_model
 from app.presentation.helpers import build_problem_image_url, get_all_descendant_folder_ids, get_owned_folder, get_owned_problem, normalize_tags, parse_object_id
 from app.presentation.schemas import CorrectAnswerPayload
 from app.presentation.solution_generation import regenerate_solution_task_for_problem
-from app.presentation.tags import _register_tags
+from app.presentation.tag_registration import _register_tags
 
 router = APIRouter(prefix="/problems", tags=["problems"])
 

--- a/backend/app/presentation/tag_registration.py
+++ b/backend/app/presentation/tag_registration.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from bson import ObjectId
+from pymongo.asynchronous.database import AsyncDatabase
+from pymongo.errors import BulkWriteError
+
+from app.infrastructure.storage.mongo import Document
+from app.presentation.helpers import normalize_tags
+
+
+async def _register_tags(database: AsyncDatabase[Document], user_id: ObjectId, tags: list[str]) -> None:
+    """Auto-register any new tags that don't already exist for the user.
+
+    Uses insert_many with ordered=False so that duplicate-key errors from
+    concurrent requests are silently skipped rather than aborting the batch.
+    """
+    normalized = normalize_tags(tags)
+    if not normalized:
+        return
+    existing = await database["tags"].find(
+        {"userId": user_id, "name": {"$in": normalized}}
+    ).to_list(length=None)
+    existing_names = {tag["name"] for tag in existing}
+    now = datetime.now(UTC)
+    new_tags = [
+        {"_id": ObjectId(), "userId": user_id, "name": name, "createdAt": now, "updatedAt": now}
+        for name in normalized
+        if name not in existing_names
+    ]
+    if new_tags:
+        try:
+            await database["tags"].insert_many(new_tags, ordered=False)
+        except BulkWriteError:
+            pass

--- a/backend/app/presentation/tags.py
+++ b/backend/app/presentation/tags.py
@@ -11,7 +11,7 @@ from pymongo.asynchronous.database import AsyncDatabase
 from app.infrastructure.storage.mongo import Document
 from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
-from app.presentation.helpers import normalize_tags, parse_object_id
+from app.presentation.helpers import parse_object_id
 
 router = APIRouter(prefix="/tags", tags=["tags"])
 
@@ -83,34 +83,6 @@ async def _count_problems_with_tag(database: AsyncDatabase[Document], user_id: O
     return await database["problems"].count_documents(
         {"userId": user_id, "tags": tag_name, "isDeleted": False}
     )
-
-
-async def _register_tags(database: AsyncDatabase[Document], user_id: ObjectId, tags: list[str]) -> None:
-    """Auto-register any new tags that don't already exist for the user.
-
-    Uses insert_many with ordered=False so that duplicate-key errors from
-    concurrent requests are silently skipped rather than aborting the batch.
-    """
-    from pymongo.errors import BulkWriteError
-
-    normalized = normalize_tags(tags)
-    if not normalized:
-        return
-    existing = await database["tags"].find(
-        {"userId": user_id, "name": {"$in": normalized}}
-    ).to_list(length=None)
-    existing_names = {tag["name"] for tag in existing}
-    now = datetime.now(UTC)
-    new_tags = [
-        {"_id": ObjectId(), "userId": user_id, "name": name, "createdAt": now, "updatedAt": now}
-        for name in normalized
-        if name not in existing_names
-    ]
-    if new_tags:
-        try:
-            await database["tags"].insert_many(new_tags, ordered=False)
-        except BulkWriteError:
-            pass
 
 
 @router.get("", response_model=TagListResponse)

--- a/backend/tests/presentation/test_tag_registration.py
+++ b/backend/tests/presentation/test_tag_registration.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from bson import ObjectId
+from pymongo.errors import BulkWriteError
+
+from app.presentation.tag_registration import _register_tags
+from tests.conftest import FakeDatabase
+
+
+def _make_tag(user_id: ObjectId, name: str) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "name": name,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_tags_empty_input_inserts_nothing() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+
+    await _register_tags(database, user_id, [])
+    assert len(database["tags"]._documents) == 0
+
+    await _register_tags(database, user_id, ["   ", ""])
+    assert len(database["tags"]._documents) == 0
+
+
+@pytest.mark.asyncio
+async def test_register_tags_skips_existing_tags() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+    database["tags"].seed(_make_tag(user_id, "algebra"))
+
+    await _register_tags(database, user_id, ["algebra", "geometry"])
+
+    tags = database["tags"]._documents
+    assert len(tags) == 2
+    names = {t["name"] for t in tags}
+    assert names == {"algebra", "geometry"}
+
+
+@pytest.mark.asyncio
+async def test_register_tags_all_duplicates_is_noop() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+    database["tags"].seed(_make_tag(user_id, "alpha"))
+    database["tags"].seed(_make_tag(user_id, "beta"))
+
+    await _register_tags(database, user_id, ["alpha", "beta"])
+
+    assert len(database["tags"]._documents) == 2
+
+
+@pytest.mark.asyncio
+async def test_register_tags_inserts_new_tags_with_correct_fields() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+
+    await _register_tags(database, user_id, ["calculus", "algebra"])
+
+    tags = database["tags"]._documents
+    assert len(tags) == 2
+    for tag in tags:
+        assert tag["userId"] == user_id
+        assert tag["name"] in {"calculus", "algebra"}
+        assert "_id" in tag
+        assert "createdAt" in tag
+        assert "updatedAt" in tag
+        assert tag["createdAt"] == tag["updatedAt"]
+
+
+@pytest.mark.asyncio
+async def test_register_tags_normalizes_input() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+
+    await _register_tags(database, user_id, ["  Algebra  ", "Algebra", "  Geometry  "])
+
+    tags = database["tags"]._documents
+    assert len(tags) == 2
+    names = {t["name"] for t in tags}
+    assert names == {"Algebra", "Geometry"}
+
+
+@pytest.mark.asyncio
+async def test_register_tags_tolerates_bulk_write_error() -> None:
+    database = FakeDatabase()
+    user_id = ObjectId()
+    mock_insert = AsyncMock(side_effect=BulkWriteError({}))
+
+    with patch.object(database["tags"], "insert_many", new=mock_insert):
+        await _register_tags(database, user_id, ["new-tag"])
+
+    mock_insert.assert_called_once()
+    _, kwargs = mock_insert.call_args
+    assert kwargs["ordered"] is False
+    assert len(database["tags"]._documents) == 0


### PR DESCRIPTION
## Summary

- Moves `_register_tags` from the router-private `presentation/tags.py` module into a dedicated tags-owned non-router persistence helper at `backend/app/presentation/tag_registration.py`.
- Updates all callers (`problems.py`, `problem_creation.py`) to import from the new helper module.
- Adds characterization tests covering empty input, duplicate skip, all-duplicate no-op, new tag insertion fields, normalization, and `BulkWriteError` tolerance.

## Linked Issue

Closes #412

## Issue Alignment

This PR implements the issue by:

- Creating `backend/app/presentation/tag_registration.py` as the tags-owned non-router persistence helper.
- Moving `_register_tags` into the new helper module without changing semantics.
- Updating the router (`tags.py`) and problem-creation callers (`problems.py`, `problem_creation.py`) to import from the new helper.
- Removing the router-private helper from `tags.py` (no compatibility export needed — no code in `tags.py` itself calls `_register_tags`).
- Adding characterization tests before the move to lock down current behavior.

Scope covered:

- Move `_register_tags` to `tag_registration.py`.
- Update all 3 call sites (1 in `problems.py`, 2 in `problem_creation.py`).
- Clean orphaned `normalize_tags` import from `tags.py` (only used by the moved function).
- Characterization tests for: empty input, duplicate skip, all-duplicate no-op, new tag insertion with correct fields, normalization (strip + dedup), `BulkWriteError` tolerance with `ordered=False`.

Out of scope / intentionally not included:

- No tag normalization logic changes (behavior preserved exactly).
- No duplicate handling changes.
- No `BulkWriteError` tolerance changes.
- No general tag API redesign.
- No unrelated router cleanup in `tags.py`.
- DB-writing code stays in the presentation layer (not moved to pure domain modules).

## Implementation Notes

- `_register_tags` was defined in `tags.py` but only called from `problems.py` and `problem_creation.py` — `tags.py` itself never called it.
- The `from pymongo.errors import BulkWriteError` import was moved from inside the function body to the module level in `tag_registration.py` (standard Python convention; behavior identical).
- `normalize_tags` was imported in `tags.py` solely for `_register_tags`; after the move, it was removed from `tags.py`'s imports (orphaned by this change).
- The function name `_register_tags` was kept unchanged to minimize churn; the module name `tag_registration` is the public interface.

## Tests

Commands run (using the repo venv; `uv run --frozen --extra dev` is the documented equivalent):

- `cd backend && python -c "from app.presentation.tag_registration import _register_tags"` — passed.
- `cd backend && pytest tests/presentation/test_tag_registration.py tests/api/test_tags.py tests/presentation/test_problem_creation.py tests/api/test_problems.py -x -q` — **71 passed** (6 new characterization + 65 existing).
- `cd backend && pytest -q` (full backend suite) — **713 passed, 1 skipped**.
- `cd backend && ruff check <edited files>` — no new errors introduced; all 6 remaining errors (5×E402 in `problem_creation.py` from logger-before-imports, 1×F841 in `problems.py:527` unused variable) are pre-existing, confirmed by stashing changes and re-running ruff on the original files (same 6 errors).

Automated tests added:

- `tests/presentation/test_tag_registration.py` — 6 characterization tests:
  - `test_register_tags_empty_input_inserts_nothing` — empty list and whitespace-only tags are no-ops.
  - `test_register_tags_skips_existing_tags` — existing tags are not re-inserted; only new tags are added.
  - `test_register_tags_all_duplicates_is_noop` — when all tags already exist, nothing is inserted.
  - `test_register_tags_inserts_new_tags_with_correct_fields` — new tags get `_id`, `userId`, `name`, `createdAt`, `updatedAt`.
  - `test_register_tags_normalizes_input` — tags are stripped and deduplicated before processing.
  - `test_register_tags_tolerates_bulk_write_error` — `insert_many(ordered=False)` raising `BulkWriteError` is silently caught; `ordered=False` verified via mock call args.

Manual verification:

- Confirmed `_register_tags` is no longer defined in `tags.py` (grep shows 0 results in that file).
- Confirmed all callers import from `app.presentation.tag_registration` (grep in worktree).
- No tag response shape, persistence shape, or duplicate behavior changed.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
