### PR TITLE
Extract shared VLM chat-completion parser onto BaseVLMClient

### DIFF
--- a/backend/app/infrastructure/vlm/base_client.py
+++ b/backend/app/infrastructure/vlm/base_client.py
@@ -5,6 +5,9 @@ import re
 from typing import Any, Callable
 
 import httpx
+from pydantic import ValidationError
+
+from app.infrastructure.vlm._models import _ChatCompletionResponse
 
 FAILURE_CODE_TIMEOUT = "vlm-timeout"
 FAILURE_CODE_NETWORK = "vlm-network-error"
@@ -189,3 +192,41 @@ class BaseVLMClient:
             retryable=False,
             raw_provider_response=content,
         )
+
+    def _parse_chat_completion_response(self, raw_body: dict[str, Any]) -> dict[str, Any]:
+        try:
+            completion = _ChatCompletionResponse.model_validate(raw_body)
+        except ValidationError as exc:
+            raise self._make_error(
+                "VLM provider response failed chat completion validation",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_body,
+            ) from exc
+
+        if not completion.choices:
+            raise self._make_error(
+                "VLM provider returned no choices",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_body,
+            )
+
+        message = completion.choices[0].message
+        content = message.content
+        if not content:
+            raise self._make_error(
+                "VLM provider response content was empty",
+                code=FAILURE_CODE_INVALID_RESPONSE,
+                retryable=False,
+                raw_provider_response=raw_body,
+            )
+
+        stripped_content, extracted_reasoning = self._strip_thinking_content(content)
+        parsed = self._load_json_content(stripped_content)
+        reasoning_content = message.reasoning_content
+        if reasoning_content is None:
+            reasoning_content = extracted_reasoning
+        if reasoning_content is not None:
+            parsed["reasoning_content"] = reasoning_content
+        return parsed

--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -24,7 +24,6 @@ from app.infrastructure.vlm._models import (
     _ChatMessage,
     _ChatMessageContentImageUrl,
     _ChatMessageContentText,
-    _ChatCompletionResponse,
 )
 from app.infrastructure.vlm.prompts import (
     ENGLISH_EXTRACTION_SYSTEM_PROMPT,
@@ -434,41 +433,3 @@ class VLMClient(BaseVLMClient):
             ],
         )
         return chat_request.model_dump(exclude_none=True)
-
-    def _parse_chat_completion_response(self, raw_body: dict[str, Any]) -> dict[str, Any]:
-        try:
-            completion = _ChatCompletionResponse.model_validate(raw_body)
-        except ValidationError as exc:
-            raise VLMError(
-                "VLM provider response failed chat completion validation",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                raw_provider_response=raw_body,
-            ) from exc
-
-        if not completion.choices:
-            raise VLMError(
-                "VLM provider returned no choices",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                raw_provider_response=raw_body,
-            )
-
-        message = completion.choices[0].message
-        content = message.content
-        if not content:
-            raise VLMError(
-                "VLM provider response content was empty",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                raw_provider_response=raw_body,
-            )
-
-        stripped_content, extracted_reasoning = self._strip_thinking_content(content)
-        parsed = self._load_json_content(stripped_content)
-        reasoning_content = message.reasoning_content
-        if reasoning_content is None:
-            reasoning_content = extracted_reasoning
-        if reasoning_content is not None:
-            parsed["reasoning_content"] = reasoning_content
-        return parsed

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -22,7 +22,6 @@ from app.infrastructure.vlm._models import (
     _ChatMessage,
     _ChatMessageContentImageUrl,
     _ChatMessageContentText,
-    _ChatCompletionResponse,
 )
 
 from app.infrastructure.vlm.solution_coaching_prompts import (
@@ -191,44 +190,6 @@ class _BaseSolutionCoachingVLMClient(BaseVLMClient):
     async def _send_chat_completion(self, payload: dict[str, Any]) -> dict[str, Any]:
         raw_body = await super()._send_chat_completion(payload)
         return self._parse_chat_completion_response(raw_body)
-
-    def _parse_chat_completion_response(self, raw_body: dict[str, Any]) -> dict[str, Any]:
-        try:
-            completion = _ChatCompletionResponse.model_validate(raw_body)
-        except ValidationError as exc:
-            raise SolutionCoachingVLMError(
-                "VLM provider response failed chat completion validation",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                raw_provider_response=raw_body,
-            ) from exc
-
-        if not completion.choices:
-            raise SolutionCoachingVLMError(
-                "VLM provider returned no choices",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                raw_provider_response=raw_body,
-            )
-
-        message = completion.choices[0].message
-        content = message.content
-        if not content:
-            raise SolutionCoachingVLMError(
-                "VLM provider response content was empty",
-                code=FAILURE_CODE_INVALID_RESPONSE,
-                retryable=False,
-                raw_provider_response=raw_body,
-            )
-
-        stripped_content, extracted_reasoning = self._strip_thinking_content(content)
-        parsed = self._load_json_content(stripped_content)
-        reasoning_content = message.reasoning_content
-        if reasoning_content is None:
-            reasoning_content = extracted_reasoning
-        if reasoning_content is not None:
-            parsed["reasoning_content"] = reasoning_content
-        return parsed
 
 
 class SolutionVLMClient(_BaseSolutionCoachingVLMClient):

--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -246,6 +246,68 @@ async def test_solution_vlm_client_rejects_malformed_response() -> None:
 
 
 @pytest.mark.asyncio
+async def test_solution_vlm_parser_rejects_invalid_chat_completion_shape() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"unexpected": "shape"})
+
+    client = _build_solution_client(handler)
+
+    with pytest.raises(SolutionCoachingVLMError) as exc_info:
+        await client.generate_solution(
+            SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+        )
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "VLM provider response failed chat completion validation"
+    assert exc_info.value.raw_provider_response == {"unexpected": "shape"}
+
+
+@pytest.mark.asyncio
+async def test_solution_vlm_parser_rejects_empty_choices() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    client = _build_solution_client(handler)
+
+    with pytest.raises(SolutionCoachingVLMError) as exc_info:
+        await client.generate_solution(
+            SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+        )
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "VLM provider returned no choices"
+    assert exc_info.value.raw_provider_response == {"choices": []}
+
+
+@pytest.mark.asyncio
+async def test_solution_vlm_parser_rejects_empty_content() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"index": 0, "message": {"role": "assistant", "content": None}}]},
+        )
+
+    client = _build_solution_client(handler)
+
+    with pytest.raises(SolutionCoachingVLMError) as exc_info:
+        await client.generate_solution(
+            SolutionVLMRequest(problem_text="题目", correct_answer="42", image_url="https://example.com/problem.png")
+        )
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "VLM provider response content was empty"
+    assert exc_info.value.raw_provider_response == {
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": None}}]
+    }
+
+
+@pytest.mark.asyncio
 async def test_solution_vlm_client_classifies_provider_failure_as_retryable() -> None:
     async def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(503, json={"detail": "overloaded"})

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -512,6 +512,62 @@ async def test_vlm_invalid_response_shape_is_rejected() -> None:
     assert exc_info.value.retryable is False
 
 
+@pytest.mark.asyncio
+async def test_vlm_parser_rejects_invalid_chat_completion_shape() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"unexpected": "shape"})
+
+    client = _build_client(handler)
+
+    with pytest.raises(VLMError) as exc_info:
+        await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "VLM provider response failed chat completion validation"
+    assert exc_info.value.raw_provider_response == {"unexpected": "shape"}
+
+
+@pytest.mark.asyncio
+async def test_vlm_parser_rejects_empty_choices() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    client = _build_client(handler)
+
+    with pytest.raises(VLMError) as exc_info:
+        await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "VLM provider returned no choices"
+    assert exc_info.value.raw_provider_response == {"choices": []}
+
+
+@pytest.mark.asyncio
+async def test_vlm_parser_rejects_empty_content() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"choices": [{"index": 0, "message": {"role": "assistant", "content": None}}]},
+        )
+
+    client = _build_client(handler)
+
+    with pytest.raises(VLMError) as exc_info:
+        await client.extract(image_url="s3://bucket/key")
+    await client.aclose()
+
+    assert exc_info.value.code == FAILURE_CODE_INVALID_RESPONSE
+    assert exc_info.value.retryable is False
+    assert str(exc_info.value) == "VLM provider response content was empty"
+    assert exc_info.value.raw_provider_response == {
+        "choices": [{"index": 0, "message": {"role": "assistant", "content": None}}]
+    }
+
+
 def test_strip_json_code_fences_leaves_plain_json_unchanged() -> None:
     plain = '{"text":"hello"}'
 


### PR DESCRIPTION
## Summary

- Move the duplicated `_parse_chat_completion_response` from `VLMClient` (`client.py`) and `_BaseSolutionCoachingVLMClient` (`solution_coaching_client.py`) onto `BaseVLMClient` (`base_client.py`), using the existing `_make_error` / `_error_factory` mechanism so each subclass continues raising its own error type (`VLMError` / `SolutionCoachingVLMError`).
- Add characterization tests pinning the three previously-uncovered parser failure paths (invalid chat-completion shape, empty choices, empty content) for both clients.

## Linked Issue

Closes #426

## Issue Alignment

This PR implements the issue (QW-I3) using the chosen characterization-first approach:

1. Inspected the parser duplication: `_parse_chat_completion_response` was byte-identical in `client.py` and `solution_coaching_client.py`, differing only in the error class raised (`VLMError` vs `SolutionCoachingVLMError`).
2. Added characterization tests pinning the three failure paths that lacked direct coverage, for each client, asserting exact error class, message string, code, retryable flag, and `raw_provider_response`.
3. Confirmed the new tests pass against the **pre-refactor** implementation.
4. Moved the parser onto `BaseVLMClient`, replacing direct `raise VLMError(...)` / `raise SolutionCoachingVLMError(...)` with `raise self._make_error(...)`, which dispatches to the subclass `_error_factory`.
5. Deleted the two duplicate methods and removed the now-orphaned `_ChatCompletionResponse` import from each subclass module.
6. Confirmed subclass error creation still uses the existing `_make_error` / `_error_factory` pattern.

Scope covered:

- Adding characterization tests for parser error class, message, code, retryable, raw response on the three previously-uncovered failure paths (x2 clients = 6 tests).
- Moving the duplicated chat-completion parsing logic into a `BaseVLMClient` helper.
- Rewiring the two VLM clients to inherit the shared helper.
- Preserving subclass-specific error classes via `_error_factory`.

Out of scope / intentionally not included:

- Hoisting `_validate_response` (left in both subclasses, untouched).
- Extracting a VLM construction factory.
- Extracting an image-content helper.
- Touching DSL sanitizer or GraphSandbox-related code.
- Changing parser error message strings.
- Service-name parameterization.

## Implementation Notes

- **Behavior preservation proof.** `_make_error(message, code=..., retryable=..., raw_provider_response=raw_body)` calls `self._error_factory(message, code=..., retryable=..., status_code=None, raw_provider_response=raw_body)`. For `VLMClient` (`_error_factory=VLMError`) this produces `VLMError(message, code=..., retryable=..., status_code=None, raw_provider_response=raw_body)` — identical to the previous direct `VLMError(message, code=..., retryable=..., raw_provider_response=raw_body)` (which also left `status_code` at its `None` default). The same holds for `SolutionCoachingVLMError`. So error class, message, code, retryable, `status_code`, and `raw_provider_response` are all preserved exactly.
- **Message strings unchanged.** The three parser failure messages are copied verbatim: `"VLM provider response failed chat completion validation"`, `"VLM provider returned no choices"`, `"VLM provider response content was empty"`.
- **`_send_chat_completion` raw-response semantics unchanged.** The base `_send_chat_completion` (raw dict handling, status-code mapping, `_decode_raw_response`) is not touched; only the response-parsing helper was centralized.
- **No orphaned code.** The only import my change orphaned was `_ChatCompletionResponse` in the two subclass modules, which I removed. `ValidationError` remains used by each subclass's own `_validate_response`. (A pre-existing unused `import json` in both subclass modules was left untouched, since it is not orphaned by this change.)
- **No circular import.** `_models.py` imports only from `pydantic`/`typing`, so importing `_ChatCompletionResponse` into `base_client.py` is safe.

## Tests

Commands run (using the repo's existing `.venv` at `backend/.venv`, with the worktree's code taking precedence via `PYTHONPATH=.`):

- `python -m pytest tests/infrastructure/test_base_vlm_client.py tests/infrastructure/test_vlm.py tests/infrastructure/test_solution_coaching_client.py tests/infrastructure/test_vlm_error_independence.py` (pre-refactor) — passed (112 tests), confirming the new characterization tests pin current behavior.
- Same command (post-refactor) — passed (112 tests), confirming behavior preservation.
- `python -m pytest tests/infrastructure/` (post-refactor) — passed (148 tests).
- `python -m pytest` (full backend suite, post-refactor) — **807 passed, 1 skipped** (the skip is pre-existing and unrelated).
- Module import sanity check — `base_client`, `client`, `solution_coaching_client` all import cleanly.

Automated tests added or updated:

- 3 tests in `tests/infrastructure/test_vlm.py`: `test_vlm_parser_rejects_invalid_chat_completion_shape`, `test_vlm_parser_rejects_empty_choices`, `test_vlm_parser_rejects_empty_content` — each asserts `VLMError`, exact message, `FAILURE_CODE_INVALID_RESPONSE`, `retryable=False`, and `raw_provider_response`.
- 3 tests in `tests/infrastructure/test_solution_coaching_client.py`: the same three paths for `SolutionVLMClient`, asserting `SolutionCoachingVLMError` (preserving error independence).

Manual verification:

- Reviewed the diff to confirm parser message strings were preserved exactly (see Implementation Notes).
- Confirmed no DSL sanitizer, GraphSandbox, validation-hoist, factory, or image-helper changes were included (only `base_client.py`, `client.py`, `solution_coaching_client.py`, and the two test files changed).
- Confirmed `_validate_response` remains in both subclasses, untouched.

## Deviations From Issue Plan

None. The issue asked for characterization-first extraction of the duplicated parser onto `BaseVLMClient` preserving subclass error classes via the existing `_make_error` / `_error_factory` pattern; that is exactly what was implemented.

## Follow-Up Work

None. The intentionally-postponed items (VLM validation hoist, VLM construction factory, image-content helper extraction) remain out of scope and should only be handled in separate issues if pursued.
