### PR TITLE
fix: ignore deleted images in bulk ingestion stage derivation

### DIFF
--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -66,6 +66,10 @@ function committedImage(overrides: Partial<BulkImage> = {}): BulkImage {
   };
 }
 
+function deletedImage(overrides: Partial<BulkImage> = {}): BulkImage {
+  return committedImage({ status: "deleted", ...overrides });
+}
+
 function queuedItem(overrides: Partial<BulkItem> = {}): BulkItem {
   return {
     itemId: "item-1",
@@ -1483,6 +1487,138 @@ describe("BulkIngestionWizard", () => {
     await waitFor(() => {
       expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
     });
+  });
+
+  it("enters review when deleted images accompany a committed image and a queued item", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          deletedImage({ imageId: "img-2" }),
+          deletedImage({ imageId: "img-3" }),
+          committedImage({ imageId: "img-4" }),
+        ],
+        items: [queuedItem({ imageId: "img-4" })],
+      }),
+    });
+    mocks.startBatchExtraction.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          deletedImage({ imageId: "img-2" }),
+          deletedImage({ imageId: "img-3" }),
+          committedImage({ imageId: "img-4" }),
+        ],
+        items: [queuedItem({ imageId: "img-4" })],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+  });
+
+  it("does not return to detect after a detail refresh that includes deleted images", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          deletedImage({ imageId: "img-2" }),
+          deletedImage({ imageId: "img-3" }),
+          committedImage({ imageId: "img-4" }),
+        ],
+        items: [queuedItem({ imageId: "img-4" })],
+      }),
+    });
+    mocks.startBatchExtraction.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          deletedImage({ imageId: "img-2" }),
+          deletedImage({ imageId: "img-3" }),
+          committedImage({ imageId: "img-4" }),
+        ],
+        items: [queuedItem({ imageId: "img-4" })],
+      }),
+    });
+    mocks.getBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          deletedImage({ imageId: "img-2" }),
+          deletedImage({ imageId: "img-3" }),
+          committedImage({ imageId: "img-4" }),
+        ],
+        items: [queuedItem({ imageId: "img-4" })],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+    expect(mocks.startBatchExtraction).toHaveBeenCalledTimes(1);
+
+    // detail refresh via getBatch returns deleted images; stage must stay in review
+    await waitFor(() => {
+      expect(mocks.getBatch).toHaveBeenCalledWith("batch-1");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("bulk-wizard-detect-step")).not.toBeInTheDocument();
+  });
+
+  it("still requires detect when a non-deleted uncommitted image is present alongside deleted images", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          {
+            imageId: "img-2",
+            status: "uploaded",
+            order: 1,
+            sourceImage: { bucket: "b", objectKey: "k" },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-detect-step")).toBeInTheDocument();
+    });
+  });
+
+  it("keeps review-to-submit preservation intact when deleted images are present", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          deletedImage({ imageId: "img-1" }),
+          committedImage({ imageId: "img-2" }),
+        ],
+        items: [readyItem({ imageId: "img-2" })],
+      }),
+    });
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-review-step")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-review-continue"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-submit-step")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("bulk-wizard-detect-step")).not.toBeInTheDocument();
   });
 
   it("transitions to expired UX when a review poll returns BATCH_EXPIRED", async () => {

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -57,7 +57,7 @@ function deriveStep(batch: BulkBatch): BulkWizardStep {
   if (batch.images.length === 0) {
     return "upload";
   }
-  if (batch.images.some((image) => image.status !== "committed")) {
+  if (hasPendingImages(batch)) {
     return "detect";
   }
   if (
@@ -81,9 +81,15 @@ function deriveStep(batch: BulkBatch): BulkWizardStep {
   return "complete";
 }
 
+function hasPendingImages(batch: BulkBatch): boolean {
+  return batch.images.some(
+    (image) => image.status !== "committed" && image.status !== "deleted",
+  );
+}
+
 function canPreserveSubmitStep(batch: BulkBatch): boolean {
   if (batch.status !== "active") return false;
-  if (batch.images.some((image) => image.status !== "committed")) return false;
+  if (hasPendingImages(batch)) return false;
   return batch.items.some(
     (item) =>
       item.status === "ready" ||
@@ -94,7 +100,7 @@ function canPreserveSubmitStep(batch: BulkBatch): boolean {
 
 function canPreserveReviewStep(batch: BulkBatch): boolean {
   if (batch.status !== "active") return false;
-  if (batch.images.some((image) => image.status !== "committed")) return false;
+  if (hasPendingImages(batch)) return false;
   return batch.items.some(
     (item) => item.status !== "deleted" && item.status !== "submitted",
   );


### PR DESCRIPTION
## Summary

- Fixed bulk-ingestion stage derivation so soft-deleted source images (`status: "deleted"`) no longer block Detect-to-Review progression or cause a Review-to-Detect regression after a detail refresh.
- The backend `GET /api/v1/ingestion-batches/{batch_id}` endpoint intentionally returns deleted images for item deletion/undo state. The wizard treated every non-committed image as pending, so a detail refresh containing deleted images reverted the stage from Review to Detect.
- Extracted a shared `hasPendingImages` predicate that excludes both `committed` and `deleted` images, and applied it to `deriveStep`, `canPreserveReviewStep`, and `canPreserveSubmitStep` so all stage decisions share identical semantics.

## Linked Issue

Closes #468

## Issue Alignment

This PR implements the issue by:

- Replacing the `image.status !== "committed"` condition with a shared `hasPendingImages` predicate that excludes both `committed` and `deleted` images, used in `deriveStep`, `canPreserveReviewStep`, and `canPreserveSubmitStep`.

Scope covered:

- Updating frontend stage derivation to ignore `deleted` images when deciding whether Detect is incomplete.
- Applying the same rule to Review/Submit step-preservation guards so a refresh cannot undo the stage transition.
- Adding regression tests for a batch containing deleted images, a committed image, and a queued item.
- Verifying the normal uncommitted-image path still opens Detect.

Out of scope / intentionally not included:

- Backend detail endpoint changes (deliberately retains deleted images).
- Soft-delete persistence / atomic-update work.

## Implementation Notes

- Added a small `hasPendingImages(batch)` helper in `BulkIngestionWizard.tsx` and used it in all three stage functions, matching the issue's "shared helper" recommendation. This mirrors the predicate `BulkDetectStep.tsx` already uses (`image.status !== "committed" && image.status !== "deleted"`).
- No backend changes. No contract changes.

## Tests

Commands run:

- `npx vitest run src/components/BulkIngestionWizard.test.tsx` - passed (37 tests, including 4 new regression tests)
- `npx tsc --noEmit` - passed (no type errors)
- `npm run build` - passed (build succeeded)

Automated tests added or updated:

- `enters review when deleted images accompany a committed image and a queued item` - three deleted images + one committed image + queued item select Review.
- `does not return to detect after a detail refresh that includes deleted images` - exercises the `getBatch` detail-response path (the exact path the manual workflow triggers) and asserts Review stays active and Detect is not shown.
- `still requires detect when a non-deleted uncommitted image is present alongside deleted images` - an `uploaded` (non-deleted, non-committed) image still selects Detect.
- `keeps review-to-submit preservation intact when deleted images are present` - Review-to-Submit preservation remains intact with deleted images present.

These regression tests would fail before the fix: the deleted images (not `committed`) would make `deriveStep` return `"detect"`.

Manual verification:

- The regression tests render the actual `BulkIngestionWizard` component and feed it the same `getBatch` detail-response shape (including deleted images) that the backend returns, then assert the stage stays in Review. This exercises the exact code path the manual four-page-PDF workflow triggers at the UI level.
- Full end-to-end manual reproduction (uploading a real four-page PDF through the running stack, deleting three pages, committing the fourth, and refreshing) was not separately performed; the automated component tests directly cover the `getBatch` detail-response path that is the root cause of the reported regression.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly: a shared pending-image predicate applied to `deriveStep`, `canPreserveReviewStep`, and `canPreserveSubmitStep`.

## Follow-Up Work

None. The separate repository read-modify-write concurrency risks are out of scope per the issue.