### PR TITLE
Deduplicate upload extension guessing

### DIFF
--- a/backend/app/presentation/bulk_ingestion.py
+++ b/backend/app/presentation/bulk_ingestion.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-import mimetypes
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Annotated, Any, NamedTuple
 
 from fastapi import APIRouter, File, UploadFile
@@ -68,24 +66,13 @@ from app.presentation.bulk_serialization import (
 )
 from app.presentation.errors import ApiError
 from app.presentation.helpers import (
+    guess_upload_extension,
     normalize_tags,
     parse_object_id,
 )
 from app.presentation.problem_creation import create_problem_from_draft
 
 router = APIRouter(prefix="/ingestion-batches", tags=["bulk-ingestion"])
-
-
-def _guess_extension(upload: UploadFile) -> str:
-    if upload.filename:
-        suffix = Path(upload.filename).suffix
-        if suffix:
-            return suffix
-    if upload.content_type:
-        guessed = mimetypes.guess_extension(upload.content_type)
-        if guessed:
-            return guessed
-    return ".bin"
 
 
 def _find_image_or_404(batch: Document, image_id: str) -> dict[str, Any]:
@@ -159,7 +146,7 @@ async def _expand_upload(
                 f"Image exceeds maximum size of {settings.bulk_ingestion_max_image_bytes} bytes",
             )
         width, height = get_image_size(image_bytes) or (None, None)
-        return [_UploadPayload(image_bytes, content_type, width, height, _guess_extension(upload))]
+        return [_UploadPayload(image_bytes, content_type, width, height, guess_upload_extension(upload))]
 
     if content_type == "application/pdf" or filename.endswith(".pdf"):
         pdf_bytes = await upload.read()

--- a/backend/app/presentation/helpers.py
+++ b/backend/app/presentation/helpers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import mimetypes
+from pathlib import Path
 from typing import Any
 
 from bson import ObjectId
+from fastapi import UploadFile
 from pymongo.asynchronous.database import AsyncDatabase
 
 from app.infrastructure.storage.mongo import Document
@@ -39,6 +42,18 @@ def parse_object_id(raw_id: str, *, resource_name: str) -> ObjectId:
     if not ObjectId.is_valid(raw_id):
         raise ApiError(404, "NOT_FOUND", f"{resource_name} not found")
     return ObjectId(raw_id)
+
+
+def guess_upload_extension(upload: UploadFile) -> str:
+    if upload.filename:
+        suffix = Path(upload.filename).suffix
+        if suffix:
+            return suffix
+    if upload.content_type:
+        guessed = mimetypes.guess_extension(upload.content_type)
+        if guessed:
+            return guessed
+    return ".bin"
 
 
 async def get_owned_problem(

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 import base64
 import hashlib
-import mimetypes
 from collections.abc import Mapping
 from io import BytesIO
-from pathlib import Path
 from typing import Any, Annotated
 
 from bson import ObjectId
@@ -27,7 +25,7 @@ from app.presentation.deps import (
     StorageDependency,
 )
 from app.presentation.errors import ApiError
-from app.presentation.helpers import normalize_tags, parse_object_id
+from app.presentation.helpers import guess_upload_extension, normalize_tags, parse_object_id
 from app.presentation.ingestion_serialization import ProblemResponse, PreviewResponse, serialize_preview, serialize_problem, _enum_value
 from app.presentation.problem_creation import create_problem_from_draft
 from app.presentation.ingestion_workflow import (
@@ -80,18 +78,6 @@ def _ensure_status(preview: Mapping[str, Any], allowed: set[str]) -> None:
         raise ApiError(409, "INVALID_PREVIEW_STATE", "Preview is not in a valid state for this operation")
 
 
-def _guess_extension(upload: UploadFile) -> str:
-    if upload.filename:
-        suffix = Path(upload.filename).suffix
-        if suffix:
-            return suffix
-    if upload.content_type:
-        guessed = mimetypes.guess_extension(upload.content_type)
-        if guessed:
-            return guessed
-    return ".bin"
-
-
 @router.post("", response_model=PreviewResponse, status_code=201)
 async def create_preview(
     image: Annotated[UploadFile, File(...)],
@@ -112,7 +98,7 @@ async def create_preview(
         raise ApiError(400, "INVALID_IMAGE", "Uploaded image is empty")
 
     now = utc_now()
-    object_key = s3_storage.build_object_key(str(user["_id"]), _guess_extension(image))
+    object_key = s3_storage.build_object_key(str(user["_id"]), guess_upload_extension(image))
     s3_storage.put_object(settings.s3_bucket, object_key, image_bytes, image.content_type)
 
     preview: Document = {

--- a/backend/tests/presentation/test_upload_extension.py
+++ b/backend/tests/presentation/test_upload_extension.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from io import BytesIO
+
+import pytest
+from fastapi import UploadFile
+from starlette.datastructures import Headers
+
+from app.presentation.helpers import guess_upload_extension
+
+
+def _make_upload(filename: str | None, content_type: str | None) -> UploadFile:
+    headers = Headers({"content-type": content_type} if content_type else {})
+    return UploadFile(file=BytesIO(b""), filename=filename, headers=headers)
+
+
+def test_returns_filename_suffix_when_present() -> None:
+    upload = _make_upload("photo.png", "image/png")
+    assert guess_upload_extension(upload) == ".png"
+
+
+def test_suffix_takes_priority_over_content_type() -> None:
+    # Suffix wins even when a different content type is present.
+    upload = _make_upload("image.txt", "image/png")
+    assert guess_upload_extension(upload) == ".txt"
+
+
+def test_preserves_filename_suffix_case() -> None:
+    # The suffix is returned verbatim, including its original case.
+    upload = _make_upload("photo.PNG", "image/png")
+    assert guess_upload_extension(upload) == ".PNG"
+
+
+def test_uses_content_type_when_filename_has_no_suffix() -> None:
+    upload = _make_upload("noext", "image/png")
+    assert guess_upload_extension(upload) == ".png"
+
+
+def test_uses_content_type_when_filename_is_empty() -> None:
+    upload = _make_upload("", "image/png")
+    assert guess_upload_extension(upload) == ".png"
+
+
+def test_uses_content_type_when_filename_is_none() -> None:
+    upload = _make_upload(None, "image/jpeg")
+    assert guess_upload_extension(upload) == ".jpg"
+
+
+def test_returns_bin_when_content_type_unknown() -> None:
+    upload = _make_upload(None, "totally/fake")
+    assert guess_upload_extension(upload) == ".bin"
+
+
+def test_returns_bin_when_no_filename_and_no_content_type() -> None:
+    upload = _make_upload(None, None)
+    assert guess_upload_extension(upload) == ".bin"
+
+
+def test_returns_bin_when_no_suffix_and_content_type_unknown() -> None:
+    upload = _make_upload("noext", "totally/fake")
+    assert guess_upload_extension(upload) == ".bin"
+
+
+@pytest.mark.parametrize(
+    ("filename", "content_type", "expected"),
+    [
+        ("photo.png", "image/png", ".png"),
+        ("photo.png", None, ".png"),
+        (None, "image/png", ".png"),
+        (None, None, ".bin"),
+        ("", "totally/fake", ".bin"),
+        ("image.txt", "image/png", ".txt"),
+    ],
+)
+def test_extension_selection_order(filename: str | None, content_type: str | None, expected: str) -> None:
+    # Documented order: filename suffix first, then content-type guess, then .bin fallback.
+    assert guess_upload_extension(_make_upload(filename, content_type)) == expected


### PR DESCRIPTION
## Summary

- Extract the duplicated `_guess_extension` logic from `backend/app/presentation/ingestion.py` and `backend/app/presentation/bulk_ingestion.py` into a single shared `guess_upload_extension` helper in `backend/app/presentation/helpers.py`.
- Both upload paths now call the shared helper. Upload behavior is unchanged: the extension decision order is preserved exactly — uploaded filename suffix first, then `mimetypes.guess_extension(content_type)`, then `.bin` fallback.
- Add direct characterization tests for the helper covering suffix priority, content-type fallback, and the `.bin` fallback for missing/unknown inputs.
- Remove the now-unused `import mimetypes` and `from pathlib import Path` imports from the two presentation modules (they were used only by the inlined helper).

## Linked Issue

Closes #444

## Issue Alignment

This PR implements the issue by:

- Adding one local helper for upload extension guessing in `backend/app/presentation/helpers.py` (the issue's preferred location).
- Replacing the duplicated helper logic in single ingestion (`ingestion.py`) and bulk ingestion (`bulk_ingestion.py`) with calls to the shared `guess_upload_extension` helper.
- Adding direct characterization tests for suffix, content-type, and `.bin` fallback behavior (the T-009 tests the issue bundles).
- Keeping existing API behavior and the ingestion flow unchanged.

Scope covered:

- Shared `guess_upload_extension(upload: UploadFile) -> str` helper preserving the exact decision order.
- Both prior call sites updated to use it.
- Direct helper tests for suffix, content-type, and `.bin` fallback (including empty filename and missing content-type edge cases).
- Existing single ingestion and bulk ingestion upload tests still pass.

Out of scope / intentionally not included:

- No changes to object key generation, accepted upload content types, PDF/image ingestion logic beyond calling the helper, storage adapters, or media persistence.

## Implementation Notes

- The helper accepts the `UploadFile` object (a true drop-in for the prior private helpers, so call sites stay identical), matching the issue's "accepts the upload object or the minimal fields needed" option.
- The decision order is byte-for-byte identical to the prior duplicated implementations, so object keys receive the exact same extension values for filename-suffix, content-type, and fallback cases.
- `UploadFile` remains imported and used in both presentation modules (as endpoint param annotations), so only the genuinely unused `mimetypes`/`Path` imports were removed.

## Tests

Commands run (from `backend/`, using the project venv):

- `python -m pytest tests/presentation/test_upload_extension.py -q` — passed (15 passed)
- `python -m pytest tests/api/test_ingestion.py tests/api/test_bulk_ingestion.py -q` — passed (108 passed in 45.39s)
- `python -m pytest tests/presentation/ -q` — passed (109 passed) (helpers consumers unaffected)

Note: the issue's suggested command uses `uv run pytest`; the project venv used here already contains the dependencies, so the same suite was executed directly with `pytest`. `pyright` was also run on the three changed source files: the change introduces no new type errors (23 pre-existing DI-annotation errors exist identically on `origin/master`).

Automated tests added or updated:

- `backend/tests/presentation/test_upload_extension.py` — new direct characterization tests:
  - filename suffix returned when present;
  - suffix takes priority over a conflicting content type;
  - filename suffix case preserved verbatim (e.g. `.PNG`);
  - content-type guess used when filename has no suffix;
  - content-type guess used when filename is empty string or `None`;
  - `.bin` returned for unknown content type, missing filename+content_type, and no-suffix+unknown-content-type;
  - parametrized selection-order summary test.

Manual verification:

- Inspected both prior call sites (`ingestion.py` create_preview object-key build, `bulk_ingestion.py` `_expand_upload` payload) — both now call `guess_upload_extension`.
- Confirmed no remaining references to the old `_guess_extension` symbol anywhere in the repo.
- Confirmed object key generation, upload validation, and content-type handling code paths were not changed (only the extension source moved).

## Deviations From Issue Plan

None. The helper was placed in `backend/app/presentation/helpers.py` as the issue prefers, and the chosen signature (`UploadFile`) is one of the two explicitly permitted options.

## Follow-Up Work

None. T-009 direct helper tests are included in this PR per the issue.
