### PR TITLE
Normalize LaTeX formatting in ingested problem text

### DIFF
--- a/backend/app/domain/normalization.py
+++ b/backend/app/domain/normalization.py
@@ -3,6 +3,49 @@ import unicodedata
 from .models import CorrectAnswer, ProblemType
 
 
+# Matches single-dollar inline math ($...$) while avoiding display math ($$...$$):
+# neither delimiter may be adjacent to another ``$``.
+_INLINE_MATH_PATTERN = r"(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)"
+_INLINE_MATH_RE = re.compile(_INLINE_MATH_PATTERN)
+_UNSIGNED_NUMBER_RE = re.compile(r"\d+(?:\.\d+)?")
+
+
+def normalize_extracted_problem_text(text: str) -> str:
+    """Normalize inline LaTeX in extracted problem text.
+
+    Applied to VLM-extracted draft text only; the raw extraction text must be
+    preserved separately. Two rules run in order:
+
+    1. Unwrap pure unsigned numbers: ``$45$`` -> ``45``, ``$3.14$`` -> ``3.14``.
+       Negatives, comma-grouped numbers, percentages, fractions, variables and
+       expressions are left wrapped.
+    2. Normalize spacing around remaining inline ``$...$``: exactly one ASCII
+       space before and after the expression unless it is at the start or end of
+       a line.
+    """
+    text = _unwrap_numeric_inline_math(text)
+    text = _normalize_inline_math_spacing(text)
+    return text
+
+
+def _unwrap_numeric_inline_math(text: str) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        inner = match.group(1).strip()
+        if _UNSIGNED_NUMBER_RE.fullmatch(inner):
+            return inner
+        return match.group(0)
+
+    return _INLINE_MATH_RE.sub(_replace, text)
+
+
+def _normalize_inline_math_spacing(text: str) -> str:
+    # Exactly one space before ``$`` when preceded by a non-space character.
+    text = re.sub(r"(?<=\S)[ \t]*(" + _INLINE_MATH_PATTERN + r")", r" \1", text)
+    # Exactly one space after ``$`` when followed by a non-space character.
+    text = re.sub(r"(" + _INLINE_MATH_PATTERN + r")[ \t]*(?=\S)", r"\1 ", text)
+    return text
+
+
 def compare_answers(normalized: CorrectAnswer, stored_answer: dict, problem_type: ProblemType) -> bool:
     """Compare a normalized answer against the stored correct answer."""
     if problem_type == ProblemType.MULTI_CHOICE:

--- a/backend/app/infrastructure/worker/extraction_worker.py
+++ b/backend/app/infrastructure/worker/extraction_worker.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from app.domain.ingestion import BatchState, ItemState
+from app.domain.normalization import normalize_extracted_problem_text
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.ingestion.crop import crop_image_to_box
 from app.infrastructure.ingestion.documents import build_crop_image
@@ -251,6 +252,7 @@ async def process_item(
         return
 
     finished_at = _utc_now()
+    normalized_text = normalize_extracted_problem_text(result.text)
     await save_item_extraction_success(
         database,
         batch_id,
@@ -258,7 +260,7 @@ async def process_item(
         item_id,
         crop=crop_meta,
         draft={
-            "text": result.text,
+            "text": normalized_text,
             "problemType": result.problem_type,
             "graphDsl": result.graph_dsl,
             "correctAnswer": result.correct_answer,

--- a/backend/app/presentation/ingestion_workflow.py
+++ b/backend/app/presentation/ingestion_workflow.py
@@ -12,6 +12,7 @@ from bson import ObjectId
 from pymongo.asynchronous.database import AsyncDatabase
 
 from app.domain import IngestionPreviewStatus, recover_stale_preview, transition_preview_state
+from app.domain.normalization import normalize_extracted_problem_text
 from app.infrastructure.config.settings import Settings
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import S3StorageAdapter, StorageObjectNotFoundError
@@ -170,9 +171,10 @@ async def _run_extraction_task(
             return
 
         finished_at = utc_now()
+        normalized_text = normalize_extracted_problem_text(result.text)
         draft = _merge_draft_with_extraction(
             preview.get("editableDraft"),
-            text=result.text,
+            text=normalized_text,
             problem_type=result.problem_type,
             graph_dsl=result.graph_dsl,
         )

--- a/backend/tests/api/test_ingestion.py
+++ b/backend/tests/api/test_ingestion.py
@@ -356,6 +356,42 @@ async def test_create_preview_with_valid_image_returns_expected_status(
 
 
 @pytest.mark.asyncio
+async def test_create_preview_normalizes_draft_text_and_preserves_raw_text(
+    ingestion_app: FastAPI,
+    authenticated_client: AsyncClient,
+) -> None:
+    helper_vlm: FakeVLMClient = ingestion_app.state.fake_helper_vlm_client
+    math_vlm: FakeVLMClient = ingestion_app.state.fake_math_ingestion_vlm_client
+    helper_vlm.responses = [
+        ClassificationResult(
+            request_type="subject-classification",
+            model="gpt-4.1-mini",
+            subject="math",
+            confidence=0.95,
+            reason="Contains math notation",
+            provider_metadata={},
+            raw_provider_response={},
+        )
+    ]
+    raw_text = "已知$45$和$x$，求$y$。"
+    math_vlm.responses = [make_extraction_result(text=raw_text)]
+    ingestion_app.state.sync_wait_seconds = 1.0
+
+    create_response = await authenticated_client.post(
+        "/api/v1/ingestion-previews",
+        files={"image": ("test.png", make_png_bytes(), "image/png")},
+    )
+
+    assert create_response.status_code == 201
+    preview = create_response.json()["preview"]
+    assert preview["status"] == "ready"
+    # Draft text is normalized: numeric unwrapped, inline math spaced.
+    assert preview["draft"]["text"] == "已知45和 $x$ ，求 $y$ 。"
+    # Raw extraction text remains the unmodified VLM output.
+    assert preview["extraction"]["rawText"] == raw_text
+
+
+@pytest.mark.asyncio
 async def test_create_preview_with_non_image_returns_validation_error(
     authenticated_client: AsyncClient,
 ) -> None:

--- a/backend/tests/domain/test_normalization.py
+++ b/backend/tests/domain/test_normalization.py
@@ -1,6 +1,6 @@
 import pytest
 from app.domain import ProblemType, CorrectAnswer, normalize_answer
-from app.domain.normalization import compare_answers
+from app.domain.normalization import compare_answers, normalize_extracted_problem_text
 
 
 def test_single_choice_normalization():
@@ -168,3 +168,67 @@ class TestCompareAnswers:
         )
         stored_answer = {"normalizedSet": ("a", "b"), "normalizedText": "a,b"}
         assert compare_answers(normalized, stored_answer, ProblemType.MULTI_CHOICE) is True
+
+
+class TestNormalizeExtractedProblemTextNumericUnwrap:
+    def test_unsigned_integer_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("The answer is $45$.") == "The answer is 45."
+
+    def test_unsigned_decimal_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("Pi is $3.14$.") == "Pi is 3.14."
+
+    def test_padded_number_unwrapped_and_trimmed(self) -> None:
+        assert normalize_extracted_problem_text("$ 45 $") == "45"
+
+
+class TestNormalizeExtractedProblemTextNoUnwrap:
+    def test_negative_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$-3$") == "$-3$"
+
+    def test_comma_grouped_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$1,000$") == "$1,000$"
+
+    def test_percentage_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$45\\%$") == "$45\\%$"
+
+    def test_variable_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$x$") == "$x$"
+
+    def test_expression_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$x+1$") == "$x+1$"
+
+    def test_fraction_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$\\frac{1}{2}$") == "$\\frac{1}{2}$"
+
+    def test_display_math_not_unwrapped(self) -> None:
+        assert normalize_extracted_problem_text("$$45$$") == "$$45$$"
+
+
+class TestNormalizeExtractedProblemTextSpacing:
+    def test_adds_spaces_around_inline_math_adjacent_to_english(self) -> None:
+        assert normalize_extracted_problem_text("Find$x$when$x+1=2$") == "Find $x$ when $x+1=2$"
+
+    def test_adds_spaces_around_inline_math_adjacent_to_chinese_and_punctuation(self) -> None:
+        assert normalize_extracted_problem_text("已知$x$，求$y$。") == "已知 $x$ ，求 $y$ 。"
+
+    def test_collapses_extra_boundary_spaces_to_one(self) -> None:
+        assert normalize_extracted_problem_text("已知  $x$  ，求  $y$  。") == "已知 $x$ ，求 $y$ 。"
+
+    def test_preserves_inline_math_at_start_of_line(self) -> None:
+        text = "$x$ is the unknown"
+        assert normalize_extracted_problem_text(text) == "$x$ is the unknown"
+
+    def test_preserves_inline_math_at_end_of_line(self) -> None:
+        text = "the unknown is $x$"
+        assert normalize_extracted_problem_text(text) == "the unknown is $x$"
+
+    def test_preserves_content_inside_delimiters(self) -> None:
+        text = "已知 $ x + 1 $ 。"
+        assert normalize_extracted_problem_text(text) == "已知 $ x + 1 $ 。"
+
+
+class TestNormalizeExtractedProblemTextCombined:
+    def test_numeric_unwrap_runs_before_spacing(self) -> None:
+        # $45$ unwraps to 45 (no longer inline math), while $x$ gets spacing.
+        assert normalize_extracted_problem_text("已知$45$和$x$。") == "已知45和 $x$ 。"
+

--- a/backend/tests/worker/test_extraction_worker.py
+++ b/backend/tests/worker/test_extraction_worker.py
@@ -314,6 +314,44 @@ async def test_process_item_success_math(
 
 
 @pytest.mark.asyncio
+async def test_process_item_normalizes_draft_text_and_preserves_raw_text(
+    database: FakeDatabase,
+    storage: FakeStorage,
+    settings: Settings,
+) -> None:
+    batch_id, user_id, _image_id, item_id = _seed_batch_with_committed_item(
+        database,
+        storage,
+        subject="math",
+        box={"x": 0, "y": 0, "width": 1, "height": 1},
+    )
+    batch = await get_batch(database, batch_id, user_id)
+    item = batch["items"][0]
+
+    math_client = FakeIngestionVLMClient(model="math-model")
+    english_client = FakeIngestionVLMClient(model="english-model")
+    raw_text = "已知$45$和$x$，求$y$。"
+    math_client.responses.append(make_extraction_result(text=raw_text, model="math-model"))
+
+    await process_item(
+        item,
+        batch,
+        database,
+        storage,
+        math_client,
+        english_client,
+        settings,
+    )
+
+    refreshed = await get_batch(database, batch_id, batch["userId"])
+    stored_item = refreshed["items"][0]
+    # Draft text is normalized: numeric unwrapped, inline math spaced.
+    assert stored_item["draft"]["text"] == "已知45和 $x$ ，求 $y$ 。"
+    # Raw extraction text remains the unmodified VLM output.
+    assert stored_item["extraction"]["rawText"] == raw_text
+
+
+@pytest.mark.asyncio
 async def test_process_item_routes_to_english_client(
     database: FakeDatabase,
     storage: FakeStorage,


### PR DESCRIPTION
## Summary

- Add a shared backend helper `normalize_extracted_problem_text` in `backend/app/domain/normalization.py` that normalizes VLM-extracted problem text before it becomes editable draft text.
- Rule 1 (numeric unwrap): pure unsigned integers/decimals in single-dollar inline math are unwrapped, e.g. `$45$` -> `45`, `$3.14$` -> `3.14`, `$ 45 $` -> `45`. Negatives, comma-grouped numbers, percentages, fractions, variables and expressions are left wrapped.
- Rule 2 (inline spacing): remaining single-dollar inline `$...$` receives exactly one ASCII space before and after the expression unless at the start/end of a line, e.g. `已知$x$，求$y$。` -> `已知 $x$ ，求 $y$ 。`.
- Applied to both ingestion paths (single-preview `_run_extraction_task` and bulk `process_item`). `extraction.rawText` always remains the original unmodified VLM output.

## Linked Issue

Closes #434

## Issue Alignment

This PR implements the issue by:

- Adding `normalize_extracted_problem_text` in the shared backend domain normalization module.
- Calling it in both single-preview ingestion (`ingestion_workflow.py`) and bulk ingestion (`extraction_worker.py`) before extracted text is stored as editable draft text.
- Preserving `extraction.rawText` as the original VLM output in both paths.

Scope covered:

- Shared backend helper with the two rules in order (numeric unwrap, then inline spacing).
- Single-preview ingestion draft normalization with raw extraction text preservation.
- Bulk ingestion worker draft normalization with raw extraction text preservation.
- Unit tests for the helper (unwrap, no-overmatch, spacing, combined) and workflow tests for both ingestion paths.

Out of scope / intentionally not included:

- Frontend rendering changes.
- VLM prompt changes.
- Data migrations or backfilling stored previews/items/problems.
- Manually edited draft changes.
- Correct-answer normalization changes.
- Display-math `$$...$$` normalization.

## Implementation Notes

- The helper uses one inline-math regex `(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)` shared by both rules. It matches only single-dollar inline math and avoids display math `$$...$$` because neither delimiter may be adjacent to another `$`.
- Numeric unwrap runs first; unwrapped `$45$` is no longer inline math so the spacing rule does not touch it.
- Spacing is applied in two passes using `[ \t]` (horizontal whitespace only, never newlines) so inline math at the start/end of a line is preserved without leading/trailing space. Leading/trailing spaces adjacent to text are collapsed to exactly one.
- The single-preview path normalizes `result.text` before passing it to `_merge_draft_with_extraction`; existing choice-option normalization still runs afterward on the resolved draft text.

## Tests

Commands run:

- `pytest tests/domain/test_normalization.py -q` - passed (36 passed)
- `pytest tests/domain/test_normalization.py tests/api/test_ingestion.py tests/worker/test_extraction_worker.py -q` - passed (98 passed)
- `pytest tests/api/test_bulk_ingestion.py tests/api/test_problems.py tests/worker/ -q` - passed (139 passed)

Note on environment: the suggested command `cd backend && uv run --frozen --extra dev pytest ...` could not be run in the worktree because `uv sync --frozen --extra dev` requires a network download of `pymupdf` that is not present in the local uv cache (offline sync fails). I ran the equivalent pytest invocations against the repository virtualenv (`backend/.venv`) with `PYTHONPATH` pointed at the worktree source so `app` resolves to the worktree code, e.g.:

```
cd backend && PYTHONPATH=$(pwd) /home/rlan/projects/LearnLoop/backend/.venv/bin/python -m pytest tests/domain/test_normalization.py tests/api/test_ingestion.py tests/worker/test_extraction_worker.py -q
```

Automated tests added or updated:

- `backend/tests/domain/test_normalization.py`: unit tests for `normalize_extracted_problem_text` covering numeric unwrap (`$45$`, `$3.14$`, `$ 45 $`), non-unwrapped cases (`$-3$`, `$1,000$`, `$45\%$`, `$x$`, `$x+1$`, `$\frac{1}{2}$`, `$$45$$`), spacing (English/Chinese/punctuation adjacency, extra-space collapse, line-boundary preservation, content preservation), and a combined rule-ordering test.
- `backend/tests/api/test_ingestion.py`: `test_create_preview_normalizes_draft_text_and_preserves_raw_text` exercising the single-preview extraction path end-to-end.
- `backend/tests/worker/test_extraction_worker.py`: `test_process_item_normalizes_draft_text_and_preserves_raw_text` exercising the bulk `process_item` path.

Manual verification:

- Both ingestion-path tests feed fake VLM output `已知$45$和$x$，求$y$。` and assert the stored draft text is `已知45和 $x$ ，求 $y$ 。` (numeric `$45$` unwrapped, `$x$`/`$y$` spaced) while `extraction.rawText` remains the original unmodified VLM output.

## Deviations From Issue Plan

None. The implementation follows the chosen approach and file locations specified in the issue.

## Follow-Up Work

None.