### PR TITLE
Revise English extraction prompt to generate correctAnswer

### DIFF
--- a/backend/app/infrastructure/vlm/prompts.py
+++ b/backend/app/infrastructure/vlm/prompts.py
@@ -347,20 +347,26 @@ Fields:
 - problemType: one of single-choice, multi-choice, fill-in-the-blank, short-answer.
 - graphDsl: nullable string. Use this only when the problem contains a geometry or coordinate-style diagram
   that can be reconstructed with the supported JSXGraph elements below. Otherwise return null.
-- correctAnswer: nullable string. If the image visibly shows the expected answer (for example an answer key,
-  a printed answer, or a clearly indicated correct option), put that answer here as plain text. If no answer is
-  visible in the image, return null. Do not solve the problem or infer an answer that is not shown.
+- correctAnswer: nullable string. Generate this by solving or answering the visible English problem.
+  - For single-choice problems, return the correct option label only, e.g. `B`.
+  - For multi-choice problems, return the correct option labels as a comma-separated list, e.g. `A, C`.
+  - For fill-in-the-blank and constrained short-answer problems, return a concise answer, e.g. `bus`.
+  - For open-ended tasks such as writing a sentence, making a dialogue, or free translation, return a reasonable model answer.
+  - If you are uncertain, provide your best guess rather than returning null.
+  - Return null only when the problem is too incomplete or incoherent to form any answer at all.
 - providerMetadata: optional object. Omit it unless the caller explicitly requires provider-specific metadata.
 
 ## Core extraction rules
 
-Extract the visible problem faithfully.
-Do not solve the problem.
-Do not answer questions.
-Do not fill in blanks.
+Extract the visible problem faithfully into the `text` field.
+Do not solve the problem in the `text` field — represent blanks with the normalized blank form.
+Do not answer questions in the `text` field.
+Do not fill in blanks in the `text` field.
 Do not correct grammar, spelling, punctuation, or capitalization unless the correction is visibly present in the image.
-Do not invent missing words, missing options, missing labels, or missing numbers.
+Do not invent missing words, missing options, missing labels, or missing numbers in the `text` field.
 If some text is unclear, extract the most likely visible text without adding explanations.
+
+The `correctAnswer` field is different: solve or answer the visible problem to generate it (see the field description above).
 
 ## Text structure
 

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -714,6 +714,31 @@ def test_english_extraction_prompt_contains_english_guidance() -> None:
 def test_english_extraction_prompt_documents_correct_answer() -> None:
     assert "correctAnswer" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
     assert "nullable string" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+    assert "solving or answering" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+    assert "Do not solve the problem or infer an answer that is not shown" not in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+
+
+def test_english_extraction_prompt_instructs_labels_only_for_choices() -> None:
+    assert "label only" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+    assert "comma-separated list" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+
+
+def test_english_extraction_prompt_instructs_model_answer_for_open_ended() -> None:
+    assert "model answer" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+    assert "open-ended" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+
+
+def test_english_extraction_prompt_instructs_best_guess_for_uncertain() -> None:
+    assert "best guess" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+
+
+def test_english_extraction_prompt_reserves_null_for_impossible() -> None:
+    assert "too incomplete or incoherent" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+
+
+def test_english_extraction_prompt_scopes_no_solve_to_text_field() -> None:
+    assert "Do not solve the problem in the `text` field" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
+    assert "solve or answer the visible problem to generate it" in ENGLISH_EXTRACTION_SYSTEM_PROMPT
 
 
 def test_math_extraction_prompt_does_not_request_correct_answer() -> None:


### PR DESCRIPTION
## Summary

- Revise `ENGLISH_EXTRACTION_SYSTEM_PROMPT` so `correctAnswer` is generated by solving or answering the visible English problem, rather than only copied when an answer is visibly printed in the image.
- Scope the global "Do not solve / Do not answer / Do not fill in blanks" rules to the `text` field only, so they no longer contradict `correctAnswer` generation.
- Add answer-format guidance: label-only for single-choice, comma-separated labels for multi-choice, concise answer for fill-in/short-answer, model answer for open-ended tasks, best guess for uncertain cases, and null only when no answer can be formed at all.
- Update and add backend tests covering the new prompt behavior.

## Linked Issue

Closes #429

## Issue Alignment

This PR implements the issue by:

1. Editing `ENGLISH_EXTRACTION_SYSTEM_PROMPT` in `backend/app/infrastructure/vlm/prompts.py`.
2. Replacing the visible-answer-only `correctAnswer` field description with instructions to solve/answer the visible English problem.
3. Scoping global "Do not solve the problem", "Do not answer questions", and "Do not fill in blanks" rules to the `text` field only, and adding a note that `correctAnswer` generation is different.
4. Adding answer-format guidance: single-choice (label only, e.g. `B`), multi-choice (comma-separated labels, e.g. `A, C`), fill-in/short-answer (concise answer), open-ended (model answer), uncertain (best guess), null (only when too incomplete/incoherent).
5. Updating existing prompt/client tests to assert the new behavior and prevent regression.
6. Confirming math extraction prompt/tests remain unchanged with respect to `correctAnswer`.

Scope covered:

- Updating `ENGLISH_EXTRACTION_SYSTEM_PROMPT` so `correctAnswer` is generated from the problem content.
- Removing English prompt text that globally forbids solving/answering in a way that conflicts with `correctAnswer` generation.
- Preserving the existing `correctAnswer: string | null` schema and draft persistence behavior (no schema or worker changes).
- Updating backend tests that lock the English extraction prompt contract.

Out of scope / intentionally not included:

- Changing the extraction JSON schema.
- Adding confidence fields or explanations for `correctAnswer`.
- Changing math extraction behavior.
- Changing frontend review UI behavior.
- Changing grading, practice, exams, or solution-coaching logic.
- Migrating existing drafts or problems.
- Broad prompt refactors unrelated to `correctAnswer` behavior.

## Implementation Notes

- **Prompt change is text-only.** The `correctAnswer` field description was rewritten from "If the image visibly shows the expected answer... Do not solve the problem or infer an answer that is not shown" to "Generate this by solving or answering the visible English problem" with the 6 format rules specified in the issue.
- **Global rules scoped to `text` field.** The "Core extraction rules" section now says "Do not solve the problem in the `text` field" instead of "Do not solve the problem." A new sentence clarifies: "The `correctAnswer` field is different: solve or answer the visible problem to generate it."
- **No schema or downstream changes.** The existing `correctAnswer: nullable string` schema, `build_extraction_user_prompt` (which includes `nullable "correctAnswer"` when `include_correct_answer=True`), extraction worker persistence, and problem creation path are all unchanged. The prompt change only affects what the VLM is instructed to produce.
- **Math extraction untouched.** `MATH_EXTRACTION_SYSTEM_PROMPT` does not mention `correctAnswer` and is not modified. `test_math_extraction_prompt_does_not_request_correct_answer` still passes.

## Tests

Commands run (using the repo's existing `.venv` at `backend/.venv`, with `PYTHONPATH=.`):

- `python -m pytest tests/infrastructure/test_vlm.py tests/worker/test_extraction_worker.py` — passed (80 tests), including:
  - `test_english_extraction_prompt_documents_correct_answer` (updated — now asserts "solving or answering" is present and old "Do not solve the problem or infer an answer that is not shown" is absent)
  - `test_vlm_extraction_english_requests_correct_answer` (unchanged — still confirms schema includes nullable `correctAnswer`)
  - `test_math_extraction_prompt_does_not_request_correct_answer` (unchanged — still passes)
  - `test_process_item_persists_english_correct_answer` (unchanged — worker still persists correctAnswer into draft)
  - 5 new tests (see below)
- `python -m pytest` (full backend suite) — **806 passed, 1 skipped** (the skip is pre-existing and unrelated).

Automated tests added or updated:

- Updated `test_english_extraction_prompt_documents_correct_answer`: now asserts `"solving or answering"` in prompt and old visible-answer-only wording is absent. Would have failed under the old prompt.
- New `test_english_extraction_prompt_instructs_labels_only_for_choices`: asserts `"label only"` and `"comma-separated list"` in prompt.
- New `test_english_extraction_prompt_instructs_model_answer_for_open_ended`: asserts `"model answer"` and `"open-ended"` in prompt.
- New `test_english_extraction_prompt_instructs_best_guess_for_uncertain`: asserts `"best guess"` in prompt.
- New `test_english_extraction_prompt_reserves_null_for_impossible`: asserts `"too incomplete or incoherent"` in prompt.
- New `test_english_extraction_prompt_scopes_no_solve_to_text_field`: asserts `"Do not solve the problem in the \`text\` field"` and `"solve or answer the visible problem to generate it"` in prompt.

All new test assertions would have failed under the old prompt (the strings did not exist before this change).

Manual verification:

1. Ran the relevant backend tests — all pass.
2. Read the final English prompt and confirmed no remaining visible-answer-only instruction for `correctAnswer`.
3. Verified no global "do not solve" wording that conflicts with `correctAnswer` generation — all such rules are now scoped to the `text` field.
4. Verified math extraction still omits `correctAnswer` — `test_math_extraction_prompt_does_not_request_correct_answer` passes.
5. Recorded exact commands and results above.

## Deviations From Issue Plan

None. The issue asked for a focused prompt-contract change updating the English extraction prompt to generate `correctAnswer` by solving/answering the visible problem, with scoped no-solve rules and answer-format guidance; that is exactly what was implemented.

## Follow-Up Work

None. Potential future work (answer confidence or review warnings) was explicitly deferred per the issue and should not be included.
