### PR TITLE
Extract ingestion repository read-mutate-persist helpers

### DIFF
--- a/backend/app/infrastructure/ingestion/repository.py
+++ b/backend/app/infrastructure/ingestion/repository.py
@@ -52,6 +52,31 @@ def _object_id(value: str | ObjectId) -> ObjectId:
     return ObjectId(value) if isinstance(value, str) else value
 
 
+async def _load_batch_for_update(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+) -> Document:
+    batch = await _collection(database).find_one(
+        {"_id": _object_id(batch_id), "userId": user_id}
+    )
+    if batch is None:
+        raise ValueError("Batch not found")
+    return batch
+
+
+async def _persist_batch(
+    database: Any,
+    batch_id: str | ObjectId,
+    user_id: Any,
+    set_fields: dict[str, Any],
+) -> None:
+    await _collection(database).update_one(
+        {"_id": _object_id(batch_id), "userId": user_id},
+        {"$set": set_fields},
+    )
+
+
 def is_batch_expired(batch: Document, *, now: datetime | None = None) -> bool:
     expires_at = batch.get("expiresAt")
     if not isinstance(expires_at, datetime):
@@ -125,18 +150,11 @@ async def add_source_image(
         now=current,
     )
 
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     images.append(image_document)
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "updatedAt": current}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "updatedAt": current})
     return image_document
 
 
@@ -151,11 +169,7 @@ async def add_items_for_image(
     now: datetime | None = None,
 ) -> list[dict[str, Any]]:
     current = now or _now()
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     new_items: list[dict[str, Any]] = []
@@ -179,10 +193,7 @@ async def add_items_for_image(
             image["updatedAt"] = current
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "items": items, "updatedAt": current}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "items": items, "updatedAt": current})
     return new_items
 
 
@@ -194,11 +205,7 @@ async def start_image_detection(
     *,
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     for image in images:
@@ -207,10 +214,7 @@ async def start_image_detection(
             image["updatedAt"] = now
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "updatedAt": now})
 
 
 async def save_image_detection_success(
@@ -225,11 +229,7 @@ async def save_image_detection_success(
     raw_provider_response: dict[str, Any] | None,
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     for image in images:
@@ -246,10 +246,7 @@ async def save_image_detection_success(
             image["updatedAt"] = now
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "updatedAt": now})
 
 
 async def save_image_detection_failure(
@@ -262,11 +259,7 @@ async def save_image_detection_failure(
     failure_message: str,
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     for image in images:
@@ -281,10 +274,7 @@ async def save_image_detection_failure(
             image["updatedAt"] = now
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "updatedAt": now})
 
 
 async def save_image_boxes_and_subject(
@@ -297,11 +287,7 @@ async def save_image_boxes_and_subject(
     boxes: list[dict[str, Any]],
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     for image in images:
@@ -313,10 +299,7 @@ async def save_image_boxes_and_subject(
             image["updatedAt"] = now
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "updatedAt": now})
 
 
 async def delete_batch_image(
@@ -327,11 +310,7 @@ async def delete_batch_image(
     *,
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     for image in images:
@@ -346,10 +325,7 @@ async def delete_batch_image(
             item["status"] = ItemState.DELETED.value
             item["updatedAt"] = now
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "items": items, "updatedAt": now})
 
 
 async def commit_image_boxes(
@@ -360,11 +336,7 @@ async def commit_image_boxes(
     *,
     now: datetime,
 ) -> list[dict[str, Any]]:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     images = list(batch.get("images", []))
     target_image = None
@@ -407,10 +379,7 @@ async def commit_image_boxes(
     target_image["committedAt"] = now
     target_image["updatedAt"] = now
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"images": images, "items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"images": images, "items": items, "updatedAt": now})
     return new_items
 
 
@@ -471,11 +440,7 @@ async def save_item_extraction_success(
     extraction: dict[str, Any],
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     for item in items:
@@ -488,10 +453,7 @@ async def save_item_extraction_success(
             item["updatedAt"] = now
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"items": items, "updatedAt": now})
 
 
 async def save_item_extraction_failure(
@@ -503,11 +465,7 @@ async def save_item_extraction_failure(
     extraction: dict[str, Any],
     now: datetime,
 ) -> None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     for item in items:
@@ -518,10 +476,7 @@ async def save_item_extraction_failure(
             item["updatedAt"] = now
             break
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"items": items, "updatedAt": now})
 
 
 async def reset_item_for_retry(
@@ -532,11 +487,7 @@ async def reset_item_for_retry(
     *,
     now: datetime,
 ) -> bool:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     changed = False
@@ -563,10 +514,7 @@ async def reset_item_for_retry(
     if not changed:
         return False
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"items": items, "updatedAt": now})
     return True
 
 
@@ -579,11 +527,7 @@ async def update_item_draft(
     draft_update: dict[str, Any],
     now: datetime,
 ) -> dict[str, Any] | None:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     updated_item: dict[str, Any] | None = None
@@ -603,10 +547,7 @@ async def update_item_draft(
     if updated_item is None:
         return None
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"items": items, "updatedAt": now})
     return updated_item
 
 
@@ -618,11 +559,7 @@ async def mark_item_deleted(
     *,
     now: datetime,
 ) -> bool:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     changed = False
@@ -642,10 +579,7 @@ async def mark_item_deleted(
     if not changed:
         return False
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"items": items, "updatedAt": now})
     return True
 
 
@@ -657,11 +591,7 @@ async def undo_item_deletion(
     *,
     now: datetime,
 ) -> bool:
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     items = list(batch.get("items", []))
     changed = False
@@ -682,10 +612,7 @@ async def undo_item_deletion(
     if not changed:
         return False
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": {"items": items, "updatedAt": now}},
-    )
+    await _persist_batch(database, batch_id, user_id, {"items": items, "updatedAt": now})
     return True
 
 
@@ -703,11 +630,7 @@ async def submit_items_and_complete_batch(
     ``submitted``. Items in other states (including ``submit-failed``) keep the
     batch active so they can be retried or deleted.
     """
-    batch = await _collection(database).find_one(
-        {"_id": _object_id(batch_id), "userId": user_id}
-    )
-    if batch is None:
-        raise ValueError("Batch not found")
+    batch = await _load_batch_for_update(database, batch_id, user_id)
 
     result_by_item = {result["itemId"]: result for result in item_results}
     items = list(batch.get("items", []))
@@ -734,10 +657,7 @@ async def submit_items_and_complete_batch(
     if all_submitted and has_submitted:
         update["status"] = BatchState.COMPLETED.value
 
-    await _collection(database).update_one(
-        {"_id": _object_id(batch_id), "userId": user_id},
-        {"$set": update},
-    )
+    await _persist_batch(database, batch_id, user_id, update)
     return await _collection(database).find_one(
         {"_id": _object_id(batch_id), "userId": user_id}
     )

--- a/backend/tests/infrastructure/test_ingestion_persistence.py
+++ b/backend/tests/infrastructure/test_ingestion_persistence.py
@@ -801,3 +801,48 @@ async def test_submit_items_and_complete_batch_completes_only_when_all_submitted
     )
     assert result["status"] == BatchState.COMPLETED.value
     assert result["updatedAt"] == later
+
+
+# ---------------------------------------------------------------------------
+# ValueError path tests for _load_batch_for_update (missing batch) and
+# commit_image_boxes (missing image). All repository mutation functions that
+# use _load_batch_for_update should raise the same ValueError for a
+# non-existent batch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_batch_raises_value_error(
+    database: FakeDatabase, user_id: ObjectId
+) -> None:
+    missing_batch_id = ObjectId()
+
+    with pytest.raises(ValueError, match="Batch not found"):
+        await start_image_detection(database, missing_batch_id, user_id, "img-1", now=NOW)
+
+    with pytest.raises(ValueError, match="Batch not found"):
+        await save_item_extraction_success(
+            database, missing_batch_id, user_id, "item-1",
+            crop={}, draft={}, extraction={}, now=NOW,
+        )
+
+    with pytest.raises(ValueError, match="Batch not found"):
+        await reset_item_for_retry(database, missing_batch_id, user_id, "item-1", now=NOW)
+
+    with pytest.raises(ValueError, match="Batch not found"):
+        await delete_batch_image(database, missing_batch_id, user_id, "img-1", now=NOW)
+
+    with pytest.raises(ValueError, match="Batch not found"):
+        await submit_items_and_complete_batch(
+            database, missing_batch_id, user_id, item_results=[], now=NOW,
+        )
+
+
+@pytest.mark.asyncio
+async def test_commit_image_boxes_raises_image_not_found(
+    database: FakeDatabase, user_id: ObjectId, settings: Settings
+) -> None:
+    batch = await create_batch(database, user_id, settings, now=NOW)
+
+    with pytest.raises(ValueError, match="Image not found"):
+        await commit_image_boxes(database, batch["_id"], user_id, "nonexistent", now=NOW)


### PR DESCRIPTION
## Summary

- Extract private `_load_batch_for_update` and `_persist_batch` helpers inside `backend/app/infrastructure/ingestion/repository.py` to consolidate the repeated `find_one` + `ValueError("Batch not found")` load boilerplate and `update_one` filter + persist boilerplate across 15 batch mutation functions.
- Each caller passes its own `$set` dict to `_persist_batch`, preserving exact `$set` shapes and whole-array update semantics.
- `claim_item` (atomic `find_one_and_update` path) is left untouched per issue scope.
- Add ValueError tests for the missing-batch path (5 representative functions) and the missing-image path (`commit_image_boxes`).

## Linked Issue

Closes #447

## Issue Alignment

This PR implements the issue by:

- Adding two private helpers: `_load_batch_for_update` (read: find_one + ValueError) and `_persist_batch` (write: update_one with caller-supplied `$set` dict).
- Migrating all 15 load-mutate-persist callers to use these helpers.
- Preserving public repository signatures, exact `$set` shapes, `ValueError` behavior, and whole-array update semantics.

Scope covered:

- Private helper(s) for repeated batch read/mutate/write boilerplate.
- Preservation of public repository signatures.
- Preservation of exact `$set` shapes for each existing function.
- Preservation of existing `ValueError` behavior.
- Preservation of whole-array update semantics.
- `claim_item` left untouched.
- ValueError tests for missing-batch and missing-image paths.

Out of scope / intentionally not included:

- Positional or atomic Mongo update migration (explicitly out of scope per issue).
- Data migrations.
- API endpoint changes.
- Changing `claim_item`.
- Setting `images` or `items` arrays in functions that did not previously set them.

## Implementation Notes

- `_load_batch_for_update(database, batch_id, user_id)` encapsulates the repeated `find_one({"_id": _object_id(batch_id), "userId": user_id})` + `if batch is None: raise ValueError("Batch not found")` pattern (15 call sites).
- `_persist_batch(database, batch_id, user_id, set_fields)` encapsulates the repeated `update_one({"_id": _object_id(batch_id), "userId": user_id}, {"$set": set_fields})` pattern. Each caller passes its own `$set` dict, so the helper does not force all callers to save the same fields.
- The mutation logic (for loops that modify items/images in place) is function-specific and stays in each caller - no mutation abstraction was added.
- `mark_batch_cleaned` uses a different filter (no `userId`), so it was not migrated.
- `submit_items_and_complete_batch` passes its dynamically-built `update` dict (which may include `status`) to `_persist_batch`, and its trailing `find_one` (to return the updated batch) is left as-is.
- Net: 55 insertions, 135 deletions = -80 lines of boilerplate.

## Tests

Commands run:

- `/home/rlan/projects/LearnLoop/backend/.venv/bin/python -m pytest tests/infrastructure/test_ingestion_persistence.py -x -q` - 27 passed (25 existing + 2 new)
- `/home/rlan/projects/LearnLoop/backend/.venv/bin/python -m pytest tests/api/test_bulk_ingestion.py -x -q` - 65 passed
- `/home/rlan/projects/LearnLoop/backend/.venv/bin/python -m pytest tests/worker/test_extraction_worker.py -x -q` - 19 passed
- `pyright backend/app/infrastructure/ingestion/repository.py` - 3 pre-existing errors (missing imports for bson/pymongo, pre-existing `reportGeneralTypeIssues` on `ensure_batch_indexes`); 0 new errors introduced.

Automated tests added or updated:

- `test_missing_batch_raises_value_error` - verifies `_load_batch_for_update` raises `ValueError("Batch not found")` for a non-existent batch across 5 representative functions (`start_image_detection`, `save_item_extraction_success`, `reset_item_for_retry`, `delete_batch_image`, `submit_items_and_complete_batch`).
- `test_commit_image_boxes_raises_image_not_found` - verifies `commit_image_boxes` raises `ValueError("Image not found")` when the batch exists but the image does not.

Manual verification:

- Compared each migrated function's old and new `$set` shape via `git diff`. The 15 old `{"$set": ...}` calls map 1:1 to 15 new `_persist_batch(...)` calls with identical field dicts.
- Confirmed `claim_item` does not appear in the diff (untouched).
- Confirmed `mark_batch_cleaned` was not migrated (different filter, no `userId`).
- Confirmed no function starts persisting `images` or `items` arrays it did not previously persist (same `$set` dicts).

## Deviations From Issue Plan

None.

## Follow-Up Work

None. The atomic update migration investigation is explicitly listed as separate follow-up work in the issue (tracked by #452).
