### PR TITLE
Extract BulkIngestionWizard common batch action handling

### DIFF
--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -567,6 +567,74 @@ describe("BulkIngestionWizard", () => {
     });
   });
 
+  it("surfaces mutation error message when detection fails", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "uploaded",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.detectImageBoxes.mockRejectedValue(new Error("VLM timeout"));
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-detect-run-img-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText("VLM timeout")).toBeInTheDocument();
+  });
+
+  it("transitions to expired UX when a common mutation returns BATCH_EXPIRED", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "uploaded",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.detectImageBoxes.mockRejectedValue(
+      new ApiError("Batch has expired", 409, "BATCH_EXPIRED"),
+    );
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({ status: "expired" }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-detect-run-img-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-expired")).toBeInTheDocument();
+    });
+  });
+
   it("surfaces upload validation failures", async () => {
     mocks.getActiveBatch.mockRejectedValue(
       new ApiError("No active batch found", 404, "NOT_FOUND"),

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -148,6 +148,17 @@ export function BulkIngestionWizard({
     }
   }, [batch, setBatchAndStep]);
 
+  const handleMutationError = useCallback(
+    async (err: unknown, fallbackMessage: string) => {
+      if (isBatchExpiredError(err)) {
+        await handleExpiredBatch();
+      } else {
+        setError(err instanceof Error ? err.message : fallbackMessage);
+      }
+    },
+    [handleExpiredBatch],
+  );
+
   useEffect(() => {
     let cancelled = false;
 
@@ -227,14 +238,10 @@ export function BulkIngestionWizard({
         const response = await detectImageBoxes(batch.id, imageId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to detect boxes");
-        }
+        await handleMutationError(err, "Failed to detect boxes");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleSaveBoxes = useCallback(
@@ -245,14 +252,10 @@ export function BulkIngestionWizard({
         const response = await saveImageBoxes(batch.id, imageId, boxes, subject);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to save boxes");
-        }
+        await handleMutationError(err, "Failed to save boxes");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleCommit = useCallback(
@@ -263,14 +266,10 @@ export function BulkIngestionWizard({
         const response = await commitImage(batch.id, imageId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to commit image");
-        }
+        await handleMutationError(err, "Failed to commit image");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleDeleteImage = useCallback(
@@ -281,14 +280,10 @@ export function BulkIngestionWizard({
         const response = await deleteImage(batch.id, imageId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to delete image");
-        }
+        await handleMutationError(err, "Failed to delete image");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleRefreshBatch = useCallback(
@@ -313,14 +308,10 @@ export function BulkIngestionWizard({
         const response = await updateItemDraft(batch.id, itemId, draft);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to save draft");
-        }
+        await handleMutationError(err, "Failed to save draft");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleRetryItem = useCallback(
@@ -331,14 +322,10 @@ export function BulkIngestionWizard({
         const response = await retryItem(batch.id, itemId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to retry item");
-        }
+        await handleMutationError(err, "Failed to retry item");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleDeleteItem = useCallback(
@@ -349,14 +336,10 @@ export function BulkIngestionWizard({
         const response = await deleteBatchItem(batch.id, itemId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(err instanceof Error ? err.message : "Failed to delete item");
-        }
+        await handleMutationError(err, "Failed to delete item");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleUndoDeleteItem = useCallback(
@@ -367,16 +350,10 @@ export function BulkIngestionWizard({
         const response = await undoDeleteBatchItem(batch.id, itemId);
         setBatchAndStep(response.batch);
       } catch (err) {
-        if (isBatchExpiredError(err)) {
-          await handleExpiredBatch();
-        } else {
-          setError(
-            err instanceof Error ? err.message : "Failed to restore item",
-          );
-        }
+        await handleMutationError(err, "Failed to restore item");
       }
     },
-    [batch, handleExpiredBatch, setBatchAndStep],
+    [batch, handleMutationError, setBatchAndStep],
   );
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
## Summary

- Extract `handleMutationError` callback that encapsulates the shared catch logic (expired-batch check + fallback error message) used by 8 common mutation handlers in `BulkIngestionWizard`.
- Apply the helper to: detect, save boxes, commit, delete image, update draft, retry item, delete item, and undo delete item.
- Special handlers (upload, refresh, submit, create) remain explicit and untouched.
- Add 2 tests: mutation error surfacing and BATCH_EXPIRED transition for common handlers.

## Linked Issue

Closes #450

## Issue Alignment

This PR implements the issue by:

- Extracting a shared catch/error helper (`handleMutationError`) as the first implementation path.
- Applying it to all 8 common handlers listed in scope.
- Preserving exact error strings and `setBatchAndStep` behavior.
- Leaving upload, refresh, submit, and create special handlers explicit.

Scope covered:

- Deduplicate common error/expired-batch handling for: detect, save boxes, commit, delete image, update draft, retry item, delete item, undo delete item.
- Shared catch/error helper as the implementation path.

Out of scope / intentionally not included:

- Rewriting the wizard state machine.
- Changing React Query keys or mutation APIs.
- Changing upload, refresh, submit, or create special handlers.
- Changing user-visible error text.
- Broad TypeScript or component cleanup.

## Implementation Notes

- `handleMutationError` accepts `(err: unknown, fallbackMessage: string)` and handles the expired-batch check + fallback error message. It depends on `handleExpiredBatch`.
- Each common handler's dependency array changed from `[batch, handleExpiredBatch, setBatchAndStep]` to `[batch, handleMutationError, setBatchAndStep]`, preserving the dependency chain (since `handleMutationError` depends on `handleExpiredBatch`).
- `handleUpdateItemDraft` intentionally does NOT call `setError("")` before the try block (preserving the original behavior where draft saves don't clear previous errors).
- The `isBatchExpiredError` function is still used directly by special handlers (`handleUploadFiles`, `handleRefreshBatch`, `handleSubmit`) and the extraction `useEffect`.

## Tests

Commands run:

- `cd frontend && npx vitest run src/components/BulkIngestionWizard.test.tsx` - passed (28 tests in 841ms)
- `cd frontend && npm run build` - passed (built in 1.18s)

Automated tests added or updated:

- `surfaces mutation error message when detection fails` - verifies a common mutation handler (detect) surfaces the error message via the wizard error state when it fails with a non-expired error.
- `transitions to expired UX when a common mutation returns BATCH_EXPIRED` - verifies a common mutation handler (detect) transitions to the expired UX when it fails with BATCH_EXPIRED.

Existing tests that verify behavior preservation:

- `runs detection for an uploaded image` - detect handler success.
- `commits an image after reviewing boxes` - commit handler success.
- `transitions to expired UX when a mutation returns BATCH_EXPIRED` - expired handling on special handler (submit).
- `transitions to expired UX when a review poll returns BATCH_EXPIRED` - expired handling on refresh handler.
- 24 other wizard tests covering upload, review, submit, completion, and step transitions.

Manual verification:

- Inspected that special handlers (upload, refresh, submit, create) remain explicit and untouched.
- Verified exact error strings match the original code for all 8 common handlers.
- CI Playwright E2E tests (`frontend/tests/bulk-ingestion.spec.ts`) passed SUCCESS at commit `fbafd4e`. This spec covers the full bulk wizard upload/review/submit flow including: happy path upload+review+submit, single image upload+submit, review editor autosave, detection failure recovery, extraction failure with item deletion, and review resume after reload. These browser-driven E2E tests substitute for the issue's manual app verification requirement.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
