### PR TITLE
Add password-protected problem disable/enable state

### DIFF
--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -199,6 +199,7 @@ class Problem(BaseModel):
     tracking: Tracking = Field(default_factory=Tracking)
     isDeleted: bool = False
     deletedAt: Optional[datetime] = None
+    isDisabled: bool = False
     createdAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updatedAt: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/backend/app/domain/practice_selection.py
+++ b/backend/app/domain/practice_selection.py
@@ -67,7 +67,14 @@ def compute_problem_weight_breakdown(
 
 
 def _has_practiceable_answer(problems: List[Problem]) -> list[Problem]:
-    return [p for p in problems if not p.isDeleted and p.correctAnswer and p.correctAnswer.normalizedText]
+    return [
+        p
+        for p in problems
+        if not p.isDeleted
+        and not p.isDisabled
+        and p.correctAnswer
+        and p.correctAnswer.normalizedText
+    ]
 
 
 def select_practice_problem(

--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -39,6 +39,8 @@ def get_eligible_problems(
     for p in problems:
         if p.isDeleted:
             continue
+        if p.isDisabled:
+            continue
         if not p.correctAnswer or not p.correctAnswer.normalizedText:
             continue
         if config.min_problem_age_days > 0:

--- a/backend/app/presentation/exam_helpers.py
+++ b/backend/app/presentation/exam_helpers.py
@@ -35,6 +35,7 @@ def problem_document_to_model(problem: Mapping[str, Any]) -> Problem:
                 "tracking": problem.get("tracking", {}),
                 "isDeleted": problem.get("isDeleted", False),
                 "deletedAt": problem.get("deletedAt"),
+                "isDisabled": problem.get("isDisabled", False),
                 "createdAt": problem["createdAt"],
                 "updatedAt": problem["updatedAt"],
             }

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -76,7 +76,11 @@ async def create_exam(
             raise ApiError(409, "ACTIVE_EXAM_EXISTS", "An active exam already exists")
 
         problem_documents = await database["problems"].find(
-            {"userId": current_user["_id"], "isDeleted": False},
+            {
+                "userId": current_user["_id"],
+                "isDeleted": False,
+                "isDisabled": {"$ne": True},
+            },
             session=session,
         ).to_list(length=None)
         eligible_documents = [

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -96,7 +96,7 @@ async def get_practice_stats(
     settings: SettingsDependency,
 ) -> PracticeStatsResponse:
     problem_documents = await database["problems"].find(
-        {"userId": current_user["_id"], "isDeleted": False}
+        {"userId": current_user["_id"], "isDeleted": False, "isDisabled": {"$ne": True}}
     ).to_list(length=None)
 
     problem_models = [problem_document_to_model(p) for p in problem_documents]
@@ -117,7 +117,7 @@ async def get_next_practice_problem(
     settings: SettingsDependency,
 ) -> PracticeNextResponse:
     problem_documents = await database["problems"].find(
-        {"userId": current_user["_id"], "isDeleted": False}
+        {"userId": current_user["_id"], "isDeleted": False, "isDisabled": {"$ne": True}}
     ).to_list(length=None)
 
     eligible_documents = [

--- a/backend/app/presentation/problem_creation.py
+++ b/backend/app/presentation/problem_creation.py
@@ -94,6 +94,7 @@ async def create_problem_from_draft(
         },
         "isDeleted": False,
         "deletedAt": None,
+        "isDisabled": False,
         "createdAt": current,
         "updatedAt": current,
     }

--- a/backend/app/presentation/problem_serialization.py
+++ b/backend/app/presentation/problem_serialization.py
@@ -35,6 +35,7 @@ class ProblemSummaryPayload(BaseModel):
     tracking: TrackingPayload
     isDeleted: bool
     deletedAt: UTCDatetime | None
+    isDisabled: bool
     createdAt: UTCDatetime
     updatedAt: UTCDatetime
     imageUrl: str | None = None
@@ -131,6 +132,7 @@ def _serialize_problem_summary(problem: dict[str, Any]) -> ProblemSummaryPayload
         tracking=_serialize_tracking(problem),
         isDeleted=bool(problem.get("isDeleted", False)),
         deletedAt=problem.get("deletedAt"),
+        isDisabled=bool(problem.get("isDisabled", False)),
         createdAt=problem["createdAt"],
         updatedAt=problem["updatedAt"],
         imageUrl=build_problem_image_url(str(problem["_id"]))

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -13,7 +13,9 @@ from pydantic import BaseModel, Field
 from app.domain.models import ProblemType
 from app.domain.normalization import normalize_answer
 from app.domain.practice_selection import PracticeSelectionConfig, compute_problem_weight_breakdown
+from app.infrastructure.auth.password import verify_password
 from app.infrastructure.config.settings import Settings, get_settings
+from app.observability import log_teacher_password_event
 from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
 from app.presentation.exam_helpers import problem_document_to_model
@@ -33,6 +35,7 @@ from app.presentation.problem_serialization import (
 )
 from app.solution_generation import regenerate_solution_task_for_problem
 from app.presentation.tag_registration import _register_tags
+from app.presentation.teacher_password import _ensure_teacher_password_hash
 
 router = APIRouter(prefix="/problems", tags=["problems"])
 
@@ -52,6 +55,11 @@ class SetProblemFolderRequest(BaseModel):
 class BulkSetFolderRequest(BaseModel):
     problemIds: list[str] = Field(min_length=1)
     folderId: str | None = None
+
+
+class ToggleProblemDisabledRequest(BaseModel):
+    isDisabled: bool
+    teacherPassword: str = Field(min_length=1, max_length=1024)
 
 
 CurrentUserDependency = Annotated[dict[str, Any], Depends(get_current_user)]
@@ -366,6 +374,44 @@ async def set_problem_folder(
 
     updated_problem = deepcopy(problem)
     updated_problem["folderId"] = target_folder_id
+    updated_problem["updatedAt"] = now
+    return ProblemResponse(problem=_serialize_problem_detail(updated_problem))
+
+
+@router.patch("/{problem_id}/disabled", response_model=ProblemResponse)
+async def set_problem_disabled(
+    problem_id: str,
+    payload: ToggleProblemDisabledRequest,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> ProblemResponse:
+    """Enable or disable a problem, protected by teacher password validation."""
+    problem = await get_owned_problem(
+        database, problem_id, current_user["_id"], allow_deleted=False
+    )
+
+    teacher_password_hash = await _ensure_teacher_password_hash(
+        current_user, database, settings
+    )
+    ok = verify_password(payload.teacherPassword, teacher_password_hash)
+    log_teacher_password_event(
+        "disable_verify_attempt",
+        user_id=str(current_user["_id"]),
+        username=current_user["username"],
+        success=ok,
+    )
+    if not ok:
+        raise ApiError(401, "UNAUTHENTICATED", "Incorrect teacher password")
+
+    now = datetime.now(UTC)
+    await database["problems"].update_one(
+        {"_id": problem["_id"]},
+        {"$set": {"isDisabled": payload.isDisabled, "updatedAt": now}},
+    )
+
+    updated_problem = deepcopy(problem)
+    updated_problem["isDisabled"] = payload.isDisabled
     updated_problem["updatedAt"] = now
     return ProblemResponse(problem=_serialize_problem_detail(updated_problem))
 

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -33,6 +33,7 @@ def make_problem(
     correct_answer_display: str = "4",
     subject: str = "math",
     is_deleted: bool = False,
+    is_disabled: bool = False,
     last_tested_at: datetime | None = None,
     exposure_count: int = 0,
 ) -> dict[str, Any]:
@@ -62,6 +63,7 @@ def make_problem(
         },
         "isDeleted": is_deleted,
         "deletedAt": None,
+        "isDisabled": is_disabled,
         "createdAt": now,
         "updatedAt": now,
     }

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -111,6 +111,7 @@ def make_problem(
     normalized_text: str | None = None,
     normalized_set: list[str] | None = None,
     is_deleted: bool = False,
+    is_disabled: bool = False,
     source_image: bool = True,
     tracking: dict[str, Any] | None = None,
     last_tested_at: datetime | None = None,
@@ -152,6 +153,7 @@ def make_problem(
         },
         "isDeleted": is_deleted,
         "deletedAt": now if is_deleted else None,
+        "isDisabled": is_disabled,
         "createdAt": now,
         "updatedAt": now,
     }
@@ -295,6 +297,50 @@ async def test_create_exam_rejects_when_no_eligible_problems(exams_app: FastAPI,
     ineligible = make_problem(user_id, text="Deleted", problem_type="fill-in-the-blank", correct_answer="4", is_deleted=True)
     answerless = make_problem(user_id, text="No answer", problem_type="fill-in-the-blank", correct_answer="")
     database["problems"].seed(ineligible, answerless)
+
+    response = await client.post("/api/v1/exams", json={"maxProblemCount": 2})
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "NO_ELIGIBLE_PROBLEMS"
+
+
+@pytest.mark.asyncio
+async def test_create_exam_excludes_disabled_problems(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    storage: FakeStorage = exams_app.state.fake_storage
+    user_id = exams_app.state.primary_user["_id"]
+    disabled = make_problem(
+        user_id, text="Disabled", problem_type="fill-in-the-blank", correct_answer="4", is_disabled=True
+    )
+    enabled = make_problem(
+        user_id, text="Enabled", problem_type="short-answer", correct_answer="Paris"
+    )
+    database["problems"].seed(disabled, enabled)
+    storage.seed(disabled["sourceImage"]["bucket"], disabled["sourceImage"]["objectKey"], b"img")
+    storage.seed(enabled["sourceImage"]["bucket"], enabled["sourceImage"]["objectKey"], b"img")
+
+    response = await client.post("/api/v1/exams", json={"maxProblemCount": 2})
+
+    assert response.status_code == 201
+    body = response.json()["exam"]
+    assert len(body["items"]) == 1
+    assert body["items"][0]["problem"]["text"] == "Enabled"
+
+
+@pytest.mark.asyncio
+async def test_create_exam_no_eligible_when_all_disabled(
+    exams_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+    disabled = make_problem(
+        user_id, text="Disabled", problem_type="fill-in-the-blank", correct_answer="4", is_disabled=True
+    )
+    database["problems"].seed(disabled)
 
     response = await client.post("/api/v1/exams", json={"maxProblemCount": 2})
 

--- a/backend/tests/api/test_practice.py
+++ b/backend/tests/api/test_practice.py
@@ -149,6 +149,59 @@ async def test_deleted_problems_excluded(
 
 
 @pytest.mark.asyncio
+async def test_disabled_problems_excluded_from_next(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    disabled = make_problem(user_id, text="Disabled", correct_answer_display="4", is_disabled=True)
+    database.seed("problems", [disabled])
+
+    response = await client.post("/api/v1/practice/next")
+    assert response.status_code == 200
+    assert response.json()["status"] == "no_problems"
+
+
+@pytest.mark.asyncio
+async def test_disabled_problems_never_selected_when_enabled_available(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    disabled = make_problem(user_id, text="Disabled", correct_answer_display="disabled", is_disabled=True)
+    enabled = make_problem(user_id, text="Enabled", correct_answer_display="enabled")
+    database.seed("problems", [disabled, enabled])
+
+    selected_texts: set[str] = set()
+    for _ in range(10):
+        response = await client.post("/api/v1/practice/next")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        selected_texts.add(data["problem"]["text"])
+
+    assert selected_texts == {"Enabled"}
+
+
+@pytest.mark.asyncio
+async def test_stats_excludes_disabled_problems(
+    practice_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = practice_app.state.fake_database
+    user_id = practice_app.state.user["_id"]
+    disabled = make_problem(user_id, text="Disabled", correct_answer_display="4", is_disabled=True)
+    enabled = make_problem(user_id, text="Enabled", correct_answer_display="4")
+    database.seed("problems", [disabled, enabled])
+
+    response = await client.get("/api/v1/practice/stats")
+    assert response.status_code == 200
+    assert response.json()["practiceableCount"] == 1
+
+
+@pytest.mark.asyncio
 async def test_empty_answer_excluded(
     practice_app: FastAPI,
     client: AsyncClient,

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -78,6 +78,7 @@ def make_problem(
     last_tested_at: Any = DEFAULT_LAST_TESTED,
     tags: list[str] | None = None,
     is_deleted: bool = False,
+    is_disabled: bool = False,
     folder_id: str | None = None,
 ) -> dict[str, Any]:
     now = updated_at or datetime.now(UTC)
@@ -119,6 +120,7 @@ def make_problem(
         },
         "isDeleted": is_deleted,
         "deletedAt": now if is_deleted else None,
+        "isDisabled": is_disabled,
         "folderId": folder_id,
         "createdAt": created,
         "updatedAt": now,
@@ -487,6 +489,132 @@ async def test_problem_routes_require_authentication(problems_app: FastAPI) -> N
     assert response.json() == {
         "error": {"code": "UNAUTHENTICATED", "message": "Authentication required"}
     }
+
+
+@pytest.mark.asyncio
+async def test_problem_payloads_include_is_disabled(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    enabled = make_problem(user_id, text="Enabled")
+    disabled = make_problem(user_id, text="Disabled", is_disabled=True)
+    database["problems"].seed(enabled, disabled)
+
+    list_response = await client.get("/api/v1/problems")
+    assert list_response.status_code == 200
+    by_text = {item["text"]: item for item in list_response.json()["items"]}
+    assert by_text["Enabled"]["isDisabled"] is False
+    assert by_text["Disabled"]["isDisabled"] is True
+
+    detail_response = await client.get(f"/api/v1/problems/{disabled['_id']}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["problem"]["isDisabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_disables_problem_with_correct_teacher_password(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id, text="To disable")
+    database["problems"].seed(problem)
+
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/disabled",
+        json={"isDisabled": True, "teacherPassword": "default-teacher-password"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()["problem"]
+    assert body["isDisabled"] is True
+
+    stored = database["problems"]._documents[0]
+    assert stored["isDisabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_enables_disabled_problem_with_correct_teacher_password(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id, text="To enable", is_disabled=True)
+    database["problems"].seed(problem)
+
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/disabled",
+        json={"isDisabled": False, "teacherPassword": "default-teacher-password"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["problem"]["isDisabled"] is False
+
+    stored = database["problems"]._documents[0]
+    assert stored["isDisabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_rejects_incorrect_teacher_password_and_leaves_state_unchanged(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id, text="Protected")
+    database["problems"].seed(problem)
+
+    response = await client.patch(
+        f"/api/v1/problems/{problem['_id']}/disabled",
+        json={"isDisabled": True, "teacherPassword": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {
+        "error": {"code": "UNAUTHENTICATED", "message": "Incorrect teacher password"}
+    }
+
+    stored = database["problems"]._documents[0]
+    assert stored.get("isDisabled") is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_rejects_missing_deleted_and_other_user_problems(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    other_user_id = problems_app.state.secondary_user["_id"]
+    deleted = make_problem(user_id, text="Deleted", is_deleted=True)
+    other_user = make_problem(other_user_id, text="Other user")
+    database["problems"].seed(deleted, other_user)
+    body = {"isDisabled": True, "teacherPassword": "default-teacher-password"}
+
+    missing_response = await client.patch(
+        f"/api/v1/problems/{ObjectId()}/disabled",
+        json=body,
+    )
+    assert missing_response.status_code == 404
+    assert missing_response.json()["error"]["code"] == "NOT_FOUND"
+
+    deleted_response = await client.patch(
+        f"/api/v1/problems/{deleted['_id']}/disabled",
+        json=body,
+    )
+    assert deleted_response.status_code == 404
+    assert deleted_response.json()["error"]["code"] == "NOT_FOUND"
+
+    forbidden_response = await client.patch(
+        f"/api/v1/problems/{other_user['_id']}/disabled",
+        json=body,
+    )
+    assert forbidden_response.status_code == 403
+    assert forbidden_response.json()["error"]["code"] == "FORBIDDEN"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -20,6 +20,7 @@ from app.domain.selection import (
 def create_test_problem(
     problem_id: str,
     is_deleted: bool = False,
+    is_disabled: bool = False,
     last_tested_at: datetime | None = None,
     failed_count: int = 0,
     exposure_count: int = 1,
@@ -46,6 +47,7 @@ def create_test_problem(
         problemType=ProblemType.SINGLE_CHOICE,
         correctAnswer=CorrectAnswer(display="a", normalizedText="a", normalizedSet=[], format="single"),
         isDeleted=is_deleted,
+        isDisabled=is_disabled,
         tracking=tracking,
         createdAt=created_at or datetime.now(timezone.utc) - timedelta(days=30),
     )
@@ -58,6 +60,20 @@ def test_exclude_deleted_problems():
     ]
     config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0)
     now = datetime.now(timezone.utc)
+    selected = select_problems(problems, 2, config, now=now)
+    assert len(selected) == 1
+    assert selected[0].id == "1"
+
+
+def test_exclude_disabled_problems():
+    problems = [
+        create_test_problem("1", is_disabled=False),
+        create_test_problem("2", is_disabled=True),
+    ]
+    config = ProblemSelectionConfig(recency_weight=1.0, failure_rate_weight=1.0)
+    now = datetime.now(timezone.utc)
+    eligible = get_eligible_problems(problems, config, now)
+    assert [p.id for p in eligible] == ["1"]
     selected = select_problems(problems, 2, config, now=now)
     assert len(selected) == 1
     assert selected[0].id == "1"

--- a/backend/tests/presentation/test_problem_creation.py
+++ b/backend/tests/presentation/test_problem_creation.py
@@ -67,9 +67,11 @@ async def test_create_problem_inserts_problem_and_enqueues_solution() -> None:
     assert problem["sourceImage"] == source_image
     assert problem["tags"] == ["tag-a"]
     assert problem["isDeleted"] is False
+    assert problem["isDisabled"] is False
 
     problems = database["problems"]._documents
     assert len(problems) == 1
+    assert problems[0]["isDisabled"] is False
 
     tasks = database["solution_generation_tasks"]._documents
     assert len(tasks) == 1

--- a/backend/tests/presentation/test_problem_serialization.py
+++ b/backend/tests/presentation/test_problem_serialization.py
@@ -90,6 +90,7 @@ def test_problem_summary_payload_key_order() -> None:
         "tracking",
         "isDeleted",
         "deletedAt",
+        "isDisabled",
         "createdAt",
         "updatedAt",
         "imageUrl",
@@ -110,6 +111,7 @@ def test_problem_detail_payload_key_order() -> None:
         "tracking",
         "isDeleted",
         "deletedAt",
+        "isDisabled",
         "createdAt",
         "updatedAt",
         "imageUrl",
@@ -238,6 +240,25 @@ def test_serialized_detail_nested_shapes() -> None:
 
 
 # ---- edge cases that must survive extraction ----
+
+
+def test_serialize_summary_defaults_missing_is_disabled_to_false() -> None:
+    problem = _make_problem()
+    summary = _serialize_problem_summary(problem)
+
+    assert summary.model_dump()["isDisabled"] is False
+
+
+def test_serialize_summary_reflects_disabled_state() -> None:
+    summary = _serialize_problem_summary(_make_problem(isDisabled=True))
+
+    assert summary.model_dump()["isDisabled"] is True
+
+
+def test_serialize_detail_reflects_disabled_state() -> None:
+    detail = _serialize_problem_detail(_make_problem(isDisabled=True))
+
+    assert detail.model_dump()["isDisabled"] is True
 
 
 def test_serialize_summary_without_source_image() -> None:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -114,6 +114,21 @@ export const api = {
     return this.post<{ status: string }>(`/problems/${problemId}/solution-regeneration`, {});
   },
 
+  /**
+   * Toggle a problem's disabled state. Requires teacher password validation,
+   * enforced server-side.
+   */
+  async setProblemDisabled<T>(
+    problemId: string,
+    isDisabled: boolean,
+    teacherPassword: string
+  ): Promise<T> {
+    return this.patch<T>(`/problems/${problemId}/disabled`, {
+      isDisabled,
+      teacherPassword,
+    });
+  },
+
   async get<T>(path: string): Promise<T> {
     const response = await fetch(`${API_BASE}${path}`, {
       credentials: "include",

--- a/frontend/src/components/TeacherPasswordModal.tsx
+++ b/frontend/src/components/TeacherPasswordModal.tsx
@@ -6,12 +6,17 @@ interface TeacherPasswordModalProps {
   isOpen: boolean;
   onClose: () => void;
   onVerified: () => void;
+  /** Optional submit handler. Defaults to teacher-password verification. When
+   * provided (e.g. for disable/enable toggle), the password is submitted to
+   * this handler instead of the standalone verify endpoint. */
+  submitPassword?: (password: string) => Promise<unknown>;
 }
 
 export function TeacherPasswordModal({
   isOpen,
   onClose,
   onVerified,
+  submitPassword,
 }: TeacherPasswordModalProps) {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -38,7 +43,8 @@ export function TeacherPasswordModal({
 
     setIsSubmitting(true);
     try {
-      await api.verifyTeacherPassword(password);
+      const submit = submitPassword ?? ((pw: string) => api.verifyTeacherPassword(pw));
+      await submit(password);
       onVerified();
       onClose();
     } catch (err) {

--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/api/client", () => ({
     patch: vi.fn(),
     delete: vi.fn(),
     verifyTeacherPassword: vi.fn(),
+    setProblemDisabled: vi.fn(),
     getSolutionStatus: vi.fn(),
     regenerateSolution: vi.fn(),
   },
@@ -69,6 +70,7 @@ const baseProblem = {
   correctAnswer: { display: "4", normalizedText: "4", normalizedSet: ["4"], format: "single" },
   imageUrl: null,
   isDeleted: false,
+  isDisabled: false,
   createdAt: "2024-01-01",
   updatedAt: "2024-01-01",
 };
@@ -96,6 +98,7 @@ describe("ProblemDetailPage", () => {
     vi.mocked(api.patch).mockReset();
     vi.mocked(api.delete).mockReset();
     vi.mocked(api.verifyTeacherPassword).mockReset();
+    vi.mocked(api.setProblemDisabled).mockReset();
     vi.mocked(api.getSolutionStatus).mockReset();
     vi.mocked(api.regenerateSolution).mockReset();
     mockNavigate.mockReset();
@@ -829,5 +832,114 @@ describe("ProblemDetailPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent("Server error");
     });
+  });
+
+  it("renders Disable button between Edit and Delete for enabled problems", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("What is 2+2?")).toBeInTheDocument();
+    });
+
+    const editButton = screen.getByRole("button", { name: "Edit" });
+    const disableButton = screen.getByTestId("toggle-disabled-button");
+    const deleteButton = screen.getByRole("button", { name: "Delete" });
+
+    expect(disableButton).toHaveTextContent("Disable");
+    // Disable is positioned between Edit and Delete in the DOM
+    expect(
+      editButton.compareDocumentPosition(disableButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      disableButton.compareDocumentPosition(deleteButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.queryByTestId("disabled-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders Enable button and Disabled badge for disabled problems", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: { ...baseProblem, isDisabled: true } })
+      .mockResolvedValueOnce(baseTracking);
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("disabled-badge")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("toggle-disabled-button")).toHaveTextContent("Enable");
+  });
+
+  it("disables a problem via teacher password modal and refreshes state", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking)
+      .mockResolvedValueOnce({ problem: { ...baseProblem, isDisabled: true } });
+
+    vi.mocked(api.setProblemDisabled).mockResolvedValueOnce({
+      problem: { ...baseProblem, isDisabled: true },
+    });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-disabled-button")).toHaveTextContent("Disable");
+    });
+
+    await user.click(screen.getByTestId("toggle-disabled-button"));
+    expect(screen.getByTestId("teacher-password-modal")).toBeInTheDocument();
+
+    await user.type(screen.getByTestId("teacher-password-input"), "teacher-password");
+    await user.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(api.setProblemDisabled).toHaveBeenCalledWith(
+        "abc123",
+        true,
+        "teacher-password",
+      );
+    });
+
+    // After success, problem is refreshed: Enable button + Disabled badge
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-disabled-button")).toHaveTextContent("Enable");
+      expect(screen.getByTestId("disabled-badge")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces error in modal on incorrect teacher password and leaves state unchanged", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+
+    vi.mocked(api.setProblemDisabled).mockRejectedValueOnce(
+      new Error("Incorrect teacher password"),
+    );
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-disabled-button")).toHaveTextContent("Disable");
+    });
+
+    await user.click(screen.getByTestId("toggle-disabled-button"));
+    await user.type(screen.getByTestId("teacher-password-input"), "wrong-password");
+    await user.click(screen.getByTestId("teacher-password-submit"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("teacher-password-error")).toHaveTextContent(
+        "Incorrect teacher password",
+      );
+    });
+
+    // Modal stays open and problem state is unchanged
+    expect(screen.getByTestId("teacher-password-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("toggle-disabled-button")).toHaveTextContent("Disable");
+    expect(screen.queryByTestId("disabled-badge")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -101,6 +101,7 @@ export function ProblemDetailPage() {
   const [showAnswer, setShowAnswer] = useState(false);
   const [showTeacherPasswordModal, setShowTeacherPasswordModal] = useState(false);
   const [showAnswerEdit, setShowAnswerEdit] = useState(false);
+  const [toggleTarget, setToggleTarget] = useState<boolean | null>(null);
   const [editForm, setEditForm] = useState<UpdateProblemInput>({});
   const [error, setError] = useState<string | null>(null);
   const tagSuggestions = useTagSuggestions();
@@ -211,6 +212,11 @@ export function ProblemDetailPage() {
     }
   };
 
+  const handleDisableToggle = (nextDisabled: boolean) => {
+    setToggleTarget(nextDisabled);
+    setShowTeacherPasswordModal(true);
+  };
+
   const pageCanvasStyle: React.CSSProperties = {
     minHeight: "calc(100vh - 60px)",
     backgroundColor: "var(--color-bg)",
@@ -316,6 +322,22 @@ export function ProblemDetailPage() {
                 }}
               >
                 Deleted
+              </span>
+            )}
+            {problem.isDisabled && (
+              <span
+                data-testid="disabled-badge"
+                className="badge badge-warning"
+                style={{
+                  fontSize: "0.75rem",
+                  padding: "0.15rem 0.5rem",
+                  borderRadius: "var(--radius-sm)",
+                  fontWeight: 600,
+                  textTransform: "none",
+                  letterSpacing: "normal"
+                }}
+              >
+                Disabled
               </span>
             )}
             {solutionStatus && (
@@ -587,6 +609,14 @@ export function ProblemDetailPage() {
             <>
               <button onClick={handleEdit} className="btn btn-secondary" style={{ padding: "0.5rem 1.25rem", borderRadius: "var(--radius-md)", fontSize: "0.875rem" }}>Edit</button>
               <button
+                onClick={() => handleDisableToggle(!problem.isDisabled)}
+                className="btn btn-secondary"
+                style={{ padding: "0.5rem 1.25rem", borderRadius: "var(--radius-md)", fontSize: "0.875rem" }}
+                data-testid="toggle-disabled-button"
+              >
+                {problem.isDisabled ? "Enable" : "Disable"}
+              </button>
+              <button
                 onClick={handleDelete}
                 disabled={deleteMutation.isPending || problem.isDeleted}
                 className="btn btn-danger"
@@ -650,8 +680,26 @@ export function ProblemDetailPage() {
 
       <TeacherPasswordModal
         isOpen={showTeacherPasswordModal}
-        onClose={() => setShowTeacherPasswordModal(false)}
+        onClose={() => {
+          setShowTeacherPasswordModal(false);
+          setToggleTarget(null);
+        }}
+        submitPassword={
+          toggleTarget !== null
+            ? (password) =>
+                api
+                  .setProblemDisabled<ProblemResponse>(problemId, toggleTarget, password)
+                  .then(() => undefined)
+            : undefined
+        }
         onVerified={() => {
+          if (toggleTarget !== null) {
+            queryClient.invalidateQueries({ queryKey: ["problem", problemId] });
+            setToggleTarget(null);
+            setShowTeacherPasswordModal(false);
+            setError(null);
+            return;
+          }
           if (isEditing) {
             setShowAnswerEdit(true);
             setEditForm((prev) => ({

--- a/frontend/src/types/problem.ts
+++ b/frontend/src/types/problem.ts
@@ -9,6 +9,7 @@ export interface ProblemDetail {
   imageUrl?: string;
   correctAnswer?: CorrectAnswer;
   isDeleted: boolean;
+  isDisabled: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -31,6 +32,7 @@ export interface ProblemListItem {
     lastAttemptCorrect?: boolean;
   };
   isDeleted: boolean;
+  isDisabled: boolean;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

- Adds a soft `isDisabled` boolean state for problems. Disabled problems remain visible and manageable but are excluded from future practice and exam selection.
- Adds a teacher-password-protected `Disable`/`Enable` toggle on the problem detail page between the existing `Edit` and `Delete` buttons, with server-side teacher-password enforcement.
- Disabled problems show a visible `Disabled` badge.

## Linked Issue

Closes #441

## Issue Alignment

This PR implements the issue by:

- Adding `isDisabled` to the `Problem` domain model (defaulting to `False`, with missing legacy values treated as enabled).
- Storing `isDisabled: False` on newly created problems.
- Exposing `isDisabled` in problem summary/detail serialization and the frontend `ProblemDetail`/`ProblemListItem` types.
- Adding `PATCH /api/v1/problems/{problem_id}/disabled` that validates the teacher password server-side (reusing the existing hash/verify + lazy-migration helper) before updating `isDisabled`, returning a `ProblemResponse`.
- Excluding disabled problems from practice stats, `/practice/next`, shared domain selection (`get_eligible_problems`), and exam creation via both a DB-level `isDisabled != true` filter and a domain-level guard.
- Adding the `Disable`/`Enable` button (between `Edit` and `Delete`) and a `Disabled` badge on the problem detail page, reusing the teacher password modal UX with a `submitPassword` callback that submits the password to the toggle endpoint.

Scope covered:

- `isDisabled` boolean state distinct from `isDeleted`.
- Backward-compatible enabled defaults for missing values.
- Backend teacher-password enforcement in the toggle request (not frontend-only).
- Disabled problems excluded from future practice and exam selection.
- Existing in-progress exams/practice sessions are not retroactively modified.
- Backend and frontend regression tests.

Out of scope / intentionally not included:

- Hiding disabled problems from problem list/detail pages (they remain visible).
- Bulk disable/enable from the problem list.
- Changing delete behavior.
- Data migration/backfill job for existing problems.
- Retrofitting existing in-progress exams or already-selected practice prompts.
- Audit logs or disabled-reason fields.

## Implementation Notes

- The toggle endpoint reuses `_ensure_teacher_password_hash` (lazy migration) and `verify_password` from the existing teacher-password module, mirroring the established `/teacher-password/verify` pattern. Wrong password returns `401 UNAUTHENTICATED` without mutating the problem.
- Selection exclusion is applied in two layers: DB queries filter `isDisabled: {$ne: true}` where practical, and the shared domain `get_eligible_problems` skips `Problem.isDisabled` so callers stay consistent.
- The `TeacherPasswordModal` gained an optional `submitPassword` callback; when omitted it falls back to the existing `verifyTeacherPassword` call, so answer reveal/edit behavior is unchanged.
- Logging uses `log_teacher_password_event("disable_verify_attempt", ...)` consistent with existing teacher-password events.

## Tests

Commands run:

- `cd backend && PYTHONPATH=. python -m pytest tests/presentation/test_problem_creation.py tests/presentation/test_problem_serialization.py tests/api/test_problems.py tests/api/test_practice.py tests/api/test_exams.py tests/domain/test_selection.py -q` — passed (149 passed)
- `cd backend && PYTHONPATH=. python -m pytest tests/ -q` — passed (873 passed, 1 skipped; no regressions)
- `cd frontend && npm test -- --run src/pages/ProblemDetailPage.test.tsx` — passed (36 passed)
- `npx tsc --noEmit` — passed (no type errors)

Automated tests added or updated:

- Backend:
  - `test_problem_creation.py`: new problem stores `isDisabled: false`.
  - `test_problem_serialization.py`: `isDisabled` defaults to `false` when missing; explicit `true` reflected; key-order updated.
  - `test_problems.py`: payloads include `isDisabled`; toggle disables/enables with correct password; rejects incorrect password (state unchanged); rejects missing/deleted/other-user problems.
  - `test_practice.py`: disabled excluded from `/practice/next` and never selected when enabled available; stats exclude disabled.
  - `test_exams.py`: exam creation excludes disabled and returns `NO_ELIGIBLE_PROBLEMS` when all eligible problems are disabled.
  - `test_selection.py`: shared domain selection excludes `isDisabled`.
- Frontend (`ProblemDetailPage.test.tsx`): `Disable` button rendered between `Edit` and `Delete`; `Enable` + `Disabled` badge for disabled problems; disable via modal calls toggle endpoint and refreshes state; incorrect password surfaces modal error and leaves state unchanged.

Manual verification:

The issue lists manual UI verification steps (disable a problem, confirm badge/Enable button, confirm exclusion from practice/exam, re-enable). These require a running full-stack environment with a real browser; automated API and component tests above cover the equivalent behavior end-to-end at the API and component level.

## Deviations From Issue Plan

None. The implementation follows the chosen approach (boolean `isDisabled` field, `PATCH /problems/{id}/disabled` endpoint with server-side teacher password validation, exclusion at both DB-query and shared-domain layers, modal reuse with a submit callback).

## Follow-Up Work

None required. Potential future enhancements (not in scope): bulk disable/enable, disabled-reason metadata, list filters for disabled problems.