### PR TITLE
Consolidate auth API client methods onto generic helpers

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -101,3 +101,137 @@ describe("API Client postFormData", () => {
     }
   });
 });
+
+// Characterization tests for auth-related client methods. These pin the exact
+// request shape (URL, method, headers, credentials, body) so the methods can be
+// safely delegated to the generic this.get/this.post helpers without changing
+// runtime behavior. logout is intentionally NOT delegated because its request
+// shape (no Content-Type header, no body) differs from this.post.
+describe("API Client auth methods", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("getMe sends a request to /auth/me with credentials and returns the parsed response", async () => {
+    const meResponse = { authenticated: true, user: { id: "u1", username: "alice" } };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(meResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await api.getMe();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/auth/me", {
+      credentials: "include",
+    });
+    expect(result).toEqual(meResponse);
+  });
+
+  it("login sends a POST to /auth/login with JSON content type, credentials, and { username, password } body", async () => {
+    const authResponse = { user: { id: "u1", username: "alice" } };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(authResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await api.login("alice", "secret");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/auth/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ username: "alice", password: "secret" }),
+    });
+    expect(result).toEqual(authResponse);
+  });
+
+  it("register sends a POST to /auth/register with JSON content type, credentials, and { username, password } body", async () => {
+    const authResponse = { user: { id: "u2", username: "bob" } };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(authResponse),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await api.register("bob", "password");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/auth/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ username: "bob", password: "password" }),
+    });
+    expect(result).toEqual(authResponse);
+  });
+
+  it("verifyTeacherPassword sends a POST to /teacher-password/verify with JSON content type, credentials, and { password } body", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await api.verifyTeacherPassword("teacher-pw");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/teacher-password/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ password: "teacher-pw" }),
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("changeTeacherPassword sends a POST to /teacher-password/change with JSON content type, credentials, and snake_case password body keys", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await api.changeTeacherPassword("current", "new", "confirm");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/teacher-password/change", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        current_password: "current",
+        new_password: "new",
+        confirm_password: "confirm",
+      }),
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("logout sends a POST to /auth/logout with credentials and no content-type header or body", async () => {
+    // Characterization: logout is intentionally excluded from consolidation.
+    // Its request shape has no Content-Type header and no body, so it cannot
+    // delegate to this.post without changing its request shape.
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await api.logout();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/auth/logout", {
+      method: "POST",
+      credentials: "include",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -65,34 +65,15 @@ export const api = {
   },
 
   async getMe(): Promise<MeResponse> {
-    const response = await fetch(`${API_BASE}/auth/me`, {
-      credentials: "include",
-    });
-    return handleResponse<MeResponse>(response);
+    return this.get<MeResponse>("/auth/me");
   },
 
   async login(username: string, password: string): Promise<AuthResponse> {
-    const response = await fetch(`${API_BASE}/auth/login`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-      body: JSON.stringify({ username, password }),
-    });
-    return handleResponse<AuthResponse>(response);
+    return this.post<AuthResponse>("/auth/login", { username, password });
   },
 
   async register(username: string, password: string): Promise<AuthResponse> {
-    const response = await fetch(`${API_BASE}/auth/register`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-      body: JSON.stringify({ username, password }),
-    });
-    return handleResponse<AuthResponse>(response);
+    return this.post<AuthResponse>("/auth/register", { username, password });
   },
 
   async logout(): Promise<{ ok: boolean }> {
@@ -104,15 +85,7 @@ export const api = {
   },
 
   async verifyTeacherPassword(password: string): Promise<{ ok: boolean }> {
-    const response = await fetch(`${API_BASE}/teacher-password/verify`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-      body: JSON.stringify({ password }),
-    });
-    return handleResponse<{ ok: boolean }>(response);
+    return this.post<{ ok: boolean }>("/teacher-password/verify", { password });
   },
 
   async changeTeacherPassword(
@@ -120,19 +93,11 @@ export const api = {
     newPassword: string,
     confirmPassword: string
   ): Promise<{ ok: boolean }> {
-    const response = await fetch(`${API_BASE}/teacher-password/change`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      credentials: "include",
-      body: JSON.stringify({
-        current_password: currentPassword,
-        new_password: newPassword,
-        confirm_password: confirmPassword,
-      }),
+    return this.post<{ ok: boolean }>("/teacher-password/change", {
+      current_password: currentPassword,
+      new_password: newPassword,
+      confirm_password: confirmPassword,
     });
-    return handleResponse<{ ok: boolean }>(response);
   },
 
   /**


### PR DESCRIPTION
## Summary

- Add request-shape characterization tests for `getMe`, `login`, `register`, `verifyTeacherPassword`, `changeTeacherPassword`, and `logout` in `frontend/src/api/client.test.ts`.
- Delegate the five matching auth methods (`getMe`, `login`, `register`, `verifyTeacherPassword`, `changeTeacherPassword`) to the existing generic `this.get` / `this.post` helpers in `frontend/src/api/client.ts`.
- Leave `logout` unchanged (its request shape differs from `this.post`).

## Linked Issue

Closes #425

## Issue Alignment

This PR implements the issue (QW-I2) using the chosen characterization-first approach:

1. Pinned the current request shape (URL, method, headers, credentials, body) for each target method with exact-match `toHaveBeenCalledWith` assertions.
2. Confirmed the tests pass against the **pre-refactor** implementation.
3. Verified each target method's request shape has exact parity with the corresponding generic helper.
4. Delegated only methods whose characterized shape matches the generic helpers.
5. Kept `logout` unchanged.

Scope covered:

- Request-shape characterization tests for `getMe`, `login`, `register`, `verifyTeacherPassword`, `changeTeacherPassword` (and `logout`, to pin its exclusion).
- Delegation of the five matching methods to `this.get` / `this.post`.
- Keeping `logout` unchanged.

Out of scope / intentionally not included:

- Changes to `TeacherPasswordModal.tsx` or `SettingsPage.tsx` error discriminator behavior.
- Matching wrong teacher-password errors by status/code alone.
- Typed teacher-password error contract changes.
- API response contract changes.
- New API client abstractions beyond the existing generic helpers.

## Implementation Notes

- Parity analysis (current direct-`fetch` shape vs. generic helper shape):
  - `getMe` -> `this.get<MeResponse>("/auth/me")`: identical (`{ credentials: "include" }`, no method key — fetch defaults to GET).
  - `login` -> `this.post<AuthResponse>("/auth/login", { username, password })`: identical.
  - `register` -> `this.post<AuthResponse>("/auth/register", { username, password })`: identical.
  - `verifyTeacherPassword` -> `this.post<{ ok: boolean }>("/teacher-password/verify", { password })`: identical.
  - `changeTeacherPassword` -> `this.post<{ ok: boolean }>("/teacher-password/change", { current_password, new_password, confirm_password })`: identical (snake_case keys preserved).
- `logout` is intentionally **not** delegated. Its request shape (`{ method: "POST", credentials: "include" }`) has no `Content-Type` header and no body, which differs from `this.post` (which always sets the JSON content-type header and a body). A characterization test pins this exact shape and documents why `logout` is excluded from consolidation.
- The characterization tests use exact-match assertions (`toHaveBeenCalledWith` with plain objects), so any accidental change to the request shape (e.g., an added header key) after delegation would fail the test — this is the strongest possible automated guarantee of request-shape parity.
- No orphaned code: `API_BASE` and `handleResponse` remain used by `logout` and the generic helpers.

## Tests

Commands run:

- `npm test -- --run src/api/client.test.ts` (pre-refactor) — passed (10 tests), confirming the characterization tests pin the current behavior.
- `npm test -- --run src/api/client.test.ts` (post-refactor) — passed (10 tests), confirming request-shape parity is preserved.
- `npm test -- --run` (full frontend unit suite, post-refactor) — passed (32 files, 462 tests), including `TeacherPasswordModal.test.tsx`, `SettingsPage.test.tsx`, and `AuthContext`-related coverage.
- `npm run build` (post-refactor) — passed (`tsc -b` + `vite build` succeeded).

Automated tests added or updated:

- Added `describe("API Client auth methods")` in `frontend/src/api/client.test.ts` with 6 characterization tests covering `getMe`, `login`, `register`, `verifyTeacherPassword`, `changeTeacherPassword`, and `logout`. Each asserts the exact `fetch` URL and options object (method, headers, credentials, body) plus the parsed return value.

Manual verification:

- The issue requests manual verification of login/session restore and teacher-password flows in a browser. These flows require a running backend and were not exercised in-browser here. However, the request-shape parity that those manual checks would ultimately validate is **proven** by the characterization tests: they assert the exact `fetch` arguments and pass both before and after the refactor, so the wire-level request behavior is provably identical. The shared `handleResponse` error path (including teacher-password error handling) is unchanged and remains covered by the existing `postFormData` error tests.
- Diff confirmed limited to `frontend/src/api/client.ts` and `frontend/src/api/client.test.ts`.

## Deviations From Issue Plan

- The issue lists characterization tests for the five target methods only; this PR also adds one characterization test for `logout`. This is within scope (the issue explicitly requires "Keeping `logout` unchanged") and the test documents *why* `logout` is excluded from delegation — it cannot delegate to `this.post` without changing its request shape. Low risk and supports the "logout unchanged" requirement.
- In-browser manual flows (login/session restore/teacher-password) were not run because they require a running backend. Request-shape parity is instead proven by exact-match characterization tests passing before and after the refactor. This is documented transparently above.

## Follow-Up Work

None. Typed teacher-password error contract work is intentionally postponed (per the issue) and should only be handled in a separate issue if product behavior changes are approved.