### PR TITLE
Remove stale-preview infrastructure dependency from domain state

### DIFF
--- a/backend/app/domain/state.py
+++ b/backend/app/domain/state.py
@@ -5,10 +5,10 @@ from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from app.infrastructure.config.settings import get_settings
-from app.infrastructure.vlm.client import FAILURE_CODE_STALE_PREVIEW
-
 from .models import IngestionPreviewStatus, ExamState
+
+# Domain-owned failure code for stale-preview recovery.
+FAILURE_CODE_STALE_PREVIEW = "vlm-stale-preview-timeout"
 
 
 class InvalidStateTransitionError(Exception):
@@ -19,7 +19,7 @@ def recover_stale_preview(
     preview: Mapping[str, Any],
     *,
     now: datetime | None = None,
-    extracting_window_seconds: float | None = None,
+    extracting_window_seconds: float,
 ) -> dict[str, Any] | None:
     status = preview.get("status")
     if status != "extracting":
@@ -34,11 +34,7 @@ def recover_stale_preview(
     if started_at.tzinfo is None:
         started_at = started_at.replace(tzinfo=UTC)
 
-    window = timedelta(
-        seconds=extracting_window_seconds
-        if extracting_window_seconds is not None
-        else get_settings().preview_extracting_window_seconds
-    )
+    window = timedelta(seconds=extracting_window_seconds)
     if current_time - started_at <= window:
         return None
 

--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from app.domain.state import FAILURE_CODE_STALE_PREVIEW as FAILURE_CODE_STALE_PREVIEW
 from app.infrastructure.vlm.base_client import (
     FAILURE_CODE_INVALID_RESPONSE,
     FAILURE_CODE_NETWORK,
@@ -38,8 +39,6 @@ from app.infrastructure.vlm.prompts import (
 )
 
 ProblemType = Literal["single-choice", "multi-choice", "fill-in-the-blank", "short-answer"]
-
-FAILURE_CODE_STALE_PREVIEW = "vlm-stale-preview-timeout"
 
 
 class VLMError(BaseVLMError):

--- a/backend/tests/domain/test_state.py
+++ b/backend/tests/domain/test_state.py
@@ -1,3 +1,6 @@
+import copy
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from app.domain import (
     IngestionPreviewStatus,
@@ -6,6 +9,10 @@ from app.domain import (
     transition_exam_state,
     InvalidStateTransitionError,
 )
+from app.domain.state import recover_stale_preview
+
+# Domain-owned constant value used as the failure code for stale-preview recovery.
+_STALE_PREVIEW_FAILURE_CODE = "vlm-stale-preview-timeout"
 
 
 def test_preview_valid_transitions():
@@ -32,3 +39,120 @@ def test_exam_valid_transitions():
 def test_exam_invalid_transitions():
     with pytest.raises(InvalidStateTransitionError):
         transition_exam_state(ExamState.SUBMITTED, ExamState.IN_PROGRESS)
+
+
+# ---------------------------------------------------------------------------
+# Characterization tests for recover_stale_preview
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+
+def _stale_preview(**overrides) -> dict:
+    """Build a preview that is well past the extracting window."""
+    base = {
+        "status": "extracting",
+        "createdAt": _NOW - timedelta(seconds=200),
+        "updatedAt": _NOW - timedelta(seconds=200),
+        "extraction": {
+            "requestStartedAt": _NOW - timedelta(seconds=200),
+            "requestFinishedAt": None,
+            "success": None,
+            "failureCode": None,
+            "failureMessage": None,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def test_recover_stale_preview_non_extracting_status_returns_none() -> None:
+    """Non-'extracting' status previews are never recovered."""
+    for status in ("uploaded", "ready", "vlm-failed", "confirmed", "expired"):
+        preview = _stale_preview(status=status)
+        assert recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30) is None
+
+
+def test_recover_stale_preview_falls_back_to_updated_at() -> None:
+    """When extraction.requestStartedAt is missing, falls back to updatedAt."""
+    preview = _stale_preview(extraction={})
+    recovered = recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30)
+    assert recovered is not None
+    assert recovered["status"] == "vlm-failed"
+
+
+def test_recover_stale_preview_falls_back_to_created_at() -> None:
+    """When requestStartedAt and updatedAt are missing, falls back to createdAt."""
+    preview = _stale_preview(extraction={})
+    preview["updatedAt"] = None
+    recovered = recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30)
+    assert recovered is not None
+
+
+def test_recover_stale_preview_non_datetime_started_at_returns_none() -> None:
+    """When started_at resolves to a truthy non-datetime, returns None (no fallback)."""
+    preview = _stale_preview(extraction={"requestStartedAt": "2024-01-01"})
+    assert recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30) is None
+
+
+def test_recover_stale_preview_all_started_at_sources_none_returns_none() -> None:
+    """When no started_at source is a datetime, returns None."""
+    preview = _stale_preview(extraction={})
+    preview["extraction"]["requestStartedAt"] = None
+    preview["updatedAt"] = None
+    preview["createdAt"] = None
+    assert recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30) is None
+
+
+def test_recover_stale_preview_naive_datetime_gets_utc() -> None:
+    """Naive datetime (no tzinfo) is treated as UTC."""
+    naive_started = datetime(2026, 1, 15, 11, 57, 0)  # 200s before _NOW, no tzinfo
+    preview = _stale_preview()
+    preview["extraction"]["requestStartedAt"] = naive_started
+    recovered = recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30)
+    assert recovered is not None
+    assert recovered["status"] == "vlm-failed"
+
+
+def test_recover_stale_preview_does_not_mutate_input() -> None:
+    """The input preview mapping is never mutated."""
+    preview = _stale_preview()
+    original = copy.deepcopy(preview)
+    recovered = recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30)
+    assert recovered is not None
+    assert preview == original
+    assert preview["status"] == "extracting"
+    assert preview["extraction"]["failureCode"] is None
+    assert preview["extraction"]["success"] is None
+
+
+def test_recover_stale_preview_exact_failure_code() -> None:
+    """Recovered preview uses the exact domain failure code."""
+    recovered = recover_stale_preview(_stale_preview(), now=_NOW, extracting_window_seconds=30)
+    assert recovered is not None
+    assert recovered["extraction"]["failureCode"] == _STALE_PREVIEW_FAILURE_CODE
+
+
+def test_recover_stale_preview_exact_recovered_shape() -> None:
+    """Recovered preview has the exact expected document shape."""
+    preview = _stale_preview()
+    recovered = recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30)
+    assert recovered is not None
+    # Changed fields
+    assert recovered["status"] == "vlm-failed"
+    assert recovered["updatedAt"] == _NOW
+    # Extraction update fields
+    assert recovered["extraction"]["success"] is False
+    assert recovered["extraction"]["requestFinishedAt"] == _NOW
+    assert recovered["extraction"]["failureCode"] == _STALE_PREVIEW_FAILURE_CODE
+    assert recovered["extraction"]["failureMessage"] == "Preview extraction exceeded the configured extracting window."
+    # Preserved fields
+    assert recovered["createdAt"] == preview["createdAt"]
+    assert recovered["extraction"]["requestStartedAt"] == preview["extraction"]["requestStartedAt"]
+
+
+def test_recover_stale_preview_fresh_extraction_returns_none() -> None:
+    """A preview within the extracting window is not recovered."""
+    preview = _stale_preview()
+    preview["extraction"]["requestStartedAt"] = _NOW - timedelta(seconds=10)
+    assert recover_stale_preview(preview, now=_NOW, extracting_window_seconds=30) is None


### PR DESCRIPTION
## Summary

- Removes the infrastructure dependency from `domain/state.py` by defining `FAILURE_CODE_STALE_PREVIEW` as a domain-owned constant and making `extracting_window_seconds` a required parameter of `recover_stale_preview`.
- Updates `infrastructure/vlm/client.py` to re-export `FAILURE_CODE_STALE_PREVIEW` from the domain (correct dependency direction: infrastructure depends on domain, not vice versa).
- Adds 10 characterization tests for `recover_stale_preview` covering all issue-required behavior cases.

## Linked Issue

Closes #411

## Issue Alignment

This PR implements the issue by:

- Defining `FAILURE_CODE_STALE_PREVIEW = "vlm-stale-preview-timeout"` as a domain-owned constant in `domain/state.py` (the value is domain policy — it describes what happens when a preview extraction times out).
- Making `extracting_window_seconds` a required parameter of `recover_stale_preview` (caller-configured, not infrastructure-defaulted). The sole caller (`ingestion_workflow.py`) already passes it explicitly.
- Removing both infrastructure imports from `domain/state.py`: `from app.infrastructure.config.settings import get_settings` and `from app.infrastructure.vlm.client import FAILURE_CODE_STALE_PREVIEW`.
- Updating `infrastructure/vlm/client.py` to re-export `FAILURE_CODE_STALE_PREVIEW` from `app.domain.state` using the `import X as X` re-export idiom, preserving the existing export chain (`vlm/__init__.py` → `vlm/client.py` → `domain/state.py`).
- Adding characterization tests before the refactor to lock down current behavior.

Scope covered:

- Define domain-owned `FAILURE_CODE_STALE_PREVIEW` constant in `domain/state.py`.
- Make `extracting_window_seconds` a required parameter (remove `None` default and `get_settings()` fallback).
- Remove both infrastructure imports from `domain/state.py`.
- Re-export `FAILURE_CODE_STALE_PREVIEW` from `infrastructure/vlm/client.py` (no external imports change).
- 10 characterization tests covering: non-`extracting` status, `started_at` fallback chain (updatedAt → createdAt), non-datetime `started_at`, all-None sources, naive datetime UTC handling, no-input-mutation, exact failure code, exact recovered document shape, and fresh extraction no-op.

Out of scope / intentionally not included:

- No stale-preview recovery semantics changes (behavior preserved exactly).
- No durable preview task redesign.
- No ingestion workflow redesign.
- No worker, storage, or VLM restructuring.
- No concurrency changes.
- No API contract or schema changes.
- No cleanup of pre-existing unused imports in `vlm/client.py` (11 pre-existing F401 ruff findings left untouched).
- The `domain/coaching/service.py` infrastructure dependency is a separate issue and was not touched.

## Implementation Notes

- `FAILURE_CODE_STALE_PREVIEW` was defined in `infrastructure/vlm/client.py` but never used there — it was only defined for other modules to import. Moving it to the domain is the correct ownership.
- The `from app.domain.state import FAILURE_CODE_STALE_PREVIEW as FAILURE_CODE_STALE_PREVIEW` re-export idiom in `vlm/client.py` tells ruff the import is intentionally re-exported (no new F401 error).
- No circular import risk: `domain/__init__.py` imports from `.models`, `.normalization`, `.selection`, `.state`, `.scoring` — none of these import from `infrastructure/vlm` (verified by grep). The `domain/coaching/service.py` infrastructure import is not loaded by `domain/__init__.py`.
- The sole caller `ingestion_workflow.py:297-300` already passes `extracting_window_seconds=settings.preview_extracting_window_seconds`, so making the parameter required has no runtime effect.
- Existing tests in `tests/infrastructure/test_vlm.py` (lines 603-635) already pass `extracting_window_seconds=30` explicitly — no test changes needed.
- Characterization tests use string literals for the failure code (`"vlm-stale-preview-timeout"`) rather than importing the constant, so they are independent of the constant's location.

## Tests

Commands run (using the repo venv; `uv run --frozen --extra dev` is the documented equivalent):

- `cd backend && python -c "from app.domain.state import recover_stale_preview, FAILURE_CODE_STALE_PREVIEW; from app.infrastructure.vlm.client import FAILURE_CODE_STALE_PREVIEW as vlm_fc; assert FAILURE_CODE_STALE_PREVIEW == vlm_fc == 'vlm-stale-preview-timeout'; print('OK')"` — passed (no circular import).
- `cd backend && pytest tests/domain/test_state.py tests/infrastructure/test_vlm.py tests/api/test_ingestion.py tests/integration/test_ingestion_workflow.py -x -q` — **115 passed** (10 new characterization + 105 existing).
- `cd backend && pytest -q` (full backend suite) — **717 passed, 1 skipped** (707 baseline + 10 new).
- `cd backend && ruff check app/domain/state.py app/infrastructure/vlm/client.py tests/domain/test_state.py` — no new errors; all 11 remaining F401 findings in `vlm/client.py` are pre-existing (confirmed by stashing changes and re-running ruff: 11 errors before and after).

Automated tests added:

- `tests/domain/test_state.py` — 10 characterization tests for `recover_stale_preview`:
  - `test_recover_stale_preview_non_extracting_status_returns_none` — non-`extracting` status previews are never recovered.
  - `test_recover_stale_preview_falls_back_to_updated_at` — when `requestStartedAt` is missing, falls back to `updatedAt`.
  - `test_recover_stale_preview_falls_back_to_created_at` — when `requestStartedAt` and `updatedAt` are missing, falls back to `createdAt`.
  - `test_recover_stale_preview_non_datetime_started_at_returns_none` — truthy non-datetime `requestStartedAt` does not fall back; returns None.
  - `test_recover_stale_preview_all_started_at_sources_none_returns_none` — all sources None → returns None.
  - `test_recover_stale_preview_naive_datetime_gets_utc` — naive datetime (no tzinfo) is treated as UTC.
  - `test_recover_stale_preview_does_not_mutate_input` — input preview is never mutated (deep-copy verified).
  - `test_recover_stale_preview_exact_failure_code` — recovered preview uses `"vlm-stale-preview-timeout"`.
  - `test_recover_stale_preview_exact_recovered_shape` — exact document shape: status, updatedAt, extraction.success, requestFinishedAt, failureCode, failureMessage, preserved fields.
  - `test_recover_stale_preview_fresh_extraction_returns_none` — preview within the extracting window is not recovered.

Manual verification:

- Confirmed `domain/state.py` no longer imports from `app.infrastructure` (grep shows 0 matches for `from app.infrastructure` in that file).
- Confirmed `infrastructure/vlm/client.py` re-exports `FAILURE_CODE_STALE_PREVIEW` from `app.domain.state` (correct dependency direction).
- No stale-preview recovery semantics changed: same failure code, same document shape, same datetime handling, same input-mutation behavior.

## Deviations From Issue Plan

None. The chosen approach (domain-owned constant for `FAILURE_CODE_STALE_PREVIEW`, caller-configured for `extracting_window_seconds`) follows the issue's guidance: "defining a domain-owned constant if the value is truly domain policy" and "passing the needed recovery threshold/configuration from the caller."

## Follow-Up Work

None.
