### PR TITLE
Extract ProblemsPage pure folder helpers

### DIFF
--- a/frontend/src/pages/ProblemsPage.folderHelpers.test.ts
+++ b/frontend/src/pages/ProblemsPage.folderHelpers.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+
+import type { FolderNode } from "@/types/folder";
+import {
+  buildAncestorMap,
+  findFolder,
+  flattenFolders,
+  getDescendantIds,
+} from "./ProblemsPage.folderHelpers";
+
+function makeFolder(
+  id: string,
+  children: FolderNode[] = [],
+  overrides: Partial<FolderNode> = {},
+): FolderNode {
+  return {
+    id,
+    name: id,
+    parentId: null,
+    problemCount: 0,
+    children,
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  };
+}
+
+describe("flattenFolders", () => {
+  it("flattens a nested folder tree with increasing depth", () => {
+    const tree = [
+      makeFolder("a", [makeFolder("b", [makeFolder("c")]), makeFolder("d")]),
+      makeFolder("e"),
+    ];
+
+    expect(flattenFolders(tree)).toEqual([
+      { ...tree[0], depth: 0 },
+      { ...tree[0].children[0], depth: 1 },
+      { ...tree[0].children[0].children[0], depth: 2 },
+      { ...tree[0].children[1], depth: 1 },
+      { ...tree[1], depth: 0 },
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(flattenFolders([])).toEqual([]);
+  });
+
+  it("handles a single root folder with no children", () => {
+    const root = makeFolder("root");
+    expect(flattenFolders([root])).toEqual([{ ...root, depth: 0 }]);
+  });
+
+  it("does not mutate the input folder nodes", () => {
+    const child = makeFolder("child");
+    const root = makeFolder("root", [child]);
+    const flattened = flattenFolders([root]);
+    expect(flattened[0]).not.toBe(root);
+    expect(root.children).toHaveLength(1);
+    expect(flattened[1]).not.toBe(child);
+  });
+});
+
+describe("getDescendantIds", () => {
+  it("returns all descendant ids across multiple levels", () => {
+    const folder = makeFolder("root", [
+      makeFolder("a", [makeFolder("b"), makeFolder("c")]),
+      makeFolder("d"),
+    ]);
+
+    expect(getDescendantIds(folder)).toEqual(new Set(["a", "b", "c", "d"]));
+  });
+
+  it("returns an empty set for a leaf folder with no children", () => {
+    expect(getDescendantIds(makeFolder("leaf"))).toEqual(new Set());
+  });
+
+  it("does not include the folder's own id", () => {
+    const folder = makeFolder("root", [makeFolder("child")]);
+    expect(getDescendantIds(folder).has("root")).toBe(false);
+  });
+});
+
+describe("findFolder", () => {
+  const tree = [
+    makeFolder("a", [makeFolder("b", [makeFolder("c")])]),
+    makeFolder("d"),
+  ];
+
+  it("finds a folder at the root level", () => {
+    expect(findFolder(tree, "a")?.id).toBe("a");
+  });
+
+  it("finds a nested folder by id", () => {
+    expect(findFolder(tree, "c")?.id).toBe("c");
+  });
+
+  it("returns undefined when the folder id is not present", () => {
+    expect(findFolder(tree, "missing")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty folder list", () => {
+    expect(findFolder([], "anything")).toBeUndefined();
+  });
+
+  it("returns the folder node with its full shape", () => {
+    const found = findFolder(tree, "b");
+    expect(found).toMatchObject({ id: "b", children: [{ id: "c" }] });
+  });
+});
+
+describe("buildAncestorMap", () => {
+  const tree = [
+    makeFolder("a", [makeFolder("b", [makeFolder("c")])]),
+    makeFolder("d"),
+  ];
+
+  it("maps root folders to an empty ancestor list", () => {
+    const map = buildAncestorMap(tree);
+    expect(map.get("a")).toEqual([]);
+    expect(map.get("d")).toEqual([]);
+  });
+
+  it("maps a nested folder to its ancestor chain", () => {
+    const map = buildAncestorMap(tree);
+    expect(map.get("c")).toEqual(["a", "b"]);
+  });
+
+  it("includes every folder in the tree", () => {
+    const map = buildAncestorMap(tree);
+    expect(Array.from(map.keys()).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns an empty map for an empty folder list", () => {
+    expect(buildAncestorMap([]).size).toBe(0);
+  });
+
+  it("handles sibling roots independently", () => {
+    const siblings = [makeFolder("root1", [makeFolder("child1")]), makeFolder("root2", [makeFolder("child2")])];
+    const map = buildAncestorMap(siblings);
+    expect(map.get("child1")).toEqual(["root1"]);
+    expect(map.get("child2")).toEqual(["root2"]);
+  });
+});

--- a/frontend/src/pages/ProblemsPage.folderHelpers.ts
+++ b/frontend/src/pages/ProblemsPage.folderHelpers.ts
@@ -1,0 +1,42 @@
+import type { FolderNode } from "@/types/folder";
+
+export function flattenFolders(
+  folders: FolderNode[],
+  depth = 0,
+): Array<FolderNode & { depth: number }> {
+  return folders.flatMap((folder) => [
+    { ...folder, depth },
+    ...flattenFolders(folder.children, depth + 1),
+  ]);
+}
+
+export function getDescendantIds(folder: FolderNode): Set<string> {
+  const ids = new Set<string>();
+  for (const child of folder.children) {
+    ids.add(child.id);
+    for (const id of getDescendantIds(child)) ids.add(id);
+  }
+  return ids;
+}
+
+export function findFolder(
+  folders: FolderNode[],
+  folderId: string,
+): FolderNode | undefined {
+  for (const folder of folders) {
+    if (folder.id === folderId) return folder;
+    const found = findFolder(folder.children, folderId);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+export function buildAncestorMap(folders: FolderNode[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  const visit = (folder: FolderNode, ancestors: string[]) => {
+    map.set(folder.id, ancestors);
+    folder.children.forEach((child) => visit(child, [...ancestors, folder.id]));
+  };
+  folders.forEach((folder) => visit(folder, []));
+  return map;
+}

--- a/frontend/src/pages/ProblemsPage.tsx
+++ b/frontend/src/pages/ProblemsPage.tsx
@@ -9,6 +9,12 @@ import { TagList } from "@/components/TagPill";
 import type { ProblemListItem, ProblemsResponse } from "@/types/problem";
 import type { FolderNode, FolderTreeResponse } from "@/types/folder";
 import { PROBLEM_TYPE_FILTER_OPTIONS } from "@/constants/problemTypes";
+import {
+  buildAncestorMap,
+  findFolder,
+  flattenFolders,
+  getDescendantIds,
+} from "./ProblemsPage.folderHelpers";
 
 const SIDEBAR_COLLAPSED_KEY = "problems.folderSidebarCollapsed";
 const UNFILED_FOLDER_ID = "unfiled";
@@ -64,41 +70,6 @@ let problemsPagePreferences: ProblemsPagePreferences = { ...DEFAULT_PREFERENCES 
 // Test-only helper to reset the in-memory preferences between test runs.
 export function _resetProblemsPagePreferencesForTests() {
   problemsPagePreferences = { ...DEFAULT_PREFERENCES };
-}
-
-function flattenFolders(folders: FolderNode[], depth = 0): Array<FolderNode & { depth: number }> {
-  return folders.flatMap((folder) => [
-    { ...folder, depth },
-    ...flattenFolders(folder.children, depth + 1),
-  ]);
-}
-
-function getDescendantIds(folder: FolderNode): Set<string> {
-  const ids = new Set<string>();
-  for (const child of folder.children) {
-    ids.add(child.id);
-    for (const id of getDescendantIds(child)) ids.add(id);
-  }
-  return ids;
-}
-
-function findFolder(folders: FolderNode[], folderId: string): FolderNode | undefined {
-  for (const folder of folders) {
-    if (folder.id === folderId) return folder;
-    const found = findFolder(folder.children, folderId);
-    if (found) return found;
-  }
-  return undefined;
-}
-
-function buildAncestorMap(folders: FolderNode[]) {
-  const map = new Map<string, string[]>();
-  const visit = (folder: FolderNode, ancestors: string[]) => {
-    map.set(folder.id, ancestors);
-    folder.children.forEach((child) => visit(child, [...ancestors, folder.id]));
-  };
-  folders.forEach((folder) => visit(folder, []));
-  return map;
 }
 
 function getErrorMessage(error: unknown) {


### PR DESCRIPTION
## Summary

- Extract the four pure folder helper functions (`flattenFolders`, `getDescendantIds`, `findFolder`, `buildAncestorMap`) from `frontend/src/pages/ProblemsPage.tsx` into a new colocated module `frontend/src/pages/ProblemsPage.folderHelpers.ts`.
- `ProblemsPage.tsx` now imports the helpers from the colocated module instead of defining them inline. Behavior is unchanged.
- Add direct characterization tests for the extracted helpers in `frontend/src/pages/ProblemsPage.folderHelpers.test.ts`.

## Linked Issue

Closes #445

## Issue Alignment

This PR implements the issue by:

- Identifying the pure folder helper functions in `ProblemsPage.tsx` that do not depend on React state or module-level mutable preferences.
- Moving only those pure helpers into a colocated helper module (`ProblemsPage.folderHelpers.ts`) and importing them back into `ProblemsPage`.
- Adding direct unit tests for the moved helper behavior.

Scope covered:

- Four pure folder helpers extracted: `flattenFolders`, `getDescendantIds`, `findFolder`, `buildAncestorMap`.
- Direct helper tests covering happy path, nested, root, sibling, leaf, and empty cases.

Out of scope / intentionally not included:

- `problemsPagePreferences` (and its `_resetProblemsPagePreferencesForTests` reset helper) remain in the page module.
- `getErrorMessage` remains in the page module (it is a generic error helper, not a folder helper).
- No React Query key changes, no filter-bar extraction, no reset/folder-UI/text changes, no broad page refactoring.

## Implementation Notes

- The extracted functions are pure: they take `FolderNode[]`/`FolderNode` and return derived values without touching React state, hooks, or the module-level mutable `problemsPagePreferences`.
- The implementations were copied verbatim (only the `FolderNode` type import and `export` keywords were added); the decision/ordering behavior is identical, so folder flattening, descendant-id collection, folder lookup, and ancestor-map building are unchanged.
- The colocated module is named `ProblemsPage.folderHelpers.ts`, matching the existing `ProblemsPage.test.tsx` colocated naming convention.
- `FolderNode` is still imported and used in `ProblemsPage.tsx` (e.g. `EMPTY_FOLDERS`, folder param types), so no import became unused there.

## Tests

Commands run (from `frontend/`):

- `./node_modules/.bin/vitest run src/pages/ProblemsPage.folderHelpers.test.ts src/pages/ProblemsPage.test.tsx` - passed (49 passed: 17 new helper tests + 32 existing ProblemsPage tests)
- `npm run build` (`tsc -b && vite build`) - passed (built successfully; the pre-existing chunk-size warning is unrelated)

Verification notes:

- The worktree had no `node_modules`; the project's installed dependencies were shared via a symlink to the main checkout's `frontend/node_modules` purely for running these commands locally. This symlink is not committed (it is not a repository change).
- `problemsPagePreferences`, the `_resetProblemsPagePreferencesForTests` reset helper, and the React Query keys were manually inspected and confirmed unchanged.
- The four helpers are only referenced inside `ProblemsPage.tsx`; no other consumers were affected.

Automated tests added or updated:

- `frontend/src/pages/ProblemsPage.folderHelpers.test.ts` (new) - 17 direct tests:
  - `flattenFolders`: nested tree with depths, empty array, single root, no input mutation.
  - `getDescendantIds`: multi-level descendants, leaf returns empty set, own id excluded.
  - `findFolder`: root match, nested match, missing returns `undefined`, empty list, full node shape preserved.
  - `buildAncestorMap`: roots map to empty ancestors, nested ancestor chain, all folders included, empty input, independent sibling roots.

Manual verification:

- Confirmed the four functions were removed from `ProblemsPage.tsx` and that the import from `./ProblemsPage.folderHelpers` is present.
- Confirmed `problemsPagePreferences` and `_resetProblemsPagePreferencesForTests` were not moved (still in the page module).
- Confirmed React Query keys (`["problems", ...]`, `["folders"]`) are unchanged.

## Deviations From Issue Plan

None. The helpers were moved to a colocated module next to `ProblemsPage.tsx` as the issue describes, and only pure folder helpers were extracted.

## Follow-Up Work

None. ProblemsPage filter-bar extraction is intentionally postponed (already noted in the issue's Follow-Up Work) and is not included here.
