### PR TITLE
Fix UTC timestamp serialization for frontend date rendering

### DIFF
--- a/backend/app/presentation/bulk_serialization.py
+++ b/backend/app/presentation/bulk_serialization.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel
@@ -11,7 +10,7 @@ from app.presentation.helpers import (
     build_ingestion_crop_url,
     build_ingestion_source_image_url,
 )
-from app.presentation.schemas import SourceImagePayload
+from app.presentation.schemas import SourceImagePayload, UTCDatetime
 
 
 class DetectionResponse(BaseModel):
@@ -29,9 +28,9 @@ class ImageResponse(BaseModel):
     subject: str | None
     boxes: list[dict[str, Any]]
     detection: DetectionResponse
-    committedAt: datetime | None
-    createdAt: datetime
-    updatedAt: datetime
+    committedAt: UTCDatetime | None
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
 
 
 class ItemResponse(BaseModel):
@@ -46,9 +45,9 @@ class ItemResponse(BaseModel):
     submit: dict[str, Any]
     origin: dict[str, Any]
     crop: dict[str, Any] | None
-    leaseUntil: datetime | None
-    createdAt: datetime
-    updatedAt: datetime
+    leaseUntil: UTCDatetime | None
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
 
 
 class BatchPayload(BaseModel):
@@ -57,9 +56,9 @@ class BatchPayload(BaseModel):
     status: str
     images: list[ImageResponse]
     items: list[ItemResponse]
-    createdAt: datetime
-    updatedAt: datetime
-    expiresAt: datetime
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
+    expiresAt: UTCDatetime
 
 
 class BatchResponse(BaseModel):

--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 from app.domain.models import ExamState, GradingStatus, ProblemType
 from app.presentation.helpers import build_problem_image_url
-from app.presentation.schemas import CorrectAnswerPayload, SourceImagePayload
+from app.presentation.schemas import CorrectAnswerPayload, SourceImagePayload, UTCDatetime
 
 
 class CreateExamRequest(BaseModel):
@@ -35,7 +34,7 @@ class ExamProblemPayload(BaseModel):
 
 class ExamAnswerPayload(BaseModel):
     raw: str | None = None
-    savedAt: datetime | None = None
+    savedAt: UTCDatetime | None = None
 
 
 class ExamGradingPayload(BaseModel):
@@ -46,7 +45,7 @@ class ExamGradingPayload(BaseModel):
     feedback: str | None = None
     providerModel: str | None = None
     rawProviderResponse: dict[str, Any] | None = None
-    gradedAt: datetime | None = None
+    gradedAt: UTCDatetime | None = None
     retryCount: int = 0
     selfReportedCorrect: bool | None = None
 
@@ -71,7 +70,7 @@ class SelectionPolicyPayload(BaseModel):
 class ExamConfigSnapshotPayload(BaseModel):
     maxProblemCount: int
     selectionPolicy: SelectionPolicyPayload
-    generatedAt: datetime
+    generatedAt: UTCDatetime
 
 
 class ExamSummaryPayload(BaseModel):
@@ -90,11 +89,11 @@ class ExamPayload(BaseModel):
     configSnapshot: ExamConfigSnapshotPayload
     items: list[ExamItemPayload]
     summary: ExamSummaryPayload
-    createdAt: datetime
-    startedAt: datetime | None = None
-    submittedAt: datetime | None = None
-    discardedAt: datetime | None = None
-    updatedAt: datetime
+    createdAt: UTCDatetime
+    startedAt: UTCDatetime | None = None
+    submittedAt: UTCDatetime | None = None
+    discardedAt: UTCDatetime | None = None
+    updatedAt: UTCDatetime
 
 
 class CreateExamResponse(BaseModel):
@@ -117,9 +116,9 @@ class SelfReportResponse(BaseModel):
 class ExamHistoryItemPayload(BaseModel):
     id: str
     state: ExamState
-    createdAt: datetime
-    submittedAt: datetime | None = None
-    discardedAt: datetime | None = None
+    createdAt: UTCDatetime
+    submittedAt: UTCDatetime | None = None
+    discardedAt: UTCDatetime | None = None
     summary: ExamSummaryPayload
 
 

--- a/backend/app/presentation/folders.py
+++ b/backend/app/presentation/folders.py
@@ -15,6 +15,7 @@ from app.presentation.helpers import (
     get_owned_folder,
     parse_object_id,
 )
+from app.presentation.schemas import UTCDatetime
 
 router = APIRouter(prefix="/folders", tags=["folders"])
 
@@ -27,8 +28,8 @@ class FolderNodePayload(BaseModel):
     parentId: str | None
     problemCount: int
     children: list["FolderNodePayload"]
-    createdAt: datetime
-    updatedAt: datetime
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
 
 
 class FolderTreeResponse(BaseModel):
@@ -51,8 +52,8 @@ class FolderPayload(BaseModel):
     id: str
     name: str
     parentId: str | None
-    createdAt: datetime
-    updatedAt: datetime
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
 
 
 class FolderResponse(BaseModel):

--- a/backend/app/presentation/ingestion_serialization.py
+++ b/backend/app/presentation/ingestion_serialization.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
 
-from app.presentation.schemas import CorrectAnswerPayload, SourceImagePayload
+from app.presentation.schemas import CorrectAnswerPayload, SourceImagePayload, UTCDatetime
 
 
 class PreviewDraftPayload(BaseModel):
@@ -20,8 +19,8 @@ class PreviewDraftPayload(BaseModel):
 
 class PreviewExtractionPayload(BaseModel):
     requestModel: str | None = None
-    requestStartedAt: datetime | None = None
-    requestFinishedAt: datetime | None = None
+    requestStartedAt: UTCDatetime | None = None
+    requestFinishedAt: UTCDatetime | None = None
     success: bool | None = None
     rawText: str | None = None
     rawProblemType: str | None = None
@@ -49,9 +48,9 @@ class PreviewPayload(BaseModel):
     draft: PreviewDraftPayload
     extraction: PreviewExtractionPayload
     helperDetection: PreviewHelperDetectionPayload
-    createdAt: datetime
-    updatedAt: datetime
-    expiresAt: datetime
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
+    expiresAt: UTCDatetime
 
 
 class PreviewResponse(BaseModel):
@@ -67,8 +66,8 @@ class ProblemPayload(BaseModel):
     correctAnswer: CorrectAnswerPayload
     tags: list[str] = Field(default_factory=list)
     sourceImage: SourceImagePayload | None = None
-    createdAt: datetime
-    updatedAt: datetime
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
 
 
 class ProblemResponse(BaseModel):

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -30,6 +30,7 @@ from app.infrastructure.storage.s3 import load_source_image_base64
 from app.presentation.helpers import build_problem_image_url, parse_object_id
 from app.presentation.exam_helpers import problem_document_to_model
 from app.presentation.errors import ApiError
+from app.presentation.schemas import UTCDatetime
 
 router = APIRouter(prefix="/practice", tags=["practice"])
 
@@ -57,7 +58,7 @@ class PracticeAttemptDetail(BaseModel):
     submittedAnswer: str
     gradingStatus: str
     gradingMethod: str
-    createdAt: datetime
+    createdAt: UTCDatetime
     feedback: str | None = None
 
 
@@ -65,7 +66,7 @@ class PracticeHistorySummary(BaseModel):
     totalAttempts: int
     correctCount: int
     wrongCount: int
-    lastPracticedAt: datetime | None = None
+    lastPracticedAt: UTCDatetime | None = None
     lastResult: str | None = None
 
 

--- a/backend/app/presentation/problem_serialization.py
+++ b/backend/app/presentation/problem_serialization.py
@@ -1,20 +1,19 @@
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel
 
 from app.domain.models import ProblemType
 from app.presentation.helpers import build_problem_image_url
-from app.presentation.schemas import CorrectAnswerPayload
+from app.presentation.schemas import CorrectAnswerPayload, UTCDatetime
 
 
 class TrackingPayload(BaseModel):
     exposureCount: int
     correctCount: int
     failedCount: int
-    lastTestedAt: datetime | None
+    lastTestedAt: UTCDatetime | None
     lastAttemptCorrect: bool | None
 
 
@@ -35,9 +34,9 @@ class ProblemSummaryPayload(BaseModel):
     tags: list[str]
     tracking: TrackingPayload
     isDeleted: bool
-    deletedAt: datetime | None
-    createdAt: datetime
-    updatedAt: datetime
+    deletedAt: UTCDatetime | None
+    createdAt: UTCDatetime
+    updatedAt: UTCDatetime
     imageUrl: str | None = None
     folderId: str | None = None
 

--- a/backend/app/presentation/schemas.py
+++ b/backend/app/presentation/schemas.py
@@ -1,8 +1,27 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
+from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field
+
+
+def ensure_utc(value: datetime | None) -> datetime | None:
+    """Treat naive datetimes (e.g. from Mongo/PyMongo) as UTC for API output.
+
+    Timezone-aware datetimes are converted to UTC; naive datetimes are assumed
+    to already be UTC. ``None`` is returned unchanged so optional fields are
+    preserved.
+    """
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+# Pydantic datetime field that always serializes with UTC timezone information.
+UTCDatetime = Annotated[datetime, AfterValidator(ensure_utc)]
 
 
 class CorrectAnswerPayload(BaseModel):
@@ -20,5 +39,5 @@ class SourceImagePayload(BaseModel):
     sha256: str | None = None
     width: int | None = None
     height: int | None = None
-    uploadedAt: datetime | None = None
+    uploadedAt: UTCDatetime | None = None
     mediaUrl: str | None = None

--- a/backend/app/presentation/tags.py
+++ b/backend/app/presentation/tags.py
@@ -12,6 +12,7 @@ from app.infrastructure.storage.mongo import Document
 from app.presentation.deps import CurrentUserDependency, DatabaseDependency
 from app.presentation.errors import ApiError
 from app.presentation.helpers import parse_object_id
+from app.presentation.schemas import UTCDatetime
 
 router = APIRouter(prefix="/tags", tags=["tags"])
 
@@ -19,7 +20,7 @@ router = APIRouter(prefix="/tags", tags=["tags"])
 class TagPayload(BaseModel):
     id: str
     name: str
-    createdAt: datetime
+    createdAt: UTCDatetime
     problemCount: int
 
 

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -231,6 +231,26 @@ async def test_problem_detail_defaults_missing_subject_to_math(
 
 
 @pytest.mark.asyncio
+async def test_problem_response_serializes_naive_utc_datetime_with_timezone(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    # Mongo/PyMongo returns UTC datetimes as naive by default. Simulate that
+    # storage shape so the regression is exercised through a real endpoint.
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    naive_utc = datetime(2026, 5, 25, 13, 51, 4)
+    problem = make_problem(user_id, created_at=naive_utc, updated_at=naive_utc)
+    database["problems"].seed(problem)
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}")
+
+    assert response.status_code == 200
+    created_at = response.json()["problem"]["createdAt"]
+    assert created_at == "2026-05-25T13:51:04Z"
+
+
+@pytest.mark.asyncio
 async def test_list_detail_update_delete_tags_and_tracking(
     problems_app: FastAPI,
     client: AsyncClient,

--- a/backend/tests/presentation/test_problem_serialization.py
+++ b/backend/tests/presentation/test_problem_serialization.py
@@ -8,7 +8,7 @@ preserving.
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timezone, timedelta
 from typing import Any
 
 from bson import ObjectId
@@ -23,6 +23,7 @@ from app.presentation.problem_serialization import (
     _serialize_problem_detail,
     _serialize_problem_summary,
 )
+from app.presentation.schemas import UTCDatetime, ensure_utc
 
 NOW = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
 
@@ -266,3 +267,52 @@ def test_serialize_detail_origin_none() -> None:
         "rawExtractedProblemType": None,
         "rawExtractedGraphDsl": None,
     }
+
+
+# ---- UTC timestamp serialization (timezone-naive Mongo datetimes) ----
+
+
+def test_ensure_utc_treats_naive_datetime_as_utc() -> None:
+    naive = datetime(2026, 5, 25, 13, 51, 4)
+    assert ensure_utc(naive) == naive.replace(tzinfo=UTC)
+
+
+def test_ensure_utc_converts_aware_datetime_to_utc() -> None:
+    aware = datetime(2026, 5, 25, 21, 51, 4, tzinfo=timezone(timedelta(hours=8)))
+    assert ensure_utc(aware) == datetime(2026, 5, 25, 13, 51, 4, tzinfo=UTC)
+
+
+def test_ensure_utc_leaves_none_unchanged() -> None:
+    assert ensure_utc(None) is None
+
+
+def test_naive_utc_datetime_serializes_with_utc_timezone() -> None:
+    # Simulates a naive UTC datetime returned by Mongo/PyMongo (tz_aware=False).
+    naive = datetime(2026, 5, 25, 13, 51, 4)
+    problem = _make_problem(createdAt=naive, updatedAt=naive)
+    detail = _serialize_problem_detail(problem)
+
+    json = detail.model_dump_json()
+    assert '"createdAt":"2026-05-25T13:51:04Z"' in json
+    assert '"updatedAt":"2026-05-25T13:51:04Z"' in json
+
+
+def test_aware_utc_datetime_serializes_with_utc_timezone() -> None:
+    problem = _make_problem()
+    detail = _serialize_problem_detail(problem)
+
+    assert detail.createdAt.tzinfo is not None
+    json = detail.model_dump_json()
+    assert '"createdAt":"2026-01-01T00:00:00Z"' in json
+
+
+def test_naive_optional_datetime_serializes_with_utc_timezone() -> None:
+    naive = datetime(2026, 5, 25, 13, 51, 4)
+    problem = _make_problem(deletedAt=naive)
+    problem["tracking"]["lastTestedAt"] = naive
+    summary = _serialize_problem_summary(problem)
+
+    json = summary.model_dump_json()
+    assert '"lastTestedAt":"2026-05-25T13:51:04Z"' in json
+    assert '"deletedAt":"2026-05-25T13:51:04Z"' in json
+

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -74,4 +74,19 @@ describe("formatDate", () => {
     // In UTC, the date should remain Jan 15
     expect(result).toContain("1/15/2026");
   });
+
+  it("renders a UTC timestamp as the GMT+8 converted time, not the raw UTC wall time", () => {
+    // Mock timezone detection to Asia/Shanghai (UTC+8).
+    vi.spyOn(Intl, "DateTimeFormat").mockImplementation(
+      (() => ({
+        resolvedOptions: () => ({ timeZone: "Asia/Shanghai" }),
+      })) as unknown as typeof Intl.DateTimeFormat,
+    );
+
+    // 2026-05-25T13:51:04Z is 2026-05-25T21:51:04+08:00 in GMT+8.
+    const result = formatDate("2026-05-25T13:51:04Z");
+    // The converted GMT+8 wall time is 9:51:04 PM, not the raw UTC 13:51.
+    expect(result).toContain("9:51:04 PM");
+    expect(result).not.toContain("1:51:04 PM");
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes the bug where UTC datetimes read from MongoDB were sent to the frontend as timezone-naive strings (e.g. `2026-05-25T13:51:04`), causing the browser to interpret them as local wall time and render the wrong converted time.
- Adds a shared backend helper `ensure_utc` and a `UTCDatetime` annotated Pydantic type in `backend/app/presentation/schemas.py` that treats naive datetimes as UTC, converts aware datetimes to UTC, and leaves `None` unchanged.
- Applies `UTCDatetime` to response-model datetime fields across the presentation layer (problem, exam, practice, ingestion, tags, bulk, folders, shared schemas) so API datetimes now serialize with a `Z` suffix, e.g. `2026-05-25T13:51:04Z`.
- Mongo storage behavior is unchanged; the fix is entirely at backend serialization.

## Linked Issue

Closes #435

## Issue Alignment

This PR implements the issue by:

- Adding a small shared backend helper (`ensure_utc`) plus a `UTCDatetime` annotated type that coerces naive datetimes to UTC and preserves/converts aware datetimes to UTC for API output, leaving `None` unchanged.
- Applying it to the response serialization paths that expose datetimes used by the frontend (problem, exam, practice, ingestion, and the other typed response models: tags, bulk, folders, shared `SourceImagePayload`).
- Keeping the frontend `formatDate` behavior and adding a test proving timezone-aware UTC input renders the GMT+8 converted time.

Scope covered:

- Backend serialization of API datetime fields (typed response models).
- Treating naive datetimes from Mongo/PyMongo as UTC before JSON serialization.
- Preserving already timezone-aware datetimes (converted to UTC).
- Regression tests for backend API serialization and frontend date formatting.

Out of scope / intentionally not included:

- MongoDB data migration or backfill.
- Changing how datetimes are stored in MongoDB (the Mongo client `tz_aware` setting is intentionally left unchanged per the issue).
- Changing the user-facing date format beyond the timezone conversion.
- Frontend library changes / new dependencies.
- Broad unrelated response-model refactors (opaque `dict[str, Any]` passthrough fields in bulk serialization, e.g. nested `extraction`/`submit` operational metadata, were not restructured).

## Implementation Notes

- `UTCDatetime = Annotated[datetime, AfterValidator(ensure_utc)]`. Pydantic runs the validator after type validation, so a naive `datetime` instance becomes UTC-aware and serializes as `...Z`. `None` passes through for optional fields.
- The type is declarative and applied only to response-model datetime fields; it coerces at validation time, so both direct construction and `model_validate(...)` dict paths (e.g. `serialize_preview`, `serialize_problem`) are handled uniformly.
- Confirmed the Mongo client (`AsyncMongoClient(uri)`) has no `tz_aware=True`, so naive UTC datetimes are the real read-back shape; the fix is applied at serialization as the issue directs.
- The frontend `formatDate` was already correct for `Z`-suffixed input; the bug was purely that the backend omitted the timezone suffix for naive datetimes.

## Tests

Commands run:

- `pytest tests/presentation tests/api -q` - passed (384 passed)
- `pytest tests/presentation/test_problem_serialization.py tests/api/test_problems.py -q` - passed (65 passed)
- `pytest tests/integration tests/worker -q` - passed (42 passed)
- `npm test -- --run src/utils/format.test.ts` - passed (9 passed)

Note on environment: the suggested `cd backend && uv run --frozen --extra dev pytest ...` could not run in the worktree because `uv sync --frozen --extra dev` requires a network download (`pymupdf`) not present in the local uv cache. I ran the equivalent pytest against the repository venv (`backend/.venv`) with `PYTHONPATH` pointed at the worktree so `app` resolves to the worktree source, e.g.:

```
cd backend && PYTHONPATH=$(pwd) /home/rlan/projects/LearnLoop/backend/.venv/bin/python -m pytest tests/presentation tests/api -q
```

Frontend tests ran via the repo `node_modules` (symlinked into the worktree for the run, then removed; `node_modules` is gitignored).

Automated tests added or updated:

- `backend/tests/presentation/test_problem_serialization.py`: `ensure_utc` helper tests (naive->UTC, aware->UTC, None unchanged), and JSON serialization tests proving naive/aware UTC datetimes and optional fields emit `Z`.
- `backend/tests/api/test_problems.py`: `test_problem_response_serializes_naive_utc_datetime_with_timezone` exercises the problem detail endpoint with a Mongo-style naive UTC datetime and asserts the response `createdAt == "2026-05-25T13:51:04Z"`.
- `frontend/src/utils/format.test.ts`: `renders a UTC timestamp as the GMT+8 converted time, not the raw UTC wall time` mocks `Asia/Shanghai` and asserts `formatDate("2026-05-25T13:51:04Z")` contains `9:51:04 PM` (the GMT+8 converted time) and not the raw UTC wall time.

Manual verification:

- Backend: a naive UTC `datetime(2026, 5, 25, 13, 51, 4)` (Mongo shape) now serializes as `2026-05-25T13:51:04Z`; an aware UTC datetime also serializes as `...Z` (verified by unit + endpoint tests).
- Frontend: `new Date("2026-05-25T13:51:04Z").toLocaleString(..., { timeZone: "Asia/Shanghai" })` produces `5/25/2026, 9:51:04 PM GMT+8`, i.e. the correct GMT+8 conversion from the UTC instant (verified by Node check and the new vitest test).

## Deviations From Issue Plan

- The issue lists "Likely relevant areas" as problem/exam/practice/ingestion serialization. The Scope states "Backend serialization of API datetime fields" generally, so I also applied `UTCDatetime` to the other typed response models with datetime fields (`tags.py`, `bulk_serialization.py`, `folders.py`, shared `SourceImagePayload`) for a complete fix of the frontend-visible bug. Each change is a direct `datetime -> UTCDatetime` field-type change, not an unrelated refactor.
- Opaque `dict[str, Any]` passthrough fields in bulk serialization (e.g. nested `extraction`/`submit` operational metadata containing datetimes) were not restructured; only the typed response datetime fields were fixed. Restructuring those would be a broad refactor explicitly out of scope.

## Follow-Up Work

A future cleanup could centralize all Pydantic response datetime serialization (and/or set PyMongo `tz_aware=True`) to also cover opaque passthrough dicts, if new real defects are observed.