### PR TITLE
LL-A4: Extract bulk-ingestion response serialization only

### DIFF
--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -58,87 +58,22 @@ from app.presentation.deps import (
     SettingsDependency,
     StorageDependency,
 )
+from app.presentation.bulk_serialization import (
+    BatchResponse,
+    SubmitItemResult,
+    SubmitSummaryPayload,
+    SubmitSummaryResponse,
+    _build_submit_result,
+    serialize_batch,
+)
 from app.presentation.errors import ApiError
 from app.presentation.helpers import (
-    build_ingestion_crop_url,
-    build_ingestion_source_image_url,
     normalize_tags,
     parse_object_id,
 )
 from app.presentation.problem_creation import create_problem_from_draft
-from app.presentation.schemas import SourceImagePayload
 
 router = APIRouter(prefix="/ingestion-batches", tags=["bulk-ingestion"])
-
-
-class DetectionResponse(BaseModel):
-    model: str | None
-    rawProviderResponse: Any | None
-    failureCode: str | None
-    failureMessage: str | None
-
-
-class ImageResponse(BaseModel):
-    imageId: str
-    status: str
-    order: int
-    sourceImage: SourceImagePayload
-    subject: str | None
-    boxes: list[dict[str, Any]]
-    detection: DetectionResponse
-    committedAt: datetime | None
-    createdAt: datetime
-    updatedAt: datetime
-
-
-class ItemResponse(BaseModel):
-    itemId: str
-    imageId: str
-    batchId: str
-    status: str
-    order: int
-    draft: dict[str, Any]
-    extraction: dict[str, Any]
-    retryCount: int
-    submit: dict[str, Any]
-    origin: dict[str, Any]
-    crop: dict[str, Any] | None
-    leaseUntil: datetime | None
-    createdAt: datetime
-    updatedAt: datetime
-
-
-class BatchPayload(BaseModel):
-    id: str
-    userId: str
-    status: str
-    images: list[ImageResponse]
-    items: list[ItemResponse]
-    createdAt: datetime
-    updatedAt: datetime
-    expiresAt: datetime
-
-
-class BatchResponse(BaseModel):
-    batch: BatchPayload
-
-
-class SubmitItemResult(BaseModel):
-    itemId: str
-    status: str
-    submittedProblemId: str | None = None
-    failureCode: str | None = None
-    failureMessage: str | None = None
-
-
-class SubmitSummaryPayload(BaseModel):
-    batchId: str
-    status: str
-    items: list[SubmitItemResult]
-
-
-class SubmitSummaryResponse(BaseModel):
-    submitSummary: SubmitSummaryPayload
 
 
 def _guess_extension(upload: UploadFile) -> str:
@@ -151,100 +86,6 @@ def _guess_extension(upload: UploadFile) -> str:
         if guessed:
             return guessed
     return ".bin"
-
-
-def _serialize_source_image(
-    source_image: dict[str, Any],
-    batch_id: str | None = None,
-    image_id: str | None = None,
-) -> dict[str, Any]:
-    data: dict[str, Any] = {
-        "bucket": source_image["bucket"],
-        "objectKey": source_image["objectKey"],
-        "contentType": source_image.get("contentType"),
-        "sizeBytes": source_image.get("sizeBytes"),
-        "sha256": source_image.get("sha256"),
-        "width": source_image.get("width"),
-        "height": source_image.get("height"),
-        "uploadedAt": source_image.get("uploadedAt"),
-    }
-    if batch_id and image_id:
-        data["mediaUrl"] = build_ingestion_source_image_url(batch_id, image_id)
-    return data
-
-
-def _serialize_image(image: dict[str, Any], batch_id: str | None = None) -> dict[str, Any]:
-    detection = image.get("detection") or {}
-    return {
-        "imageId": image["imageId"],
-        "status": image["status"],
-        "order": image["order"],
-        "sourceImage": _serialize_source_image(
-            image.get("sourceImage") or {}, batch_id=batch_id, image_id=image.get("imageId")
-        ),
-        "subject": image.get("subject"),
-        "boxes": list(image.get("boxes", [])),
-        "detection": {
-            "model": detection.get("model"),
-            "rawProviderResponse": detection.get("rawProviderResponse"),
-            "failureCode": detection.get("failureCode"),
-            "failureMessage": detection.get("failureMessage"),
-        },
-        "committedAt": image.get("committedAt"),
-        "createdAt": image["createdAt"],
-        "updatedAt": image["updatedAt"],
-    }
-
-
-def _serialize_item(item: dict[str, Any], batch_id: str | None = None) -> dict[str, Any]:
-    crop = item.get("crop")
-    if crop and batch_id:
-        crop = dict(crop)
-        crop["mediaUrl"] = build_ingestion_crop_url(batch_id, item["itemId"])
-    return {
-        "itemId": item["itemId"],
-        "imageId": item["imageId"],
-        "batchId": str(item["batchId"]),
-        "status": item["status"],
-        "order": item["order"],
-        "draft": dict(item.get("draft", {})),
-        "extraction": dict(item.get("extraction", {})),
-        "retryCount": item.get("retryCount", 0),
-        "submit": dict(item.get("submit", {})),
-        "origin": dict(item.get("origin", {})),
-        "crop": crop,
-        "leaseUntil": item.get("leaseUntil"),
-        "createdAt": item["createdAt"],
-        "updatedAt": item["updatedAt"],
-    }
-
-
-def serialize_batch(batch: Document, *, include_deleted: bool = False) -> dict[str, Any]:
-    batch_id = str(batch["_id"])
-    if include_deleted:
-        images = list(batch.get("images", []))
-        items = list(batch.get("items", []))
-    else:
-        images = [
-            image for image in batch.get("images", [])
-            if image.get("status") != ImageState.DELETED.value
-        ]
-        items = [
-            item for item in batch.get("items", [])
-            if item.get("status") != ItemState.DELETED.value
-        ]
-    return {
-        "batch": {
-            "id": batch_id,
-            "userId": str(batch["userId"]),
-            "status": batch["status"],
-            "images": [_serialize_image(image, batch_id=batch_id) for image in images],
-            "items": [_serialize_item(item, batch_id=batch_id) for item in items],
-            "createdAt": batch["createdAt"],
-            "updatedAt": batch["updatedAt"],
-            "expiresAt": batch["expiresAt"],
-        }
-    }
 
 
 def _find_image_or_404(batch: Document, image_id: str) -> dict[str, Any]:
@@ -762,17 +603,6 @@ async def undo_delete_item_endpoint(
     if updated_batch is None:
         raise ApiError(404, "NOT_FOUND", "Batch not found")
     return BatchResponse(**serialize_batch(updated_batch, include_deleted=True))
-
-
-def _build_submit_result(item: dict[str, Any]) -> SubmitItemResult:
-    submit = dict(item.get("submit") or {})
-    return SubmitItemResult(
-        itemId=item["itemId"],
-        status=item["status"],
-        submittedProblemId=submit.get("submittedProblemId"),
-        failureCode=submit.get("failureCode"),
-        failureMessage=submit.get("failureMessage"),
-    )
 
 
 @router.post("/{batch_id}/submit", response_model=SubmitSummaryResponse)

--- a/backend/app/presentation/bulk_serialization.py
+++ b/backend/app/presentation/bulk_serialization.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from app.domain.ingestion import ImageState, ItemState
+from app.infrastructure.storage.mongo import Document
+from app.presentation.helpers import (
+    build_ingestion_crop_url,
+    build_ingestion_source_image_url,
+)
+from app.presentation.schemas import SourceImagePayload
+
+
+class DetectionResponse(BaseModel):
+    model: str | None
+    rawProviderResponse: Any | None
+    failureCode: str | None
+    failureMessage: str | None
+
+
+class ImageResponse(BaseModel):
+    imageId: str
+    status: str
+    order: int
+    sourceImage: SourceImagePayload
+    subject: str | None
+    boxes: list[dict[str, Any]]
+    detection: DetectionResponse
+    committedAt: datetime | None
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class ItemResponse(BaseModel):
+    itemId: str
+    imageId: str
+    batchId: str
+    status: str
+    order: int
+    draft: dict[str, Any]
+    extraction: dict[str, Any]
+    retryCount: int
+    submit: dict[str, Any]
+    origin: dict[str, Any]
+    crop: dict[str, Any] | None
+    leaseUntil: datetime | None
+    createdAt: datetime
+    updatedAt: datetime
+
+
+class BatchPayload(BaseModel):
+    id: str
+    userId: str
+    status: str
+    images: list[ImageResponse]
+    items: list[ItemResponse]
+    createdAt: datetime
+    updatedAt: datetime
+    expiresAt: datetime
+
+
+class BatchResponse(BaseModel):
+    batch: BatchPayload
+
+
+class SubmitItemResult(BaseModel):
+    itemId: str
+    status: str
+    submittedProblemId: str | None = None
+    failureCode: str | None = None
+    failureMessage: str | None = None
+
+
+class SubmitSummaryPayload(BaseModel):
+    batchId: str
+    status: str
+    items: list[SubmitItemResult]
+
+
+class SubmitSummaryResponse(BaseModel):
+    submitSummary: SubmitSummaryPayload
+
+
+def _serialize_source_image(
+    source_image: dict[str, Any],
+    batch_id: str | None = None,
+    image_id: str | None = None,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "bucket": source_image["bucket"],
+        "objectKey": source_image["objectKey"],
+        "contentType": source_image.get("contentType"),
+        "sizeBytes": source_image.get("sizeBytes"),
+        "sha256": source_image.get("sha256"),
+        "width": source_image.get("width"),
+        "height": source_image.get("height"),
+        "uploadedAt": source_image.get("uploadedAt"),
+    }
+    if batch_id and image_id:
+        data["mediaUrl"] = build_ingestion_source_image_url(batch_id, image_id)
+    return data
+
+
+def _serialize_image(image: dict[str, Any], batch_id: str | None = None) -> dict[str, Any]:
+    detection = image.get("detection") or {}
+    return {
+        "imageId": image["imageId"],
+        "status": image["status"],
+        "order": image["order"],
+        "sourceImage": _serialize_source_image(
+            image.get("sourceImage") or {}, batch_id=batch_id, image_id=image.get("imageId")
+        ),
+        "subject": image.get("subject"),
+        "boxes": list(image.get("boxes", [])),
+        "detection": {
+            "model": detection.get("model"),
+            "rawProviderResponse": detection.get("rawProviderResponse"),
+            "failureCode": detection.get("failureCode"),
+            "failureMessage": detection.get("failureMessage"),
+        },
+        "committedAt": image.get("committedAt"),
+        "createdAt": image["createdAt"],
+        "updatedAt": image["updatedAt"],
+    }
+
+
+def _serialize_item(item: dict[str, Any], batch_id: str | None = None) -> dict[str, Any]:
+    crop = item.get("crop")
+    if crop and batch_id:
+        crop = dict(crop)
+        crop["mediaUrl"] = build_ingestion_crop_url(batch_id, item["itemId"])
+    return {
+        "itemId": item["itemId"],
+        "imageId": item["imageId"],
+        "batchId": str(item["batchId"]),
+        "status": item["status"],
+        "order": item["order"],
+        "draft": dict(item.get("draft", {})),
+        "extraction": dict(item.get("extraction", {})),
+        "retryCount": item.get("retryCount", 0),
+        "submit": dict(item.get("submit", {})),
+        "origin": dict(item.get("origin", {})),
+        "crop": crop,
+        "leaseUntil": item.get("leaseUntil"),
+        "createdAt": item["createdAt"],
+        "updatedAt": item["updatedAt"],
+    }
+
+
+def serialize_batch(batch: Document, *, include_deleted: bool = False) -> dict[str, Any]:
+    batch_id = str(batch["_id"])
+    if include_deleted:
+        images = list(batch.get("images", []))
+        items = list(batch.get("items", []))
+    else:
+        images = [
+            image for image in batch.get("images", [])
+            if image.get("status") != ImageState.DELETED.value
+        ]
+        items = [
+            item for item in batch.get("items", [])
+            if item.get("status") != ItemState.DELETED.value
+        ]
+    return {
+        "batch": {
+            "id": batch_id,
+            "userId": str(batch["userId"]),
+            "status": batch["status"],
+            "images": [_serialize_image(image, batch_id=batch_id) for image in images],
+            "items": [_serialize_item(item, batch_id=batch_id) for item in items],
+            "createdAt": batch["createdAt"],
+            "updatedAt": batch["updatedAt"],
+            "expiresAt": batch["expiresAt"],
+        }
+    }
+
+
+def _build_submit_result(item: dict[str, Any]) -> SubmitItemResult:
+    submit = dict(item.get("submit") or {})
+    return SubmitItemResult(
+        itemId=item["itemId"],
+        status=item["status"],
+        submittedProblemId=submit.get("submittedProblemId"),
+        failureCode=submit.get("failureCode"),
+        failureMessage=submit.get("failureMessage"),
+    )

--- a/backend/tests/presentation/test_bulk_serialization.py
+++ b/backend/tests/presentation/test_bulk_serialization.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import copy
+from datetime import UTC, datetime
+from typing import Any
+
+from bson import ObjectId
+
+from app.domain.ingestion import ImageState, ItemState
+from app.presentation.bulk_serialization import (
+    BatchResponse,
+    SubmitItemResult,
+    _build_submit_result,
+    serialize_batch,
+)
+
+NOW = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+BATCH_ID = ObjectId.from_datetime(NOW)
+BATCH_ID_STR = str(BATCH_ID)
+
+
+def _make_source_image(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "bucket": "test-bucket",
+        "objectKey": "obj-1",
+        "contentType": "image/png",
+        "sizeBytes": 100,
+        "sha256": "abc123",
+        "width": 10,
+        "height": 10,
+        "uploadedAt": NOW,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_image(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "imageId": "img-1",
+        "status": ImageState.READY.value,
+        "order": 0,
+        "sourceImage": _make_source_image(),
+        "subject": "math",
+        "boxes": [{"x": 1, "y": 2, "w": 3, "h": 4}],
+        "detection": {
+            "model": "vlm-1",
+            "rawProviderResponse": {"foo": "bar"},
+            "failureCode": None,
+            "failureMessage": None,
+        },
+        "committedAt": None,
+        "createdAt": NOW,
+        "updatedAt": NOW,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_item(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "itemId": "item-1",
+        "imageId": "img-1",
+        "batchId": BATCH_ID,
+        "status": ItemState.READY.value,
+        "order": 0,
+        "draft": {"text": "question"},
+        "extraction": {"raw": "data"},
+        "retryCount": 0,
+        "submit": {},
+        "origin": {"source": "upload"},
+        "crop": {
+            "bucket": "test-bucket",
+            "objectKey": "crop-1",
+            "contentType": "image/png",
+        },
+        "leaseUntil": None,
+        "createdAt": NOW,
+        "updatedAt": NOW,
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_batch(images: list | None = None, items: list | None = None, **overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "_id": BATCH_ID,
+        "userId": ObjectId.from_datetime(NOW),
+        "status": "active",
+        "images": images if images is not None else [_make_image()],
+        "items": items if items is not None else [_make_item()],
+        "createdAt": NOW,
+        "updatedAt": NOW,
+        "expiresAt": NOW,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Complete response shape
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_batch_complete_shape():
+    batch = _make_batch()
+    result = serialize_batch(batch)
+
+    assert set(result.keys()) == {"batch"}
+    payload = result["batch"]
+    assert payload["id"] == BATCH_ID_STR
+    assert payload["userId"] == str(batch["userId"])
+    assert payload["status"] == "active"
+    assert payload["createdAt"] == NOW
+    assert payload["updatedAt"] == NOW
+    assert payload["expiresAt"] == NOW
+
+    image = payload["images"][0]
+    assert image == {
+        "imageId": "img-1",
+        "status": "ready",
+        "order": 0,
+        "sourceImage": {
+            "bucket": "test-bucket",
+            "objectKey": "obj-1",
+            "contentType": "image/png",
+            "sizeBytes": 100,
+            "sha256": "abc123",
+            "width": 10,
+            "height": 10,
+            "uploadedAt": NOW,
+            "mediaUrl": "/api/v1/ingestion-batches/{}/images/img-1/source".format(BATCH_ID_STR),
+        },
+        "subject": "math",
+        "boxes": [{"x": 1, "y": 2, "w": 3, "h": 4}],
+        "detection": {
+            "model": "vlm-1",
+            "rawProviderResponse": {"foo": "bar"},
+            "failureCode": None,
+            "failureMessage": None,
+        },
+        "committedAt": None,
+        "createdAt": NOW,
+        "updatedAt": NOW,
+    }
+
+    item = payload["items"][0]
+    assert item == {
+        "itemId": "item-1",
+        "imageId": "img-1",
+        "batchId": BATCH_ID_STR,
+        "status": "ready",
+        "order": 0,
+        "draft": {"text": "question"},
+        "extraction": {"raw": "data"},
+        "retryCount": 0,
+        "submit": {},
+        "origin": {"source": "upload"},
+        "crop": {
+            "bucket": "test-bucket",
+            "objectKey": "crop-1",
+            "contentType": "image/png",
+            "mediaUrl": "/api/v1/ingestion-batches/{}/items/item-1/crop".format(BATCH_ID_STR),
+        },
+        "leaseUntil": None,
+        "createdAt": NOW,
+        "updatedAt": NOW,
+    }
+
+
+def test_serialize_batch_validates_as_batch_response():
+    """The serialized dict must be accepted by the BatchResponse model."""
+    batch = _make_batch()
+    result = serialize_batch(batch)
+    response = BatchResponse(**result)
+    assert response.batch.id == BATCH_ID_STR
+
+
+# ---------------------------------------------------------------------------
+# include_deleted True / False
+# ---------------------------------------------------------------------------
+
+
+def test_include_deleted_false_filters_deleted_images_and_items():
+    deleted_image = _make_image(
+        imageId="img-deleted",
+        status=ImageState.DELETED.value,
+        sourceImage=_make_source_image(objectKey="obj-deleted"),
+    )
+    deleted_item = _make_item(
+        itemId="item-deleted",
+        status=ItemState.DELETED.value,
+        crop=None,
+    )
+    batch = _make_batch(images=[_make_image(), deleted_image], items=[_make_item(), deleted_item])
+
+    result = serialize_batch(batch, include_deleted=False)
+    image_ids = [img["imageId"] for img in result["batch"]["images"]]
+    item_ids = [it["itemId"] for it in result["batch"]["items"]]
+    assert image_ids == ["img-1"]
+    assert item_ids == ["item-1"]
+
+
+def test_include_deleted_true_keeps_deleted_images_and_items():
+    deleted_image = _make_image(
+        imageId="img-deleted",
+        status=ImageState.DELETED.value,
+        sourceImage=_make_source_image(objectKey="obj-deleted"),
+    )
+    deleted_item = _make_item(
+        itemId="item-deleted",
+        status=ItemState.DELETED.value,
+        crop=None,
+    )
+    batch = _make_batch(images=[_make_image(), deleted_image], items=[_make_item(), deleted_item])
+
+    result = serialize_batch(batch, include_deleted=True)
+    image_ids = [img["imageId"] for img in result["batch"]["images"]]
+    item_ids = [it["itemId"] for it in result["batch"]["items"]]
+    assert image_ids == ["img-1", "img-deleted"]
+    assert item_ids == ["item-1", "item-deleted"]
+
+
+# ---------------------------------------------------------------------------
+# Source image media URL present and omitted
+# ---------------------------------------------------------------------------
+
+
+def test_source_image_media_url_present():
+    batch = _make_batch()
+    result = serialize_batch(batch)
+    source_image = result["batch"]["images"][0]["sourceImage"]
+    assert "mediaUrl" in source_image
+    assert source_image["mediaUrl"] == "/api/v1/ingestion-batches/{}/images/img-1/source".format(BATCH_ID_STR)
+
+
+def test_source_image_media_url_omitted_when_image_id_missing():
+    """An image without an imageId still serializes but omits mediaUrl."""
+    batch = _make_batch(images=[_make_image(imageId="")])
+    result = serialize_batch(batch)
+    source_image = result["batch"]["images"][0]["sourceImage"]
+    assert "mediaUrl" not in source_image
+
+
+# ---------------------------------------------------------------------------
+# Crop media URL present and omitted
+# ---------------------------------------------------------------------------
+
+
+def test_crop_media_url_present():
+    batch = _make_batch()
+    result = serialize_batch(batch)
+    crop = result["batch"]["items"][0]["crop"]
+    assert "mediaUrl" in crop
+    assert crop["mediaUrl"] == "/api/v1/ingestion-batches/{}/items/item-1/crop".format(BATCH_ID_STR)
+
+
+def test_crop_media_url_omitted_when_crop_none():
+    batch = _make_batch(items=[_make_item(crop=None)])
+    result = serialize_batch(batch)
+    assert result["batch"]["items"][0]["crop"] is None
+
+
+# ---------------------------------------------------------------------------
+# Missing or None detection fields
+# ---------------------------------------------------------------------------
+
+
+def test_detection_fields_none_when_detection_missing():
+    batch = _make_batch(images=[_make_image(detection=None)])
+    result = serialize_batch(batch)
+    detection = result["batch"]["images"][0]["detection"]
+    assert detection == {
+        "model": None,
+        "rawProviderResponse": None,
+        "failureCode": None,
+        "failureMessage": None,
+    }
+
+
+def test_detection_fields_none_when_detection_empty():
+    batch = _make_batch(images=[_make_image(detection={})])
+    result = serialize_batch(batch)
+    detection = result["batch"]["images"][0]["detection"]
+    assert detection == {
+        "model": None,
+        "rawProviderResponse": None,
+        "failureCode": None,
+        "failureMessage": None,
+    }
+
+
+def test_detection_partial_fields_preserved():
+    batch = _make_batch(
+        images=[_make_image(detection={"model": "vlm-2", "failureCode": "oops"})]
+    )
+    result = serialize_batch(batch)
+    detection = result["batch"]["images"][0]["detection"]
+    assert detection == {
+        "model": "vlm-2",
+        "rawProviderResponse": None,
+        "failureCode": "oops",
+        "failureMessage": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# No input document mutation
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_batch_does_not_mutate_input():
+    batch = _make_batch()
+    snapshot = copy.deepcopy(batch)
+    serialize_batch(batch)
+    assert batch == snapshot
+
+
+def test_serialize_batch_does_not_mutate_input_with_deleted():
+    batch = _make_batch(
+        images=[_make_image(), _make_image(imageId="img-del", status=ImageState.DELETED.value)],
+        items=[_make_item(), _make_item(itemId="item-del", status=ItemState.DELETED.value, crop=None)],
+    )
+    snapshot = copy.deepcopy(batch)
+    serialize_batch(batch, include_deleted=True)
+    assert batch == snapshot
+
+
+def test_serialize_batch_does_not_mutate_crop_dict():
+    """The crop dict inside an item must not gain a mediaUrl key in the input."""
+    batch = _make_batch()
+    original_crop = copy.deepcopy(batch["items"][0]["crop"])
+    serialize_batch(batch)
+    assert batch["items"][0]["crop"] == original_crop
+
+
+# ---------------------------------------------------------------------------
+# _build_submit_result
+# ---------------------------------------------------------------------------
+
+
+def test_build_submit_result_ready_item():
+    item = _make_item(
+        status=ItemState.SUBMITTED.value,
+        submit={"submittedProblemId": "prob-1", "success": True, "failureCode": None, "failureMessage": None},
+    )
+    result = _build_submit_result(item)
+    assert result == SubmitItemResult(
+        itemId="item-1",
+        status=ItemState.SUBMITTED.value,
+        submittedProblemId="prob-1",
+        failureCode=None,
+        failureMessage=None,
+    )
+
+
+def test_build_submit_result_failed_item():
+    item = _make_item(
+        status=ItemState.SUBMIT_FAILED.value,
+        submit={"submittedProblemId": None, "success": False, "failureCode": "bad", "failureMessage": "oops"},
+    )
+    result = _build_submit_result(item)
+    assert result == SubmitItemResult(
+        itemId="item-1",
+        status=ItemState.SUBMIT_FAILED.value,
+        submittedProblemId=None,
+        failureCode="bad",
+        failureMessage="oops",
+    )
+
+
+def test_build_submit_result_missing_submit():
+    item = _make_item(submit=None)
+    result = _build_submit_result(item)
+    assert result.itemId == "item-1"
+    assert result.submittedProblemId is None
+    assert result.failureCode is None
+    assert result.failureMessage is None


### PR DESCRIPTION
## Summary

- Move bulk-ingestion response models and serializer functions from `app.presentation.bulk_ingestion` into a new presentation-local serialization module `app.presentation.bulk_serialization`.
- Add characterization tests that lock down current response serialization behavior before and after the structural move.
- Router orchestration, request models, and persistence behavior are unchanged.

## Linked Issue

Closes #414

## Issue Alignment

This PR implements the issue by:

- Adding characterization tests in `tests/presentation/test_bulk_serialization.py` covering all required cases: `include_deleted=True/False`, source image media URL present/omitted, crop media URL present/omitted, missing/None detection fields, complete response shape, and no-input-mutation.
- Moving only response models (`DetectionResponse`, `ImageResponse`, `ItemResponse`, `BatchPayload`, `BatchResponse`, `SubmitItemResult`, `SubmitSummaryPayload`, `SubmitSummaryResponse`) and serializer functions (`_serialize_source_image`, `_serialize_image`, `_serialize_item`, `serialize_batch`, `_build_submit_result`) into `app.presentation.bulk_serialization`.
- Updating `bulk_ingestion.py` to import the moved symbols from the new module.

Scope covered:

- Characterization tests for response serialization.
- Structural move of response models and serializers to a presentation-local module.
- Updated router imports.

Out of scope / intentionally not included:

- Request models (`SaveBoxesRequest`, `UpdateItemDraftRequest`) — left in `bulk_ingestion.py`.
- Endpoint orchestration or router logic changes — unchanged.
- `_find_image_or_404`, `_load_owned_batch`, `_load_owned_batch_for_read`, `_validate_image_upload` — untouched.
- `_guess_extension` deduplication — not included (postponed per issue).
- Persisted document changes — none.
- Worker, VLM, storage, concurrency, or durable preview task redesign — none.

## Implementation Notes

- The characterization tests were written and verified to pass **before** moving any production code, then re-verified to pass **after** the move.
- The moved code is verbatim — no logic changes, only a structural relocation.
- The `bulk_ingestion.py` router now imports `BatchResponse`, `SubmitItemResult`, `SubmitSummaryPayload`, `SubmitSummaryResponse`, `_build_submit_result`, and `serialize_batch` from `app.presentation.bulk_serialization`.
- No longer-needed imports (`SourceImagePayload`, `build_ingestion_crop_url`, `build_ingestion_source_image_url`) were removed from `bulk_ingestion.py`.

## Tests

Commands run:

- `PYTHONPATH=backend python -m pytest tests/presentation/test_bulk_serialization.py -q` — 17 passed (before and after the move)
- `PYTHONPATH=backend python -m pytest tests/presentation/test_bulk_serialization.py tests/api/test_bulk_ingestion.py -q` — 82 passed
- `PYTHONPATH=backend python -m pytest -q` — 771 passed, 1 skipped
- `ruff check backend/app/presentation/bulk_serialization.py backend/tests/presentation/test_bulk_serialization.py` — All checks passed

Automated tests added or updated:

- `tests/presentation/test_bulk_serialization.py` — 17 characterization tests covering complete response shape, `include_deleted` True/False, source image media URL present/omitted, crop media URL present/omitted, missing/None detection fields, no-input-mutation, and `_build_submit_result` for ready/failed/missing-submit items.

Manual verification:

- Verified that characterization tests pass before the structural move (locking down current behavior) and after the move (proving behavior preservation).
- Verified no request models, endpoint orchestration, or persistence behavior changed.
- Verified the change can be rolled back by reverting this PR.

## Deviations From Issue Plan

None.

## Follow-Up Work

None. `_guess_extension` deduplication remains postponed per the issue's Follow-Up Work section.