### PR TITLE
feat: add s shortcut to save pending bulk-ingestion bounding boxes

### DIFF
--- a/frontend/src/components/BulkDetectStep.tsx
+++ b/frontend/src/components/BulkDetectStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { BulkBatch, BulkImageBox } from "@/types/bulkIngestion";
 import { BoxEditor } from "./BoxEditor";
 
@@ -46,6 +46,7 @@ export function BulkDetectStep({
   const [workingImageId, setWorkingImageId] = useState<string | null>(null);
   const [pendingBoxes, setPendingBoxes] = useState<Record<string, BulkImageBox[]>>({});
   const [pendingSubjects, setPendingSubjects] = useState<Record<string, string>>({});
+  const shortcutSavingRef = useRef(false);
 
   const withImageLoader = useCallback(
     async (imageId: string, action: () => void | Promise<void>) => {
@@ -79,6 +80,58 @@ export function BulkDetectStep({
   const actionableImages = batch.images.filter(
     (image) => image.status !== "committed" && image.status !== "deleted",
   );
+
+  const handleShortcutSave = useCallback(async () => {
+    if (shortcutSavingRef.current) return;
+
+    const pending: { imageId: string; boxes: BulkImageBox[]; subject: string }[] =
+      [];
+    for (const image of actionableImages) {
+      const boxes = pendingBoxes[image.imageId] ?? image.boxes;
+      const currentSubject = image.subject ?? "math";
+      const subject = pendingSubjects[image.imageId] ?? currentSubject;
+      if (
+        JSON.stringify(boxes) !== JSON.stringify(image.boxes) ||
+        subject !== currentSubject
+      ) {
+        pending.push({ imageId: image.imageId, boxes, subject });
+      }
+    }
+
+    if (pending.length === 0) return;
+
+    shortcutSavingRef.current = true;
+    try {
+      for (const card of pending) {
+        await withImageLoader(card.imageId, () =>
+          handleSave(card.imageId, card.boxes, card.subject),
+        );
+      }
+    } finally {
+      shortcutSavingRef.current = false;
+    }
+  }, [actionableImages, pendingBoxes, pendingSubjects, withImageLoader, handleSave]);
+
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key !== "s" || event.repeat) return;
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      event.preventDefault();
+      void handleShortcutSave();
+    }
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [handleShortcutSave]);
 
   return (
     <div data-testid="bulk-wizard-detect-step">

--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -805,6 +805,325 @@ describe("BulkIngestionWizard", () => {
     });
   });
 
+  it("saves pending bounding-box edits via the s shortcut", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.saveImageBoxes.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "math",
+            boxes: [],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    const editor = screen.getByTestId("box-editor");
+    vi.spyOn(editor, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 200,
+      height: 100,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 100,
+      toJSON: () => "",
+    });
+    fireEvent.resize(window);
+
+    fireEvent.mouseDown(editor, { clientX: 15, clientY: 15 });
+    fireEvent.mouseUp(editor);
+    fireEvent.click(screen.getByTestId("delete-box-box-1"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-save-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "s" });
+
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledWith("batch-1", "img-1", [], "math");
+    });
+  });
+
+  it("saves all changed cards via a single s press", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+          {
+            imageId: "img-2",
+            status: "ready",
+            order: 1,
+            sourceImage: { bucket: "b", objectKey: "k2", width: 200, height: 100, mediaUrl: "http://example.com/img2.png" },
+            subject: "math",
+            boxes: [{ boxId: "box-2", x: 30, y: 30, width: 40, height: 40 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.saveImageBoxes.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "english",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+          {
+            imageId: "img-2",
+            status: "ready",
+            order: 1,
+            sourceImage: { bucket: "b", objectKey: "k2", width: 200, height: 100, mediaUrl: "http://example.com/img2.png" },
+            subject: "english",
+            boxes: [{ boxId: "box-2", x: 30, y: 30, width: 40, height: 40 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+      expect(screen.getByTestId("bulk-detect-image-img-2")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("bulk-detect-subject-img-1"), {
+      target: { value: "english" },
+    });
+    fireEvent.change(screen.getByTestId("bulk-detect-subject-img-2"), {
+      target: { value: "english" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-save-img-1")).toBeInTheDocument();
+      expect(screen.getByTestId("bulk-detect-save-img-2")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "s" });
+
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledTimes(2);
+    });
+    expect(mocks.saveImageBoxes).toHaveBeenNthCalledWith(
+      1,
+      "batch-1",
+      "img-1",
+      [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+      "english",
+    );
+    expect(mocks.saveImageBoxes).toHaveBeenNthCalledWith(
+      2,
+      "batch-1",
+      "img-2",
+      [{ boxId: "box-2", x: 30, y: 30, width: 40, height: 40 }],
+      "english",
+    );
+  });
+
+  it("does not save when s is pressed with no pending changes", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "s" });
+    });
+    expect(mocks.saveImageBoxes).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeated, modified, and editable-origin s key events", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("bulk-detect-subject-img-1"), {
+      target: { value: "english" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-save-img-1")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "s", repeat: true });
+    });
+    expect(mocks.saveImageBoxes).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "s", ctrlKey: true });
+    });
+    expect(mocks.saveImageBoxes).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "S" });
+    });
+    expect(mocks.saveImageBoxes).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.keyDown(screen.getByTestId("bulk-detect-subject-img-1"), { key: "s" });
+    });
+    expect(mocks.saveImageBoxes).not.toHaveBeenCalled();
+  });
+
+  it("prevents a second save sequence while one is in progress", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    let resolveSave!: (value: BatchResponse) => void;
+    mocks.saveImageBoxes.mockReturnValue(
+      new Promise<BatchResponse>((resolve) => {
+        resolveSave = resolve;
+      }),
+    );
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByTestId("bulk-detect-subject-img-1"), {
+      target: { value: "english" },
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-save-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "s" });
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.keyDown(window, { key: "s" });
+    await act(async () => {});
+    expect(mocks.saveImageBoxes).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSave({
+        batch: makeBatch({
+          images: [
+            {
+              imageId: "img-1",
+              status: "ready",
+              order: 0,
+              sourceImage: { bucket: "b", objectKey: "k", width: 200, height: 100, mediaUrl: "http://example.com/img.png" },
+              subject: "english",
+              boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+              detection: { model: "model" },
+              createdAt: "2026-07-03T00:00:00Z",
+              updatedAt: "2026-07-03T00:00:00Z",
+            },
+          ],
+        }),
+      });
+    });
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("keeps ready items in review until the user continues to submit", async () => {
     mocks.getActiveBatch.mockResolvedValue({
       batch: makeBatch({


### PR DESCRIPTION
## Summary

- Add a bare `s` keyboard shortcut to the bulk-ingestion **Review detected boxes** step that saves every image card with pending box or subject edits through the existing `saveImageBoxes` mutation.
- The listener is scoped to `BulkDetectStep`, with cleanup on unmount, following the same `window.addEventListener("keydown", ...)` pattern already used by `Modal` and `BoxEditor`.
- Guards: ignores repeat events, modifier chords (Ctrl/Meta/Alt), uppercase `S` (Shift), and key presses originating from editable controls (INPUT/TEXTAREA/SELECT/contentEditable). Prevents re-entry while a save sequence is in progress via a ref guard.

## Linked Issue

Closes #466

## Issue Alignment

This PR implements the issue by:

- Adding a lifecycle-managed window keydown handler in `BulkDetectStep` that recognizes only bare lowercase `s`, ignoring editable targets and modifier/repeat events, and preventing default handling when it runs.
- Deriving changed cards using the same box (`JSON.stringify` comparison) and subject comparisons that control each card's Save button.
- Snapshotting changed cards and invoking the existing `handleSave` flow sequentially via `withImageLoader`, preventing duplicate shortcut sequences; doing nothing when the snapshot is empty.
- Keeping button-triggered saves and all existing API/error behavior intact.

Scope covered:

- Keyboard listener scoped to `BulkDetectStep` with cleanup on unmount.
- Sequential execution of the existing save path for all pending cards.
- Preservation of loading, server error, and pending-state behavior.
- Frontend regression tests for the shortcut and its guards.

Out of scope / intentionally not included:

- Backend endpoints, persistence schema, or API client contract changes.
- New shortcuts in upload, extraction review, or submission stages.
- An active-card model, a visible shortcut hint, or changes to detect, commit, or delete behavior.

## Implementation Notes

- `handleShortcutSave` takes a snapshot of changed cards at the moment `s` is pressed, then saves them one at a time through `withImageLoader` + `handleSave`. This preserves the existing single-image loading model and ensures deterministic server-response ordering.
- A `shortcutSavingRef` ref guards against re-entry: a second `s` press while a save sequence is running is a no-op.
- The keydown effect re-registers when `handleShortcutSave` changes (i.e., when pending state changes), following the same dependency-driven pattern as `BoxEditor` and `Modal`.

## Tests

Commands run:

- `npx vitest run src/components/BulkIngestionWizard.test.tsx` — passed (33 tests, 374ms)
- `npx vitest run src/components/BoxEditor.test.tsx` — passed (9 tests, 54ms)
- `npm run build` — passed (TypeScript compilation + Vite production build)

Automated tests added or updated:

- `saves pending bounding-box edits via the s shortcut` — deletes a box via BoxEditor, presses `s`, asserts `saveImageBoxes` receives the pending empty-boxes state.
- `saves all changed cards via a single s press` — two cards with subject changes, presses `s`, asserts both saves are called with correct boxes and subjects.
- `does not save when s is pressed with no pending changes` — no edits, presses `s`, asserts no save request.
- `ignores repeated, modified, and editable-origin s key events` — tests `repeat: true`, `ctrlKey: true`, uppercase `S`, and `s` from a SELECT element; asserts no save.
- `prevents a second save sequence while one is in progress` — uses a controllable promise to keep the first save pending, presses `s` again, resolves, and asserts only one save call.

Manual verification:

- Not yet performed in the Docker Compose environment (requires manual box editing in a running browser session). The automated tests exercise the full wizard/component wiring including BoxEditor box edits, subject changes, keyboard event dispatch, and the save mutation call chain.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.