### PR TITLE
Fix remaining flaky ProblemsPage folder-button getByRole calls

### DIFF
--- a/frontend/src/pages/ProblemsPage.test.tsx
+++ b/frontend/src/pages/ProblemsPage.test.tsx
@@ -183,9 +183,9 @@ describe("ProblemsPage", () => {
     expect(screen.getByLabelText("All Problems count")).toHaveTextContent("4");
     expect(screen.getByRole("button", { name: "Show Unfiled" })).toBeInTheDocument();
     expect(screen.getByLabelText("Unfiled count")).toHaveTextContent("1");
-    expect(screen.getByRole("button", { name: "Select folder Chapter 1" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Select folder Chapter 1" })).toBeInTheDocument();
     expect(screen.getByLabelText("Chapter 1 count")).toHaveTextContent("3");
-    expect(screen.getByRole("button", { name: "Select folder Section 1" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Select folder Section 1" })).toBeInTheDocument();
     expect(screen.getByLabelText("Section 1 count")).toHaveTextContent("2");
   });
 
@@ -234,7 +234,7 @@ describe("ProblemsPage", () => {
     const { unmount } = renderProblemsPage();
     await screen.findByText("What is 2+2?");
 
-    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.click(await screen.findByRole("button", { name: "Select folder Section 1" }));
     await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
     await user.selectOptions(screen.getByLabelText("Filter by Type:"), "short-answer");
     await user.type(screen.getByLabelText("Search problems:"), "proof");
@@ -280,7 +280,7 @@ describe("ProblemsPage", () => {
     renderProblemsPage();
     await screen.findByText("What is 2+2?");
 
-    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.click(await screen.findByRole("button", { name: "Select folder Section 1" }));
 
     await waitFor(() => {
       const lastUrl = problemRequestUrls().at(-1) ?? "";
@@ -296,7 +296,7 @@ describe("ProblemsPage", () => {
     const { unmount } = renderProblemsPage();
     await screen.findByText("What is 2+2?");
 
-    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.click(await screen.findByRole("button", { name: "Select folder Section 1" }));
     await user.selectOptions(screen.getByLabelText("Filter by Tag:"), "algebra");
     await user.type(screen.getByLabelText("Search problems:"), "proof");
     await user.selectOptions(screen.getByLabelText("Sort by:"), "selectionScore");
@@ -385,7 +385,7 @@ describe("ProblemsPage", () => {
     renderProblemsPage();
     await screen.findByText("What is 2+2?");
 
-    await user.click(screen.getByRole("button", { name: "Select folder Chapter 1" }));
+    await user.click(await screen.findByRole("button", { name: "Select folder Chapter 1" }));
     await user.click(screen.getByRole("button", { name: "Hide" }));
 
     expect(window.sessionStorage.getItem("problems.folderSidebarCollapsed")).toBe("true");
@@ -398,7 +398,7 @@ describe("ProblemsPage", () => {
 
     const { unmount } = renderProblemsPage();
     await screen.findByText("What is 2+2?");
-    await user.click(screen.getByRole("button", { name: "Select folder Section 1" }));
+    await user.click(await screen.findByRole("button", { name: "Select folder Section 1" }));
     await waitFor(() => {
       expect(problemRequestUrls().at(-1) ?? "").toContain("folderId=section-1");
     });


### PR DESCRIPTION
## Summary

- Convert 7 remaining synchronous `screen.getByRole("button", { name: "Select folder ..." })` calls in `ProblemsPage.test.tsx` to async `await screen.findByRole(...)`, eliminating the timing flake that intermittently fails CI.
- This extends the fix from #406 (which fixed one occurrence at line 339) to all remaining sync folder-button calls.

## Linked Issue

Closes #456

## Issue Alignment

This PR implements the issue by:

- Converting all remaining synchronous `getByRole("button", { name: "Select folder ..." })` calls to `findByRole`, matching the pattern already established at lines 215, 339, and 409.

Scope covered:

- Lines 186 and 188: assertion-style `expect(screen.getByRole(...)).toBeInTheDocument()` -> `expect(await screen.findByRole(...)).toBeInTheDocument()`.
- Lines 237, 283, 299, 388, 401: click-style `await user.click(screen.getByRole(...))` -> `await user.click(await screen.findByRole(...))`.

Out of scope / intentionally not included:

- Changes to the `ProblemsPage` component logic.
- Changes to folder rendering logic.
- Test infrastructure refactoring beyond the targeted `getByRole` -> `findByRole` conversions.

## Implementation Notes

- The folder sidebar renders asynchronously after the problem list loads. Synchronous `getByRole` throws immediately if the element is not yet present, racing with async rendering. `findByRole` returns a Promise that resolves when the element appears (or times out after the default 1000ms), eliminating the race.
- After this fix, all 10 folder-button lookups in `ProblemsPage.test.tsx` use `findByRole` (3 pre-existing from #406 + 7 new from this PR). No sync `getByRole` folder-button calls remain.
- The change is test-only; no production code was modified.

## Tests

Commands run:

- `npx vitest run src/pages/ProblemsPage.test.tsx` - 32 passed (run 1)
- `npx vitest run src/pages/ProblemsPage.test.tsx` - 32 passed (run 2, flake check)
- `npx vitest run src/pages/ProblemsPage.test.tsx` - 32 passed (run 3, flake check)
- `npm run build` (`tsc -b && vite build`) - succeeded (pre-existing chunk-size warning only)

Automated tests added or updated:

- No new tests added. The existing 32 ProblemsPage tests now use async `findByRole` for all folder-button lookups, eliminating the intermittent CI failure that blocked PR #455 (see closed issue #406 for the original flake report).

Manual verification:

- Three consecutive test runs all passed with 32/32 tests, confirming the flake is resolved. The previously failing test ("renders All Problems, Unfiled, and nested folders with count badges" at line 175, which used sync `getByRole` at lines 186/188) now passes deterministically.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
