### PR TITLE
fix: raise Nginx client_max_body_size for ingestion-batch uploads

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -12,6 +12,7 @@ server {
   }
 
   location /api/ {
+    client_max_body_size 512m;
     proxy_pass http://app:8000;
     proxy_http_version 1.1;
     proxy_set_header Host $host;

--- a/frontend/tests/compose-smoke.spec.ts
+++ b/frontend/tests/compose-smoke.spec.ts
@@ -1,4 +1,62 @@
 import { expect, test } from "@playwright/test";
+import { crc32, deflateSync } from "node:zlib";
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const typeBuf = Buffer.from(type, "ascii");
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBuf, data])) >>> 0, 0);
+  return Buffer.concat([len, typeBuf, data, crc]);
+}
+
+/** Build a valid 1x1 PNG whose total file size is at least `minBytes`. */
+function buildLargePng(minBytes: number): Buffer {
+  const sig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  const ihdrData = Buffer.alloc(13);
+  ihdrData.writeUInt32BE(1, 0); // width
+  ihdrData.writeUInt32BE(1, 4); // height
+  ihdrData[8] = 8; // bit depth
+  ihdrData[9] = 2; // color type: RGB
+
+  // Raw row: filter byte (0) + one black pixel (R, G, B)
+  const idatData = deflateSync(Buffer.from([0, 0, 0, 0]));
+
+  const ihdrChunk = pngChunk("IHDR", ihdrData);
+  const idatChunk = pngChunk("IDAT", idatData);
+  const iendChunk = pngChunk("IEND", Buffer.alloc(0));
+
+  // Pad with a standard tEXt ancillary chunk to reach the target size.
+  const fixedSize = sig.length + ihdrChunk.length + idatChunk.length + iendChunk.length;
+  const textOverhead = 12 + Buffer.from("Comment\0", "ascii").length; // chunk framing + keyword
+  const padLen = Math.max(0, minBytes - fixedSize - textOverhead);
+  const textData = Buffer.concat([Buffer.from("Comment\0", "ascii"), Buffer.alloc(padLen, 0x41)]);
+
+  return Buffer.concat([sig, ihdrChunk, pngChunk("tEXt", textData), idatChunk, iendChunk]);
+}
+
+type MultipartFile = { filename: string; mimeType: string; buffer: Buffer };
+
+/** Build a raw multipart/form-data body with multiple files under one field name. */
+function buildMultipartBody(fieldName: string, files: MultipartFile[]): { body: Buffer; contentType: string } {
+  const boundary = `----LLBoundary${Date.now().toString(36)}${Math.random().toString(36).slice(2)}`;
+  const parts: Buffer[] = [];
+  for (const file of files) {
+    parts.push(Buffer.from(`--${boundary}\r\n`));
+    parts.push(Buffer.from(
+      `Content-Disposition: form-data; name="${fieldName}"; filename="${file.filename}"\r\n` +
+      `Content-Type: ${file.mimeType}\r\n\r\n`,
+    ));
+    parts.push(file.buffer);
+    parts.push(Buffer.from("\r\n"));
+  }
+  parts.push(Buffer.from(`--${boundary}--\r\n`));
+  return {
+    body: Buffer.concat(parts),
+    contentType: `multipart/form-data; boundary=${boundary}`,
+  };
+}
 
 test.describe("Docker Compose Smoke Validation", () => {
   test("backend health check responds with 200 OK and status ok", async ({ request }) => {
@@ -46,5 +104,54 @@ test.describe("Docker Compose Smoke Validation", () => {
     const registerHeading = page.getByRole("heading", { name: "Register" });
     await expect(registerHeading).toBeVisible();
     await expect(page).toHaveURL(/\/register/);
+  });
+
+  test("multi-image upload above 1 MiB succeeds through Nginx proxy", async ({ request }) => {
+    // All requests use relative URLs resolved against baseURL (http://127.0.0.1:8080),
+    // exercising the Nginx proxy rather than the backend directly (port 8000).
+    const username = `bulkuser-${Date.now()}`;
+    const password = "testpass123";
+
+    // Register and authenticate through the proxy.
+    await request.post("/api/v1/auth/register", { data: { username, password } });
+    const loginRes = await request.post("/api/v1/auth/login", { data: { username, password } });
+    expect(loginRes.ok(), `login failed: ${loginRes.status()}`).toBeTruthy();
+
+    const setCookie = loginRes.headers()["set-cookie"] ?? "";
+    const sessionToken = setCookie.match(/ll_session=([^;]+)/)?.[1];
+    expect(sessionToken, "session cookie should be present after login").toBeTruthy();
+    const cookieHeader = `ll_session=${sessionToken}`;
+
+    // Create an ingestion batch through the proxy.
+    const batchRes = await request.post("/api/v1/ingestion-batches", {
+      headers: { Cookie: cookieHeader },
+    });
+    expect(batchRes.status()).toBe(201);
+    const batchId = (await batchRes.json()).batch.id;
+
+    // Two valid PNGs whose combined size exceeds 1 MiB (Nginx default limit).
+    const pngA = buildLargePng(600 * 1024);
+    const pngB = buildLargePng(600 * 1024);
+    expect(pngA.length + pngB.length).toBeGreaterThan(1024 * 1024);
+
+    // Build multipart body manually — Playwright's multipart param does not
+    // support multiple files under the same field name ("images").
+    const { body, contentType } = buildMultipartBody("images", [
+      { filename: "a.png", mimeType: "image/png", buffer: pngA },
+      { filename: "b.png", mimeType: "image/png", buffer: pngB },
+    ]);
+
+    // Upload through the Nginx proxy (port 8080). Returns 413 before the fix.
+    const uploadRes = await request.post(`/api/v1/ingestion-batches/${batchId}/images`, {
+      headers: { Cookie: cookieHeader, "Content-Type": contentType },
+      data: body,
+    });
+
+    if (uploadRes.status() !== 201) {
+      throw new Error(`Upload failed: ${uploadRes.status()} ${await uploadRes.text()}`);
+    }
+    const { batch } = await uploadRes.json();
+    expect(batch.images).toHaveLength(2);
+    expect(batch.images.every((img: { status: string }) => img.status === "uploaded")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add `client_max_body_size 512m;` to the Nginx `/api/` proxy location in `frontend/nginx.conf`, so multi-image ingestion-batch uploads exceeding the default 1 MiB limit reach the backend instead of being rejected with HTTP 413.
- Add a Compose smoke regression test that uploads two valid PNGs (>1 MiB combined) through the Nginx proxy on port 8080 and asserts a 201 response with two uploaded images.

## Linked Issue

Closes #464

## Issue Alignment

This PR implements the issue by:

- Adding `client_max_body_size 512m;` to the `location /api/` block in `frontend/nginx.conf`, placed before `proxy_pass`.
- Extending `frontend/tests/compose-smoke.spec.ts` with a regression test that registers and authenticates a user through `http://127.0.0.1:8080`, creates an ingestion batch, and uploads two valid PNG files whose combined multipart payload exceeds 1 MiB.

Scope covered:

- Nginx `client_max_body_size 512m` configured in the `/api/` proxy location.
- Docker Compose proxy-path regression test exercising port 8080 (not direct port 8000).
- Test uses two valid generated PNGs with aggregate payload above 1 MiB.
- Test asserts 201 response, exactly two images, both with `uploaded` status.
- Test verified to fail with HTTP 413 before the configuration change.

Out of scope / intentionally not included:

- Changing `bulk_ingestion_max_images` or `bulk_ingestion_max_image_bytes`.
- Adding a backend aggregate batch-byte limit or frontend pre-upload validation.
- Changing generic frontend error copy.
- Changing limits for unrelated upload endpoints.

## Implementation Notes

- The `512m` limit accommodates the current maximum batch contract of 50 images × 10 MiB (500 MiB) plus multipart overhead.
- The regression test generates valid PNG files using Node.js `zlib` (`crc32` for PNG chunk CRCs, `deflateSync` for IDAT data). Each PNG is a genuine 1×1 RGB image padded with a standard `tEXt` ancillary chunk to reach 600 KiB. PIL (Pillow) verification confirmed the generated PNGs are decodable.
- The multipart form body is constructed manually because Playwright's `multipart` parameter does not support multiple files under the same field name (`images`).
- All API requests in the new test use relative URLs resolved against `baseURL` (`http://127.0.0.1:8080`) to ensure traffic goes through the Nginx proxy, not directly to the backend on port 8000.

## Tests

Commands run:

- `cd frontend && npm test -- --run` — **passed** (510 tests, 34 test files)
- `cd frontend && npm run build` — **passed** (tsc -b && vite build, 413 modules transformed)
- `docker compose up -d --build --wait` — **passed** (all 4 services healthy)
- `docker compose --profile bootstrap run --rm rustfs-bootstrap` — **passed** (S3 bucket created)
- `cd frontend && npm run test:smoke:compose` — **passed** (4 tests, including new regression test)
- Pre-fix verification (temporarily removed `client_max_body_size` from running container, reloaded nginx): new test **failed with HTTP 413** as expected.
- Post-fix verification (restored `client_max_body_size 512m`, reloaded nginx): new test **passed with 201**.

Automated tests added or updated:

- `compose-smoke.spec.ts`: new test `"multi-image upload above 1 MiB succeeds through Nginx proxy"` — registers a user, creates a batch, uploads two ~600 KiB valid PNGs through port 8080, asserts 201 with two `uploaded` images.

Manual verification:

- Confirmed the generated PNG is a valid, decodable image using Python PIL (`Image.open` + `verify`).
- Confirmed the upload request goes through `http://127.0.0.1:8080` (Nginx proxy) and returns 201.
- Confirmed the same request returns 413 when `client_max_body_size` is absent.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly: `client_max_body_size 512m;` in the `location /api/` block, and a Compose smoke test through port 8080 with two valid PNGs above 1 MiB.

## Follow-Up Work

The issue mentions a potential follow-up to introduce an explicit backend aggregate batch-byte limit and frontend pre-upload validation. This is not included in this PR as it is explicitly out of scope.