### PR TITLE
Extract BulkReviewStep pure helper and validation logic

### DIFF
--- a/frontend/src/components/BulkReviewStep.helpers.test.ts
+++ b/frontend/src/components/BulkReviewStep.helpers.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+
+import type { BulkDraft, BulkItem } from "@/types/bulkIngestion";
+import {
+  defaultDraft,
+  getRequiredFieldGaps,
+  retryDelayMs,
+  serializeDraft,
+  statusLabel,
+} from "./BulkReviewStep.helpers";
+
+function makeItem(draft: Partial<BulkDraft> = {}): BulkItem {
+  return {
+    itemId: "item-1",
+    imageId: "img-1",
+    batchId: "batch-1",
+    status: "ready",
+    order: 0,
+    draft,
+    extraction: {},
+    retryCount: 0,
+    submit: {},
+    origin: {},
+    createdAt: "",
+    updatedAt: "",
+  };
+}
+
+describe("retryDelayMs", () => {
+  it("preserves the base retry value at zero failures", () => {
+    expect(retryDelayMs(0)).toBe(500);
+  });
+
+  it("grows exponentially with the failure count", () => {
+    expect(retryDelayMs(1)).toBe(1000);
+    expect(retryDelayMs(2)).toBe(2000);
+  });
+
+  it("caps at the maximum retry value", () => {
+    expect(retryDelayMs(3)).toBe(4000);
+    expect(retryDelayMs(4)).toBe(4000);
+    expect(retryDelayMs(10)).toBe(4000);
+  });
+});
+
+describe("defaultDraft", () => {
+  it("fills defaults for an empty draft", () => {
+    expect(defaultDraft(makeItem({}))).toEqual({
+      text: "",
+      problemType: "short-answer",
+      graphDsl: "",
+      correctAnswer: "",
+      tags: [],
+      subject: "math",
+    });
+  });
+
+  it("fills defaults for null fields", () => {
+    expect(
+      defaultDraft(
+        makeItem({
+          text: null,
+          problemType: null,
+          graphDsl: null,
+          correctAnswer: null,
+          tags: undefined,
+          subject: null,
+        }),
+      ),
+    ).toEqual({
+      text: "",
+      problemType: "short-answer",
+      graphDsl: "",
+      correctAnswer: "",
+      tags: [],
+      subject: "math",
+    });
+  });
+
+  it("preserves provided draft values", () => {
+    const draft: BulkDraft = {
+      text: "What is 2+2?",
+      problemType: "single-choice",
+      graphDsl: "graph-dsl",
+      correctAnswer: "4",
+      tags: ["math", "arithmetic"],
+      subject: "english",
+    };
+    expect(defaultDraft(makeItem(draft))).toEqual(draft);
+  });
+});
+
+describe("serializeDraft", () => {
+  it("returns a JSON string equal to JSON.stringify", () => {
+    const draft: BulkDraft = {
+      text: "x",
+      problemType: "short-answer",
+      graphDsl: "",
+      correctAnswer: "y",
+      tags: ["t"],
+      subject: "math",
+    };
+    expect(serializeDraft(draft)).toBe(JSON.stringify(draft));
+  });
+
+  it("produces equal output for equal drafts", () => {
+    const draft: BulkDraft = { text: "a", correctAnswer: "b" };
+    expect(serializeDraft(draft)).toBe(serializeDraft({ ...draft }));
+  });
+});
+
+describe("statusLabel", () => {
+  it.each([
+    ["queued", "Queued"],
+    ["extracting", "Extracting..."],
+    ["ready", "Ready"],
+    ["failed", "Extraction failed"],
+    ["submit-failed", "Submit failed"],
+    ["deleted", "Deleted"],
+    ["submitted", "Submitted"],
+  ])("maps status %s to its label", (status, label) => {
+    expect(statusLabel(status)).toBe(label);
+  });
+
+  it("returns the raw status for unknown values", () => {
+    expect(statusLabel("unexpected")).toBe("unexpected");
+    expect(statusLabel("")).toBe("");
+  });
+});
+
+describe("getRequiredFieldGaps", () => {
+  it("reports no gaps for a complete draft", () => {
+    expect(
+      getRequiredFieldGaps({
+        text: "Question",
+        problemType: "short-answer",
+        correctAnswer: "Answer",
+      }),
+    ).toEqual({ text: false, problemType: false, correctAnswer: false });
+  });
+
+  it("reports a gap when text is empty or whitespace", () => {
+    expect(getRequiredFieldGaps({ text: "", problemType: "x", correctAnswer: "y" }).text).toBe(true);
+    expect(getRequiredFieldGaps({ text: "   ", problemType: "x", correctAnswer: "y" }).text).toBe(true);
+  });
+
+  it("reports a gap when text is missing", () => {
+    expect(getRequiredFieldGaps({ problemType: "x", correctAnswer: "y" }).text).toBe(true);
+  });
+
+  it("reports a gap when problemType is missing", () => {
+    expect(getRequiredFieldGaps({ text: "x", correctAnswer: "y" }).problemType).toBe(true);
+  });
+
+  it("reports a gap when correctAnswer is empty or whitespace", () => {
+    expect(getRequiredFieldGaps({ text: "x", problemType: "y", correctAnswer: "" }).correctAnswer).toBe(true);
+    expect(getRequiredFieldGaps({ text: "x", problemType: "y", correctAnswer: "  " }).correctAnswer).toBe(true);
+  });
+
+  it("reports all gaps for an empty draft", () => {
+    expect(getRequiredFieldGaps({})).toEqual({ text: true, problemType: true, correctAnswer: true });
+  });
+});

--- a/frontend/src/components/BulkReviewStep.helpers.ts
+++ b/frontend/src/components/BulkReviewStep.helpers.ts
@@ -1,0 +1,52 @@
+import type { BulkDraft, BulkItem } from "@/types/bulkIngestion";
+
+const BASE_RETRY_MS = 500;
+const MAX_RETRY_MS = 4000;
+
+export function retryDelayMs(failureCount: number): number {
+  return Math.min(BASE_RETRY_MS * 2 ** failureCount, MAX_RETRY_MS);
+}
+
+export function defaultDraft(item: BulkItem): BulkDraft {
+  return {
+    text: item.draft.text ?? "",
+    problemType: item.draft.problemType ?? "short-answer",
+    graphDsl: item.draft.graphDsl ?? "",
+    correctAnswer: item.draft.correctAnswer ?? "",
+    tags: item.draft.tags ?? [],
+    subject: item.draft.subject ?? "math",
+  };
+}
+
+export function serializeDraft(draft: BulkDraft): string {
+  return JSON.stringify(draft);
+}
+
+export function statusLabel(status: string): string {
+  switch (status) {
+    case "queued":
+      return "Queued";
+    case "extracting":
+      return "Extracting...";
+    case "ready":
+      return "Ready";
+    case "failed":
+      return "Extraction failed";
+    case "submit-failed":
+      return "Submit failed";
+    case "deleted":
+      return "Deleted";
+    case "submitted":
+      return "Submitted";
+    default:
+      return status;
+  }
+}
+
+export function getRequiredFieldGaps(draft: BulkDraft) {
+  return {
+    text: !draft.text || draft.text.trim() === "",
+    problemType: !draft.problemType,
+    correctAnswer: !draft.correctAnswer || draft.correctAnswer.trim() === "",
+  };
+}

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -3,15 +3,16 @@ import type { BulkBatch, BulkDraft, BulkItem } from "@/types/bulkIngestion";
 import { TagInput } from "./TagInput";
 import { GraphSandbox } from "./GraphSandbox";
 import { LatexText } from "./LatexText";
+import {
+  defaultDraft,
+  getRequiredFieldGaps,
+  retryDelayMs,
+  serializeDraft,
+  statusLabel,
+} from "./BulkReviewStep.helpers";
 
 const POLL_INTERVAL_MS = 2500;
-const BASE_RETRY_MS = 500;
-const MAX_RETRY_MS = 4000;
 const ACTION_REQUIRED_BORDER = "2px solid var(--color-error, #dc2626)";
-
-function retryDelayMs(failureCount: number): number {
-  return Math.min(BASE_RETRY_MS * 2 ** failureCount, MAX_RETRY_MS);
-}
 
 const PROBLEM_TYPES = [
   { value: "single-choice", label: "Single choice" },
@@ -24,50 +25,6 @@ const SUBJECTS = [
   { value: "math", label: "Math" },
   { value: "english", label: "English" },
 ];
-
-function defaultDraft(item: BulkItem): BulkDraft {
-  return {
-    text: item.draft.text ?? "",
-    problemType: item.draft.problemType ?? "short-answer",
-    graphDsl: item.draft.graphDsl ?? "",
-    correctAnswer: item.draft.correctAnswer ?? "",
-    tags: item.draft.tags ?? [],
-    subject: item.draft.subject ?? "math",
-  };
-}
-
-function serializeDraft(draft: BulkDraft): string {
-  return JSON.stringify(draft);
-}
-
-function statusLabel(status: string): string {
-  switch (status) {
-    case "queued":
-      return "Queued";
-    case "extracting":
-      return "Extracting...";
-    case "ready":
-      return "Ready";
-    case "failed":
-      return "Extraction failed";
-    case "submit-failed":
-      return "Submit failed";
-    case "deleted":
-      return "Deleted";
-    case "submitted":
-      return "Submitted";
-    default:
-      return status;
-  }
-}
-
-function getRequiredFieldGaps(draft: BulkDraft) {
-  return {
-    text: !draft.text || draft.text.trim() === "",
-    problemType: !draft.problemType,
-    correctAnswer: !draft.correctAnswer || draft.correctAnswer.trim() === "",
-  };
-}
 
 export interface BulkReviewStepProps {
   batch: BulkBatch;


### PR DESCRIPTION
## Summary

- Extract the pure helper and validation functions from `frontend/src/components/BulkReviewStep.tsx` into a new colocated module `frontend/src/components/BulkReviewStep.helpers.ts`.
- `BulkReviewStep.tsx` now imports the helpers from the colocated module instead of defining them inline. Behavior is unchanged.
- Add direct characterization tests for the extracted helpers in `frontend/src/components/BulkReviewStep.helpers.test.ts`.

## Linked Issue

Closes #446

## Issue Alignment

This PR implements the issue by:

- Identifying the pure helper and validation functions in `BulkReviewStep.tsx` that do not depend on React state.
- Moving only those pure functions and validation helpers into a colocated module (`BulkReviewStep.helpers.ts`) and importing them back into the component.

Scope covered:

- Five pure helpers/validation helpers extracted: `defaultDraft`, `serializeDraft`, `statusLabel`, `getRequiredFieldGaps` (validation), and `retryDelayMs` (pure retry/backoff computation).
- The two backoff constants `BASE_RETRY_MS` and `MAX_RETRY_MS` move with `retryDelayMs` (they are only used by that function), enabling direct backoff-value tests.
- Direct characterization tests covering happy paths, edge/invalid cases, and preservation of labels, defaults, and backoff values.

Out of scope / intentionally not included:

- React state, effects, and autosave behavior stay in the component (the autosave effect is unchanged).
- `POLL_INTERVAL_MS`, `ACTION_REQUIRED_BORDER`, `PROBLEM_TYPES`, and `SUBJECTS` remain in the component (used by component effects/JSX).
- No autosave hook extraction; no changes to autosave timing, retry behavior, backoff values, user-visible labels, or defaults.
- No cross-component deduplication of the `statusLabel`/`SUBJECTS` copies that also exist in `BulkDetectStep.tsx`/`BulkSubmitStep.tsx` (separate, broader refactor, out of scope).

## Implementation Notes

- The extracted functions are pure: `defaultDraft`/`serializeDraft`/`statusLabel`/`getRequiredFieldGaps` take draft/item/status inputs and return derived values; `retryDelayMs` takes a failure count and returns the delay. None touch React state, hooks, or effects.
- Implementations were copied verbatim (only `export` keywords, the `BulkDraft`/`BulkItem` type import, and moving the two backoff constants alongside `retryDelayMs` were added). Labels, defaults, and backoff values are byte-for-byte identical.
- The colocated module is named `BulkReviewStep.helpers.ts`, consistent with the colocated-helper convention used for `ProblemsPage.folderHelpers.ts`.
- `retryDelayMs` was included because the issue's "Tests Required" explicitly asks tests to verify "Preservation of labels, defaults, and backoff values"; extracting it makes the backoff curve directly unit-testable. The autosave effect itself remains in the component.
- `BulkDraft`/`BulkItem` remain imported and used in `BulkReviewStep.tsx`, so no type import became unused.

## Tests

Commands run (from `frontend/`):

- `./node_modules/.bin/vitest run src/components/BulkReviewStep.helpers.test.ts src/components/BulkReviewStep.test.tsx` - passed (51 passed: 22 new helper tests + 29 existing component tests)
- `npm run build` (`tsc -b && vite build`) - passed (built successfully; the pre-existing chunk-size warning is unrelated)

Verification notes:

- The worktree had no `node_modules`; the project's installed dependencies were shared via a symlink to the main checkout's `frontend/node_modules` purely for running these commands locally. This symlink is not committed (it is not a repository change).
- The five helpers are only referenced inside `BulkReviewStep.tsx` (verified via repo-wide search); the `statusLabel`/`SUBJECTS` copies in `BulkDetectStep.tsx`/`BulkSubmitStep.tsx` are separate definitions and were intentionally not touched.

Automated tests added or updated:

- `frontend/src/components/BulkReviewStep.helpers.test.ts` (new) - 22 direct tests:
  - `retryDelayMs`: base value at 0 failures (500), exponential growth (1000, 2000), cap at max (4000) for 3/4/10 failures.
  - `defaultDraft`: defaults for empty draft, defaults for null fields, preservation of provided values.
  - `serializeDraft`: equals `JSON.stringify`, stable output for equal drafts.
  - `statusLabel`: all known statuses mapped to expected labels; unknown status returned verbatim.
  - `getRequiredFieldGaps`: no gaps for complete draft; gaps for empty/whitespace/missing text, missing problemType, empty/whitespace correctAnswer; all gaps for empty draft.

Manual verification:

- Confirmed the five function definitions and the two backoff constants were removed from `BulkReviewStep.tsx` and that the import from `./BulkReviewStep.helpers` is present.
- Confirmed `POLL_INTERVAL_MS`, `ACTION_REQUIRED_BORDER`, `PROBLEM_TYPES`, and `SUBJECTS` remain in the component.
- Confirmed labels (`statusLabel` outputs), defaults (`defaultDraft` values), and backoff values (`retryDelayMs` constants/curve) are unchanged, with direct tests now covering them.

## Deviations From Issue Plan

None. Only pure helper and validation helpers were extracted to a colocated module next to `BulkReviewStep.tsx`, as the issue describes. `retryDelayMs` was included as a pure function to make the issue-required "backoff values" preservation directly testable; its constants moved with it and their values are unchanged.

## Follow-Up Work

None. `BulkReviewStep` autosave hook extraction is intentionally postponed (already noted in the issue's Follow-Up Work) and is not included here. Cross-component `statusLabel`/`SUBJECTS` deduplication is a separate, broader refactor and is also out of scope.
