### PR TITLE
Add First-Pass Rate metric to homepage

### DIFF
--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -27,6 +27,12 @@ class HomeConquest(BaseModel):
     percentage: int
 
 
+class HomeFirstPass(BaseModel):
+    attemptedProblems: int
+    firstPassCorrectProblems: int
+    percentage: int
+
+
 class HomeActivityDay(BaseModel):
     date: str
     count: int
@@ -41,6 +47,7 @@ class HomeActivity(BaseModel):
 class HomeSummaryResponse(BaseModel):
     coverage: HomeCoverage
     conquest: HomeConquest
+    firstPass: HomeFirstPass
     activity: HomeActivity
 
 
@@ -68,6 +75,7 @@ async def get_home_summary(
 
     tried_problem_ids: set[Any] = set()
     latest_mastery: dict[Any, tuple[datetime, bool]] = {}
+    earliest_attempt: dict[Any, tuple[datetime, bool]] = {}
 
     def _consider_mastery(problem_id: Any, event_time: Any, status: str) -> None:
         if status not in _MASTERY_STATUSES:
@@ -79,6 +87,16 @@ async def get_home_summary(
         if previous is None or event_time > previous[0]:
             latest_mastery[problem_id] = (event_time, is_correct)
 
+    def _consider_first_pass(problem_id: Any, event_time: Any, status: str) -> None:
+        if not isinstance(event_time, datetime):
+            return
+        is_correct = status == GradingStatus.CORRECT.value
+        previous = earliest_attempt.get(problem_id)
+        if previous is None or event_time < previous[0]:
+            earliest_attempt[problem_id] = (event_time, is_correct)
+        elif event_time == previous[0]:
+            earliest_attempt[problem_id] = (event_time, previous[1] or is_correct)
+
     practice_attempts = await database["practice_attempts"].find(
         {"userId": user_id}
     ).to_list(length=None)
@@ -87,6 +105,11 @@ async def get_home_summary(
         if problem_id in non_deleted_problem_ids:
             tried_problem_ids.add(problem_id)
             _consider_mastery(
+                problem_id,
+                attempt.get("createdAt"),
+                str(attempt.get("gradingStatus", "")),
+            )
+            _consider_first_pass(
                 problem_id,
                 attempt.get("createdAt"),
                 str(attempt.get("gradingStatus", "")),
@@ -108,6 +131,11 @@ async def get_home_summary(
                 submitted_at,
                 str(grading.get("status", "")),
             )
+            _consider_first_pass(
+                problem_id,
+                submitted_at,
+                str(grading.get("status", "")),
+            )
 
     tried_problems = len(tried_problem_ids)
     percentage = round((tried_problems / total_problems) * 100) if total_problems else 0
@@ -115,6 +143,13 @@ async def get_home_summary(
     mastered_problems = sum(1 for _, is_correct in latest_mastery.values() if is_correct)
     conquest_percentage = (
         round((mastered_problems / total_problems) * 100) if total_problems else 0
+    )
+
+    first_pass_correct_problems = sum(
+        1 for _, is_correct in earliest_attempt.values() if is_correct
+    )
+    first_pass_percentage = (
+        round((first_pass_correct_problems / tried_problems) * 100) if tried_problems else 0
     )
 
     today = datetime.now(tz).date()
@@ -159,6 +194,11 @@ async def get_home_summary(
             totalProblems=total_problems,
             masteredProblems=mastered_problems,
             percentage=conquest_percentage,
+        ),
+        firstPass=HomeFirstPass(
+            attemptedProblems=tried_problems,
+            firstPassCorrectProblems=first_pass_correct_problems,
+            percentage=first_pass_percentage,
         ),
         activity=HomeActivity(
             startDate=start_date.strftime("%Y-%m-%d"),

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -102,6 +102,9 @@ async def test_summary_no_problems_returns_zero(home_app: FastAPI, client: Async
     assert data["conquest"]["totalProblems"] == 0
     assert data["conquest"]["masteredProblems"] == 0
     assert data["conquest"]["percentage"] == 0
+    assert data["firstPass"]["attemptedProblems"] == 0
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+    assert data["firstPass"]["percentage"] == 0
     assert data["activity"]["startDate"]
     assert data["activity"]["endDate"]
     assert len(data["activity"]["days"]) == 365
@@ -545,3 +548,225 @@ async def test_summary_omitting_timezone_defaults_to_utc(
     day_with = next(d for d in data_with["activity"]["days"] if d["date"] == today_str)
     day_without = next(d for d in data_without["activity"]["days"] if d["date"] == today_str)
     assert day_with["count"] == day_without["count"]
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_no_attempts_returns_zero(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Problems exist but no attempts: firstPass should be zero."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 0
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+    assert data["firstPass"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_correct_practice_attempt(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """First practice attempt correct yields 100%."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 1
+    assert data["firstPass"]["firstPassCorrectProblems"] == 1
+    assert data["firstPass"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_incorrect_then_correct_not_first_pass(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """First attempt incorrect, later correct: not first-pass correct."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    newer = datetime(2026, 2, 1, tzinfo=UTC)
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem["_id"], created_at=older, grading_status="incorrect"),
+        make_practice_attempt(user_id, problem["_id"], created_at=newer, grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 1
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+    assert data["firstPass"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_exam_correct_item(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """First submitted exam item correct counts as first-pass correct."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("exams", [
+        make_submitted_exam(
+            user_id,
+            problem_ids=[problem["_id"]],
+            submitted_at=datetime(2026, 1, 15, tzinfo=UTC),
+            item_grading_statuses=["correct"],
+        )
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 1
+    assert data["firstPass"]["firstPassCorrectProblems"] == 1
+    assert data["firstPass"]["percentage"] == 100
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_pending_review_counts_in_denominator_only(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Pending-review first attempt counts in denominator, not numerator."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("practice_attempts", [
+        make_practice_attempt(
+            user_id, problem["_id"],
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            grading_status="pending-review",
+        ),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 1
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+    assert data["firstPass"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_ungraded_exam_counts_in_denominator_only(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Ungraded exam item first attempt counts in denominator, not numerator."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    database.seed("exams", [
+        make_submitted_exam(
+            user_id,
+            problem_ids=[problem["_id"]],
+            submitted_at=datetime(2026, 1, 15, tzinfo=UTC),
+            item_grading_statuses=["ungraded"],
+        )
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 1
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+    assert data["firstPass"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_deleted_problems_excluded(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Deleted problems' attempts do not count in firstPass."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    active = make_problem(user_id)
+    deleted = make_problem(user_id, is_deleted=True)
+    database.seed("problems", [active, deleted])
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, deleted["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 0
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+    assert data["firstPass"]["percentage"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_other_users_excluded(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Other users' attempts do not count in firstPass."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    other_user_id = ObjectId()
+    own = make_problem(user_id)
+    other = make_problem(other_user_id)
+    database.seed("problems", [own, other])
+    database.seed("practice_attempts", [
+        make_practice_attempt(other_user_id, other["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="correct"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 0
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_discarded_in_progress_excluded(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Discarded and in-progress exams do not count in firstPass."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem = make_problem(user_id)
+    database.seed("problems", [problem])
+    now = datetime(2026, 1, 1, tzinfo=UTC)
+
+    in_progress_exam = make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=now)
+    in_progress_exam["state"] = "in-progress"
+    in_progress_exam["submittedAt"] = None
+    discarded_exam = make_submitted_exam(user_id, problem_ids=[problem["_id"]], submitted_at=now)
+    discarded_exam["state"] = "discarded"
+    database.seed("exams", [in_progress_exam, discarded_exam])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 0
+    assert data["firstPass"]["firstPassCorrectProblems"] == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_first_pass_mixed_correct_and_incorrect(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """One first-correct and one first-incorrect: 50%."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    problem_a = make_problem(user_id)
+    problem_b = make_problem(user_id)
+    database.seed("problems", [problem_a, problem_b])
+    database.seed("practice_attempts", [
+        make_practice_attempt(user_id, problem_a["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="correct"),
+        make_practice_attempt(user_id, problem_b["_id"], created_at=datetime(2026, 1, 1, tzinfo=UTC), grading_status="incorrect"),
+    ])
+
+    response = await client.get("/api/v1/home/summary")
+    data = response.json()
+    assert data["firstPass"]["attemptedProblems"] == 2
+    assert data["firstPass"]["firstPassCorrectProblems"] == 1
+    assert data["firstPass"]["percentage"] == 50

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -71,6 +71,7 @@ describe("App", () => {
       json: async () => ({
         coverage: { totalProblems: 0, triedProblems: 0, percentage: 0 },
         conquest: { totalProblems: 0, masteredProblems: 0, percentage: 0 },
+        firstPass: { attemptedProblems: 0, firstPassCorrectProblems: 0, percentage: 0 },
         activity: { startDate: "2024-01-01", endDate: "2024-12-31", days: [{ date: "2024-01-01", count: 0 }] },
       }),
     });

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -36,6 +36,9 @@ function summaryResponse(overrides: Partial<{
   percentage: number;
   masteredProblems: number;
   conquestPercentage: number;
+  firstPassAttempted: number;
+  firstPassCorrect: number;
+  firstPassPercentage: number;
   days: { date: string; count: number }[];
 }> = {}) {
   const today = new Date();
@@ -56,6 +59,11 @@ function summaryResponse(overrides: Partial<{
       totalProblems,
       masteredProblems: overrides.masteredProblems ?? 0,
       percentage: overrides.conquestPercentage ?? 0,
+    },
+    firstPass: {
+      attemptedProblems: overrides.firstPassAttempted ?? 1,
+      firstPassCorrectProblems: overrides.firstPassCorrect ?? 0,
+      percentage: overrides.firstPassPercentage ?? 0,
     },
     activity: {
       startDate: days[0].date,
@@ -109,7 +117,7 @@ describe("HomePage", () => {
   it("renders zero-problem state with 0% and note", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => summaryResponse({ totalProblems: 0, triedProblems: 0, percentage: 0, masteredProblems: 0, conquestPercentage: 0 }),
+      json: async () => summaryResponse({ totalProblems: 0, triedProblems: 0, percentage: 0, masteredProblems: 0, conquestPercentage: 0, firstPassAttempted: 0, firstPassCorrect: 0, firstPassPercentage: 0 }),
     });
     renderHomePage();
     await waitFor(() => {
@@ -118,6 +126,8 @@ describe("HomePage", () => {
     expect(screen.getByTestId("home-coverage-text").textContent).toContain("No problems yet");
     expect(screen.getByTestId("home-conquest-percentage").textContent).toBe("0%");
     expect(screen.getByTestId("home-conquest-text").textContent).toContain("No problems yet");
+    expect(screen.getByTestId("home-firstpass-percentage").textContent).toBe("0%");
+    expect(screen.getByTestId("home-firstpass-text").textContent).toContain("No attempts yet");
   });
 
   it("renders coverage percentage and supporting text in normal state", async () => {
@@ -148,6 +158,46 @@ describe("HomePage", () => {
       expect(screen.getByTestId("home-conquest-percentage").textContent).toBe("50%");
     });
     expect(screen.getByTestId("home-conquest-text").textContent).toContain("2 of 4 problems mastered");
+  });
+
+  it("renders first-pass rate as the third stat card with percentage and supporting text", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({
+        totalProblems: 4,
+        triedProblems: 3,
+        percentage: 75,
+        masteredProblems: 2,
+        conquestPercentage: 50,
+        firstPassAttempted: 4,
+        firstPassCorrect: 2,
+        firstPassPercentage: 50,
+      }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-firstpass-percentage").textContent).toBe("50%");
+    });
+    expect(screen.getByTestId("home-firstpass-text").textContent).toContain("2 of 4 attempted problems correct on first try");
+  });
+
+  it("renders no-attempt message when firstPass has zero attempts", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({
+        totalProblems: 2,
+        triedProblems: 0,
+        percentage: 0,
+        firstPassAttempted: 0,
+        firstPassCorrect: 0,
+        firstPassPercentage: 0,
+      }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-firstpass-percentage").textContent).toBe("0%");
+    });
+    expect(screen.getByTestId("home-firstpass-text").textContent).toContain("No attempts yet");
   });
 
   it("renders activity grid cells with returned counts", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -16,6 +16,12 @@ interface HomeConquest {
   percentage: number;
 }
 
+interface HomeFirstPass {
+  attemptedProblems: number;
+  firstPassCorrectProblems: number;
+  percentage: number;
+}
+
 interface HomeActivityDay {
   date: string;
   count: number;
@@ -30,6 +36,7 @@ interface HomeActivity {
 interface HomeSummaryResponse {
   coverage: HomeCoverage;
   conquest: HomeConquest;
+  firstPass: HomeFirstPass;
   activity: HomeActivity;
 }
 
@@ -156,7 +163,7 @@ export function HomePage() {
     return <main style={pageCanvasStyle} />;
   }
 
-  const { coverage, conquest, activity } = data;
+  const { coverage, conquest, firstPass, activity } = data;
   const maxCount = activity.days.reduce((max, day) => Math.max(max, day.count), 0);
   const weekColumns = buildWeekColumns(activity.days);
   const monthLabels = buildMonthLabels(weekColumns);
@@ -217,6 +224,24 @@ export function HomePage() {
             ) : (
               <>
                 {conquest.masteredProblems} of {conquest.totalProblems} problems mastered
+              </>
+            )}
+          </div>
+        </section>
+
+        <section style={statCardStyle}>
+          <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.5rem" }}>
+            First-Pass Rate
+          </div>
+          <div data-testid="home-firstpass-percentage" style={{ fontSize: "3.5rem", fontWeight: 800, lineHeight: 1, color: "var(--color-primary)" }}>
+            {firstPass.percentage}%
+          </div>
+          <div data-testid="home-firstpass-text" style={{ marginTop: "0.5rem", color: "var(--color-text-muted)", fontSize: "0.95rem" }}>
+            {firstPass.attemptedProblems === 0 ? (
+              "No attempts yet. Try problems to start tracking first-pass rate."
+            ) : (
+              <>
+                {firstPass.firstPassCorrectProblems} of {firstPass.attemptedProblems} attempted problems correct on first try
               </>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Add a third homepage stat card `First-Pass Rate` showing the percentage of attempted problems whose earliest recorded attempt was correct.
- Backend: new `HomeFirstPass` model + `firstPass` field on `HomeSummaryResponse`; tracks earliest attempt per problem across practice attempts and submitted exam items.
- Frontend: new `HomeFirstPass` type + third stat card rendered after `Conquest Rate`.

## Linked Issue

Closes #438

## Issue Alignment

This PR implements the issue by:

- Extending `/api/v1/home/summary` with a `firstPass` object (`attemptedProblems`, `firstPassCorrectProblems`, `percentage`).
- Calculating first-pass rate from the same data sources and ownership filtering as coverage/conquest: `practice_attempts` (using `createdAt`) and submitted exam items (using exam `submittedAt`).
- Excluding deleted problems, other users' data, discarded exams, and in-progress exams (same filters as existing metrics).
- Rendering `First-Pass Rate` as the third stat card on the homepage.

Scope covered:

- Backend `HomeFirstPass` model and `firstPass` field on `HomeSummaryResponse`.
- Earliest-attempt tracking across practice and exam sources with tie-breaking (same-timestamp events: correct if any is correct).
- Frontend `HomeFirstPass` type, third stat card with normal and zero-attempt supporting text.
- Backend and frontend tests for normal, zero-attempt, exclusion, and mixed-correctness cases.

Out of scope / intentionally not included:

- Charts, filters, trend views, or drill-downs for first-pass data.
- Data migrations, new collections, or historical backfills.
- Changes to existing coverage/conquest/activity calculations.
- Changes to practice or exam grading behavior.
- Separate API endpoint.

## Implementation Notes

- `earliest_attempt` dict tracks `(datetime, is_correct)` per problem. The helper `_consider_first_pass` is called at the same call sites as the existing `_consider_mastery`, using the same `problem_id`, `event_time`, and `status` arguments.
- Tie-breaking: when multiple events share the earliest timestamp, `is_correct` is OR-ed (correct if any event at that timestamp is correct).
- The denominator (`attemptedProblems`) equals `tried_problems` (the existing `tried_problem_ids` set), matching coverage's attempted-problem semantics.
- Non-datetime `event_time` values are skipped (consistent with `_consider_mastery`).
- Frontend zero-attempt state is based on `firstPass.attemptedProblems === 0` (distinct from the zero-problem state based on `coverage.totalProblems === 0`).

## Tests

Commands run:

- `cd backend && PYTHONPATH=$(pwd) /home/rlan/projects/LearnLoop/backend/.venv/bin/python -m pytest tests/api/test_home.py -q` - passed (31 passed)
- `cd frontend && npm test -- --run src/pages/HomePage.test.tsx` - passed (21 passed)

> Note: `uv run --frozen --extra dev` is unavailable in worktrees due to `pymupdf` not being in the uv cache. The same test suites were run against the repo venv with `PYTHONPATH` override, which exercises the same code.

Automated tests added or updated:

Backend (`tests/api/test_home.py`):
- `test_summary_no_problems_returns_zero` - updated to assert `firstPass` is zero.
- `test_summary_first_pass_no_attempts_returns_zero` - problems exist but no attempts.
- `test_summary_first_pass_correct_practice_attempt` - first practice attempt correct -> 100%.
- `test_summary_first_pass_incorrect_then_correct_not_first_pass` - first incorrect, later correct -> 0%.
- `test_summary_first_pass_exam_correct_item` - exam item correct -> 100%.
- `test_summary_first_pass_pending_review_counts_in_denominator_only` - pending-review in denominator, not numerator.
- `test_summary_first_pass_ungraded_exam_counts_in_denominator_only` - ungraded exam in denominator, not numerator.
- `test_summary_first_pass_deleted_problems_excluded` - deleted problem attempts excluded.
- `test_summary_first_pass_other_users_excluded` - other users' attempts excluded.
- `test_summary_first_pass_discarded_in_progress_excluded` - discarded/in-progress exams excluded.
- `test_summary_first_pass_mixed_correct_and_incorrect` - one first-correct, one first-incorrect -> 50%.

Frontend (`src/pages/HomePage.test.tsx`):
- `summaryResponse` helper updated to include `firstPass` defaults.
- Zero-problem test updated to assert first-pass zero-attempt message.
- `renders first-pass rate as the third stat card with percentage and supporting text` - normal state.
- `renders no-attempt message when firstPass has zero attempts` - zero-attempt state.

Manual verification:

- Backend: 31/31 tests pass including 11 new first-pass tests covering all required scenarios.
- Frontend: 21/21 tests pass including 3 new/updated first-pass tests.
- The third stat card renders after `Conquest Rate` with `data-testid="home-firstpass-percentage"` and `data-testid="home-firstpass-text"`.

## Deviations From Issue Plan

None.

## Follow-Up Work

None required. Future work could add trend or drill-down views for first-pass performance, but that is explicitly out of scope per the issue.