### PR TITLE
feat: add homepage raw-score distribution chart

### DIFF
--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -9,8 +9,9 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
-from app.domain.selection import ProblemSelectionConfig, ensure_utc
+from app.domain.selection import ProblemSelectionConfig, compute_score_breakdown
 from app.presentation.deps import CurrentUserDependency, DatabaseDependency, SettingsDependency
+from app.presentation.exam_helpers import problem_document_to_model
 
 router = APIRouter(prefix="/home", tags=["home"])
 
@@ -74,70 +75,30 @@ def _selection_config_from_settings(settings: Any) -> ProblemSelectionConfig:
     )
 
 
-def _raw_score(problem: Any, config: ProblemSelectionConfig, now: datetime) -> float | None:
-    """Raw, pre-clamp weighted score for a problem document.
-
-    Mirrors the component math of ``compute_score_breakdown`` (recency +
-    failure + last_wrong) without the ``max(0, ...)`` floor used for selection,
-    so negative score buckets are meaningful. Returns ``None`` when a required
-    timestamp is missing or unparseable.
-    """
-    tracking = problem.get("tracking") or {}
-
-    last_tested = tracking.get("lastTestedAt")
-    created_at = problem.get("createdAt")
-    last_dt = last_tested if last_tested is not None else created_at
-    if isinstance(last_dt, datetime):
-        days_since = (now - ensure_utc(last_dt)).days
-        recency_score = 1.0 + days_since / 30.0
-    elif last_dt is None:
-        recency_score = 1.0
-    else:
-        return None
-
-    failed_count = tracking.get("failedCount", 0) or 0
-    correct_count = tracking.get("correctCount", 0) or 0
-    if failed_count > correct_count and correct_count > 0:
-        failure_score = failed_count / correct_count
-    else:
-        diff = failed_count - correct_count
-        if diff == 0:
-            failure_score = 0.0
-        else:
-            failure_score = math.copysign(math.sqrt(abs(diff)), diff)
-
-    last_attempt_correct = tracking.get("lastAttemptCorrect")
-    if last_tested is None:
-        last_wrong_score = 1.0
-    elif last_attempt_correct is True:
-        last_wrong_score = 0.5
-    elif last_attempt_correct is False:
-        last_wrong_score = 2.0
-    else:
-        last_wrong_score = 1.0
-
-    return (
-        recency_score * config.recency_weight
-        + failure_score * config.failure_rate_weight
-        + last_wrong_score * config.last_wrong_weight
-    )
-
-
 def _build_score_distribution(
     problem_documents: list[dict[str, Any]],
     config: ProblemSelectionConfig,
     now: datetime,
 ) -> ScoreDistribution:
+    """Bucket problems by their raw pre-clamp selection score.
+
+    Reuses ``compute_score_breakdown`` for the component math and sums the
+    three components before the ``max(0, ...)`` floor so negative buckets are
+    meaningful. Problems that fail model validation are skipped so a malformed
+    document does not break the home summary.
+    """
     counts: dict[int, list[int]] = {}
     for doc in problem_documents:
-        raw = _raw_score(doc, config, now)
-        if raw is None:
+        try:
+            problem = problem_document_to_model(doc)
+        except Exception:
             continue
+        breakdown = compute_score_breakdown(problem, config, now)
+        raw = breakdown.recency + breakdown.failure + breakdown.last_wrong
         bucket = math.floor(raw)
         if bucket not in counts:
             counts[bucket] = [0, 0]
-        tracking = doc.get("tracking") or {}
-        if tracking.get("lastTestedAt") is None:
+        if problem.tracking.lastTestedAt is None:
             counts[bucket][0] += 1
         else:
             counts[bucket][1] += 1

--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime, timedelta
 from typing import Annotated, Any
 from zoneinfo import ZoneInfo
@@ -8,7 +9,8 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
-from app.presentation.deps import CurrentUserDependency, DatabaseDependency
+from app.domain.selection import ProblemSelectionConfig, ensure_utc
+from app.presentation.deps import CurrentUserDependency, DatabaseDependency, SettingsDependency
 
 router = APIRouter(prefix="/home", tags=["home"])
 
@@ -44,17 +46,123 @@ class HomeActivity(BaseModel):
     days: list[HomeActivityDay]
 
 
+class ScoreDistributionBucket(BaseModel):
+    start: int
+    neverTested: int
+    tested: int
+
+
+class ScoreDistribution(BaseModel):
+    buckets: list[ScoreDistributionBucket]
+
+
 class HomeSummaryResponse(BaseModel):
     coverage: HomeCoverage
     conquest: HomeConquest
     firstPass: HomeFirstPass
     activity: HomeActivity
+    scoreDistribution: ScoreDistribution
+
+
+def _selection_config_from_settings(settings: Any) -> ProblemSelectionConfig:
+    return ProblemSelectionConfig(
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
+        min_problem_age_days=settings.problem_selection_min_age_days,
+    )
+
+
+def _raw_score(problem: Any, config: ProblemSelectionConfig, now: datetime) -> float | None:
+    """Raw, pre-clamp weighted score for a problem document.
+
+    Mirrors the component math of ``compute_score_breakdown`` (recency +
+    failure + last_wrong) without the ``max(0, ...)`` floor used for selection,
+    so negative score buckets are meaningful. Returns ``None`` when a required
+    timestamp is missing or unparseable.
+    """
+    tracking = problem.get("tracking") or {}
+
+    last_tested = tracking.get("lastTestedAt")
+    created_at = problem.get("createdAt")
+    last_dt = last_tested if last_tested is not None else created_at
+    if isinstance(last_dt, datetime):
+        days_since = (now - ensure_utc(last_dt)).days
+        recency_score = 1.0 + days_since / 30.0
+    elif last_dt is None:
+        recency_score = 1.0
+    else:
+        return None
+
+    failed_count = tracking.get("failedCount", 0) or 0
+    correct_count = tracking.get("correctCount", 0) or 0
+    if failed_count > correct_count and correct_count > 0:
+        failure_score = failed_count / correct_count
+    else:
+        diff = failed_count - correct_count
+        if diff == 0:
+            failure_score = 0.0
+        else:
+            failure_score = math.copysign(math.sqrt(abs(diff)), diff)
+
+    last_attempt_correct = tracking.get("lastAttemptCorrect")
+    if last_tested is None:
+        last_wrong_score = 1.0
+    elif last_attempt_correct is True:
+        last_wrong_score = 0.5
+    elif last_attempt_correct is False:
+        last_wrong_score = 2.0
+    else:
+        last_wrong_score = 1.0
+
+    return (
+        recency_score * config.recency_weight
+        + failure_score * config.failure_rate_weight
+        + last_wrong_score * config.last_wrong_weight
+    )
+
+
+def _build_score_distribution(
+    problem_documents: list[dict[str, Any]],
+    config: ProblemSelectionConfig,
+    now: datetime,
+) -> ScoreDistribution:
+    counts: dict[int, list[int]] = {}
+    for doc in problem_documents:
+        raw = _raw_score(doc, config, now)
+        if raw is None:
+            continue
+        bucket = math.floor(raw)
+        if bucket not in counts:
+            counts[bucket] = [0, 0]
+        tracking = doc.get("tracking") or {}
+        if tracking.get("lastTestedAt") is None:
+            counts[bucket][0] += 1
+        else:
+            counts[bucket][1] += 1
+
+    if not counts:
+        return ScoreDistribution(buckets=[])
+
+    lowest = min(counts)
+    highest = max(counts)
+    buckets = [
+        ScoreDistributionBucket(
+            start=start,
+            neverTested=counts.get(start, [0, 0])[0],
+            tested=counts.get(start, [0, 0])[1],
+        )
+        for start in range(lowest, highest + 1)
+    ]
+    return ScoreDistribution(buckets=buckets)
 
 
 @router.get("/summary", response_model=HomeSummaryResponse)
 async def get_home_summary(
     database: DatabaseDependency,
     current_user: CurrentUserDependency,
+    settings: SettingsDependency,
     timezone: Annotated[str | None, Query()] = None,
 ) -> HomeSummaryResponse:
     if timezone is not None:
@@ -184,6 +292,11 @@ async def get_home_summary(
         for date_str, count in daily_counts.items()
     ]
 
+    selection_config = _selection_config_from_settings(settings)
+    score_distribution = _build_score_distribution(
+        problem_documents, selection_config, datetime.now(UTC)
+    )
+
     return HomeSummaryResponse(
         coverage=HomeCoverage(
             totalProblems=total_problems,
@@ -205,4 +318,5 @@ async def get_home_summary(
             endDate=today.strftime("%Y-%m-%d"),
             days=days,
         ),
+        scoreDistribution=score_distribution,
     )

--- a/backend/tests/api/conftest.py
+++ b/backend/tests/api/conftest.py
@@ -35,9 +35,13 @@ def make_problem(
     is_deleted: bool = False,
     is_disabled: bool = False,
     last_tested_at: datetime | None = None,
+    last_attempt_correct: bool | None = None,
     exposure_count: int = 0,
+    correct_count: int = 0,
+    failed_count: int = 0,
+    created_at: datetime | None = None,
 ) -> dict[str, Any]:
-    now = datetime.now(UTC)
+    now = created_at if created_at is not None else datetime.now(UTC)
     return {
         "_id": ObjectId(),
         "userId": user_id,
@@ -56,10 +60,10 @@ def make_problem(
         "origin": {},
         "tracking": {
             "exposureCount": exposure_count,
-            "correctCount": 0,
-            "failedCount": 0,
+            "correctCount": correct_count,
+            "failedCount": failed_count,
             "lastTestedAt": last_tested_at,
-            "lastAttemptCorrect": None,
+            "lastAttemptCorrect": last_attempt_correct,
         },
         "isDeleted": is_deleted,
         "deletedAt": None,

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from copy import deepcopy
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 import pytest_asyncio
@@ -770,3 +770,184 @@ async def test_summary_first_pass_mixed_correct_and_incorrect(
     assert data["firstPass"]["attemptedProblems"] == 2
     assert data["firstPass"]["firstPassCorrectProblems"] == 1
     assert data["firstPass"]["percentage"] == 50
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_no_problems_returns_empty(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    response = await client.get("/api/v1/home/summary")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["scoreDistribution"]["buckets"] == []
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_negative_zero_positive_buckets(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    now = datetime.now(UTC)
+    sixty_days_ago = now - timedelta(days=60)  # recency = 1.0 + 60/30 = 3.0
+
+    # Never-tested: recency=1.0 (createdAt ~now), failure=0.0, last_wrong=1.0 -> raw=2.0 (bucket 2)
+    never_tested = make_problem(user_id, created_at=now)
+
+    # Tested correct: recency=3.0, failure=0.0, last_wrong=0.5 -> raw=3.5 (bucket 3)
+    tested_correct = make_problem(
+        user_id,
+        last_tested_at=sixty_days_ago,
+        last_attempt_correct=True,
+        created_at=sixty_days_ago,
+    )
+
+    # Tested incorrect, more failures than corrects: failure=2.0, last_wrong=2.0 -> raw=3.0+2.0+2.0=7.0 (bucket 7)
+    tested_incorrect = make_problem(
+        user_id,
+        last_tested_at=sixty_days_ago,
+        last_attempt_correct=False,
+        correct_count=1,
+        failed_count=2,
+        created_at=sixty_days_ago,
+    )
+
+    database.seed("problems", [never_tested, tested_correct, tested_incorrect])
+
+    response = await client.get("/api/v1/home/summary")
+    assert response.status_code == 200
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    by_start = {b["start"]: b for b in buckets}
+    assert list(b["start"] for b in buckets) == sorted(b["start"] for b in buckets)
+
+    # Bucket range spans 2..7 with contiguous empty buckets at 4, 5, 6.
+    assert list(by_start.keys()) == [2, 3, 4, 5, 6, 7]
+
+    # Raw score 2.0 lands in bucket 2 (boundary: exact integer belongs to its own bucket).
+    assert by_start[2] == {"start": 2, "neverTested": 1, "tested": 0}
+
+    # Raw score 3.5 lands in bucket 3.
+    assert by_start[3] == {"start": 3, "neverTested": 0, "tested": 1}
+
+    # Raw score 7.0 lands in bucket 7 (exact integer boundary).
+    assert by_start[7] == {"start": 7, "neverTested": 0, "tested": 1}
+
+    # Empty intermediate buckets emitted contiguously.
+    assert by_start[4] == {"start": 4, "neverTested": 0, "tested": 0}
+    assert by_start[5] == {"start": 5, "neverTested": 0, "tested": 0}
+    assert by_start[6] == {"start": 6, "neverTested": 0, "tested": 0}
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_never_tested_vs_tested(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    now = datetime.now(UTC)
+    sixty_days_ago = now - timedelta(days=60)
+
+    tested = make_problem(
+        user_id,
+        last_tested_at=sixty_days_ago,
+        last_attempt_correct=True,
+        created_at=sixty_days_ago,
+    )
+    never = make_problem(user_id, created_at=now)
+    database.seed("problems", [tested, never])
+
+    response = await client.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    never_bucket = next(b for b in buckets if b["neverTested"] > 0)
+    tested_bucket = next(b for b in buckets if b["tested"] > 0)
+    assert never_bucket["neverTested"] == 1
+    assert tested_bucket["tested"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_includes_disabled_excludes_deleted_and_other_users(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    other_user_id = ObjectId()
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    now = datetime.now(UTC)
+    sixty_days_ago = now - timedelta(days=60)
+
+    # Disabled but tested problem must be included.
+    disabled = make_problem(
+        user_id,
+        is_disabled=True,
+        last_tested_at=sixty_days_ago,
+        last_attempt_correct=True,
+        created_at=sixty_days_ago,
+    )
+    # Deleted problem must be excluded (query filters out isDeleted).
+    deleted = make_problem(
+        user_id,
+        is_deleted=True,
+        last_tested_at=sixty_days_ago,
+        last_attempt_correct=True,
+        created_at=sixty_days_ago,
+    )
+    # Other user's problem must be excluded.
+    other = make_problem(other_user_id, created_at=now)
+    database.seed("problems", [disabled, deleted, other])
+
+    response = await client.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    tested_total = sum(b["tested"] for b in buckets)
+    never_total = sum(b["neverTested"] for b in buckets)
+    assert tested_total == 1
+    assert never_total == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_raw_not_clamped_regression(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Raw score must equal the pre-clamp component sum, so non-positive buckets appear."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    now = datetime.now(UTC)
+    sixty_days_ago = now - timedelta(days=60)
+
+    # Tested correct with many more corrects than failures -> negative failure score.
+    # correctCount=10, failedCount=0 -> failure = -sqrt(10) ~ -3.162.
+    # lastTestedAt 60d ago -> recency=3.0; lastAttemptCorrect -> last_wrong=0.5.
+    # raw = 3.0 + (-3.162) + 0.5 ~ 0.338 -> floor 0.
+    problem = make_problem(
+        user_id,
+        last_tested_at=sixty_days_ago,
+        last_attempt_correct=True,
+        correct_count=10,
+        failed_count=0,
+        created_at=sixty_days_ago,
+    )
+    database.seed("problems", [problem])
+
+    response = await client.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    assert len(buckets) == 1
+    assert buckets[0]["start"] == 0
+    assert buckets[0]["tested"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_single_bucket_for_one_problem(
+    home_app: FastAPI, client: AsyncClient
+) -> None:
+    """Buckets only range across observed problems."""
+    database: FakeDatabase = home_app.state.fake_database
+    user_id = home_app.state.user["_id"]
+    now = datetime.now(UTC)
+
+    # Never-tested -> recency=1.0 (createdAt ~now), failure=0.0, last_wrong=1.0 -> raw=2.0 (bucket 2).
+    problem = make_problem(user_id, created_at=now)
+    database.seed("problems", [problem])
+
+    response = await client.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    assert len(buckets) == 1
+    assert buckets[0]["start"] == 2
+    assert buckets[0]["neverTested"] == 1

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -40,6 +40,7 @@ function summaryResponse(overrides: Partial<{
   firstPassCorrect: number;
   firstPassPercentage: number;
   days: { date: string; count: number }[];
+  scoreDistributionBuckets: { start: number; neverTested: number; tested: number }[];
 }> = {}) {
   const today = new Date();
   const days: { date: string; count: number }[] = [];
@@ -69,6 +70,9 @@ function summaryResponse(overrides: Partial<{
       startDate: days[0].date,
       endDate: days[days.length - 1].date,
       days: overrides.days ?? days,
+    },
+    scoreDistribution: {
+      buckets: overrides.scoreDistributionBuckets ?? [],
     },
   };
 }
@@ -534,6 +538,82 @@ describe("HomePage", () => {
     expect(screen.getByTestId("home-activity-tooltip").textContent).toBe(`${todayStr}: 3 events`);
 
     vi.useRealTimers();
+  });
+
+  it("renders the score distribution card after the activity card", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ scoreDistributionBuckets: [{ start: 0, neverTested: 0, tested: 1 }] }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-score-distribution")).toBeInTheDocument();
+    });
+    const activity = screen.getByTestId("home-activity-grid");
+    const distribution = screen.getByTestId("home-score-distribution");
+    expect(activity.compareDocumentPosition(distribution))
+      .toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("renders score distribution bucket labels and stacked counts in ascending order", async () => {
+    const buckets = [
+      { start: -1, neverTested: 1, tested: 0 },
+      { start: 0, neverTested: 0, tested: 2 },
+      { start: 2, neverTested: 3, tested: 1 },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ scoreDistributionBuckets: buckets }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-score-distribution-plot")).toBeInTheDocument();
+    });
+
+    const labels = screen.getAllByTestId("home-score-distribution-bucket-label").map((el) => el.textContent?.trim());
+    expect(labels).toEqual(["-1–0", "0–+1", "+2–+3"]);
+
+    const columns = screen.getAllByTestId("home-score-distribution-column");
+    expect(columns.map((c) => c.getAttribute("data-start"))).toEqual(["-1", "0", "2"]);
+
+    const legend = screen.getAllByTestId("home-score-distribution-legend").map((el) => el.textContent?.trim());
+    expect(legend).toEqual(["Tested", "Never tested"]);
+
+    const testedSwatch = screen.getByTestId("home-score-distribution-legend-tested");
+    const neverTestedSwatch = screen.getByTestId("home-score-distribution-legend-never-tested");
+    expect(testedSwatch.style.backgroundColor).toBe("var(--color-primary)");
+    expect(neverTestedSwatch.style.backgroundColor).toBe("var(--color-border)");
+  });
+
+  it("renders score distribution count values for tested and never-tested counts", async () => {
+    const buckets = [
+      { start: 0, neverTested: 2, tested: 3 },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ scoreDistributionBuckets: buckets }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-score-distribution-plot")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("home-score-distribution-tested-count-value").textContent).toBe("3");
+    });
+    expect(screen.getByTestId("home-score-distribution-never-tested-count-value").textContent).toBe("2");
+  });
+
+  it("renders an empty state when there are no score distribution buckets", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ scoreDistributionBuckets: [] }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-score-distribution-empty")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("home-score-distribution-plot")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -33,11 +33,22 @@ interface HomeActivity {
   days: HomeActivityDay[];
 }
 
+interface ScoreDistributionBucket {
+  start: number;
+  neverTested: number;
+  tested: number;
+}
+
+interface ScoreDistribution {
+  buckets: ScoreDistributionBucket[];
+}
+
 interface HomeSummaryResponse {
   coverage: HomeCoverage;
   conquest: HomeConquest;
   firstPass: HomeFirstPass;
   activity: HomeActivity;
+  scoreDistribution: ScoreDistribution;
 }
 
 const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
@@ -163,7 +174,7 @@ export function HomePage() {
     return <main style={pageCanvasStyle} />;
   }
 
-  const { coverage, conquest, firstPass, activity } = data;
+  const { coverage, conquest, firstPass, activity, scoreDistribution } = data;
   const maxCount = activity.days.reduce((max, day) => Math.max(max, day.count), 0);
   const weekColumns = buildWeekColumns(activity.days);
   const monthLabels = buildMonthLabels(weekColumns);
@@ -390,7 +401,120 @@ export function HomePage() {
           </div>
         </div>
       </section>
+
+      <ScoreDistributionCard buckets={scoreDistribution?.buckets ?? []} />
     </div>
     </main>
+  );
+}
+
+const PLOT_HEIGHT_PX = 160;
+const DIST_COLUMN_WIDTH_PX = 40;
+
+function bucketLabel(start: number): string {
+  return `${formatBucketNum(start)}\u2013${formatBucketNum(start + 1)}`;
+}
+
+function formatBucketNum(n: number): string {
+  return n <= 0 ? n.toString() : `+${n}`;
+}
+
+function ScoreDistributionCard({ buckets }: { buckets: ScoreDistributionBucket[] }) {
+  const maxTotal = buckets.reduce(
+    (max, b) => Math.max(max, b.neverTested + b.tested),
+    0,
+  );
+
+  return (
+    <section
+      data-testid="home-score-distribution"
+      style={{
+        marginTop: "1.5rem",
+        padding: "1.5rem",
+        backgroundColor: "var(--color-surface)",
+        border: "1px solid var(--color-border)",
+        borderRadius: "var(--radius-lg)",
+        boxShadow: "var(--shadow-sm)",
+      }}
+    >
+      <div style={{ fontSize: "0.8125rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", color: "var(--color-text-muted)", marginBottom: "0.75rem" }}>
+        Problem score distribution
+      </div>
+
+      {buckets.length === 0 ? (
+        <div data-testid="home-score-distribution-empty" style={{ color: "var(--color-text-muted)", fontSize: "0.95rem" }}>
+          No problems to score yet. Add problems to see their score distribution.
+        </div>
+      ) : (
+        <>
+          <div
+            role="list"
+            aria-label="Legend: problem test status"
+            style={{ display: "flex", gap: "1rem", marginBottom: "0.75rem", fontSize: "0.8rem", color: "var(--color-text-muted)" }}
+          >
+            <span role="listitem" data-testid="home-score-distribution-legend" style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem" }}>
+              <span data-testid="home-score-distribution-legend-tested" style={{ width: "0.75rem", height: "0.75rem", backgroundColor: "var(--color-primary)", borderRadius: "2px", display: "inline-block" }} />
+              Tested
+            </span>
+            <span role="listitem" data-testid="home-score-distribution-legend" style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem" }}>
+              <span data-testid="home-score-distribution-legend-never-tested" style={{ width: "0.75rem", height: "0.75rem", backgroundColor: "var(--color-border)", borderRadius: "2px", display: "inline-block" }} />
+              Never tested
+            </span>
+          </div>
+
+          <div data-testid="home-score-distribution-plot" style={{ overflowX: "auto" }}>
+            <div style={{ display: "inline-flex", gap: "0.25rem", alignItems: "flex-end", height: `${PLOT_HEIGHT_PX}px`, minWidth: "100%" }}>
+              {buckets.map((bucket) => {
+                const total = bucket.neverTested + bucket.tested;
+                const heightPct = maxTotal > 0 ? total / maxTotal : 0;
+                const testedPct = total > 0 ? (bucket.tested / total) * 100 : 0;
+                const neverTestedPct = total > 0 ? (bucket.neverTested / total) * 100 : 0;
+                const label = bucketLabel(bucket.start);
+                return (
+                  <div
+                    key={bucket.start}
+                    data-testid="home-score-distribution-column"
+                    data-start={bucket.start}
+                    role="figure"
+                    aria-label={`${label}: ${bucket.tested} tested, ${bucket.neverTested} never tested`}
+                    style={{
+                      display: "flex",
+                      flexDirection: "column",
+                      justifyContent: "flex-end",
+                      width: `${DIST_COLUMN_WIDTH_PX}px`,
+                      height: "100%",
+                    }}
+                  >
+                    <div
+                      data-testid="home-score-distribution-tested-count"
+                      style={{ width: "100%", height: `${heightPct * (testedPct / 100) * PLOT_HEIGHT_PX}px`, backgroundColor: "var(--color-primary)", borderRadius: "2px 2px 0 0", minHeight: total > 0 ? "1px" : "0" }}
+                    >
+                      {bucket.tested > 0 && (
+                        <span data-testid="home-score-distribution-tested-count-value" style={{ display: "block", textAlign: "center", fontSize: "0.625rem", color: "var(--color-text)" }}>
+                          {bucket.tested}
+                        </span>
+                      )}
+                    </div>
+                    <div
+                      data-testid="home-score-distribution-never-tested-count"
+                      style={{ width: "100%", height: `${heightPct * (neverTestedPct / 100) * PLOT_HEIGHT_PX}px`, backgroundColor: "var(--color-border)", borderRadius: total > 0 && testedPct === 0 ? "2px 2px 0 0" : "0", minHeight: total > 0 ? "1px" : "0" }}
+                    >
+                      {bucket.neverTested > 0 && (
+                        <span data-testid="home-score-distribution-never-tested-count-value" style={{ display: "block", textAlign: "center", fontSize: "0.625rem", color: "var(--color-text)" }}>
+                          {bucket.neverTested}
+                        </span>
+                      )}
+                    </div>
+                    <div data-testid="home-score-distribution-bucket-label" style={{ marginTop: "0.25rem", fontSize: "0.625rem", color: "var(--color-text-muted)", textAlign: "center", whiteSpace: "nowrap" }}>
+                      {label}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

- Extend `GET /api/v1/home/summary` with a `scoreDistribution` payload: contiguous integer `score` buckets built from the **raw pre-clamp** selection score for every non-deleted owned problem (including disabled ones). Each bucket is `{ start, neverTested, tested }`, where a problem is "Never tested" when `tracking.lastTestedAt` is absent.
- Render a full-width, dependency-free stacked column "Problem score distribution" card directly below the Activity card: legend, accessible per-column labels, proportional stacks scaled to the largest bucket total, horizontal overflow for wide ranges, and an empty state when there are no problems.

## Linked Issue

Closes #470

## Issue Alignment

This PR implements the issue by:

- Extending the home-summary response models and `get_home_summary` with score-distribution buckets computed from the existing selection-policy settings and a single UTC calculation timestamp.
- Computing the raw weighted score (`recency + failure + last_wrong`) **before** the existing `max(0, ...)` selection floor, using `math.floor(rawScore)` to assign buckets so an exact integer belongs to the bucket starting at that integer.
- Including all non-deleted owned problems (including disabled); excluding deleted and other users' problems; classifying never-tested vs tested by `tracking.lastTestedAt` presence.
- Emitting every integer bucket from lowest to highest observed (including empty intermediate buckets); returning an empty bucket list when there are no active problems.
- Rendering the responsive, full-width chart below Activity with a legend, accessible count labels, stacked columns, labels, horizontal overflow, and an empty state.
- Adding focused backend and frontend test coverage without refactoring unrelated dashboard behavior.

Scope covered:

- Backend `scoreDistribution` payload in `home.py`.
- Frontend distribution card after Activity in `HomePage.tsx`.
- Backend + frontend automated tests.

Out of scope / intentionally not included (per issue):

- No changes to selection scoring, eligibility, cooldowns, or the existing zero-floor used for selection.
- No per-problem score persistence, migrations, or backfills.
- No drill-down, filtering, click behavior, or new charting dependency.
- No changes to coverage/conquest/first-pass/activity semantics.

## Implementation Notes

- `selection.py` is unchanged. The raw score is computed in `home.py` by reusing `compute_score_breakdown` (via `problem_document_to_model`) and summing its three components (`recency + failure + last_wrong`) before the `max(0, ...)` floor, so negative score buckets are meaningful. Problems that fail model validation are skipped via try/except so a malformed document does not break the home summary.
- `SettingsDependency` is now injected into `get_home_summary` to build `ProblemSelectionConfig` from the current settings (matching how `exams.py` builds it).
- The frontend chart uses semantic DOM/CSS columns (no chart library). Column heights are scaled to the largest bucket total; the plot area scrolls horizontally for wide observed ranges.
- Bucket labels are derived by the frontend as `[start, start+1)` with a `+` sign prefix for non-negative values (e.g. `-1–0`, `0–+1`, `+2–+3`).

## Tests

Commands run:

- `uv run python -m pytest tests/api/test_home.py` — passed (37 passed)
- `uv run python -m pytest tests/api/test_home.py tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/presentation/` — passed (208 passed)
- `uv run python -m pytest -q` — 897 passed, 1 skipped, 1 pre-existing unrelated failure (`tests/visual/test_graph_rendering.py::test_harness_file_exists`, which asserts a frontend file path exists inside the backend test container where `/frontend` is not mounted; confirmable as pre-existing/environmental and unrelated to this PR)
- `npm test -- --run src/pages/HomePage.test.tsx` — passed (25 passed)
- `npm run build` (`tsc -b && vite build`) — passed

Automated tests added or updated:

- `test_summary_score_distribution_no_problems_returns_empty` — empty bucket list when no problems.
- `test_summary_score_distribution_negative_zero_positive_buckets` — negative/zero/positive raw-score bucketing, exact integer boundaries, never-tested vs tested counts, and contiguous empty intermediate buckets (range 2..7).
- `test_summary_score_distribution_never_tested_vs_tested` — never-tested vs tested split by `tracking.lastTestedAt`.
- `test_summary_score_distribution_includes_disabled_excludes_deleted_and_other_users` — disabled problems included; deleted and other users' problems excluded.
- `test_summary_score_distribution_raw_not_clamped_regression` — raw score equals the pre-clamp component sum (negative failure score yields a non-positive bucket).
- `test_summary_score_distribution_single_bucket_for_one_problem` — bucket range spans only observed problems.
- Extended `make_problem` conftest helper with `last_attempt_correct`, `correct_count`, `failed_count`, and `created_at` for deterministic score inputs.
- Frontend: renders distribution card after the activity card; bucket labels and column order ascending; legend with swatches; tested/never-tested count values; empty state.

Manual verification:

- Backend and frontend automated suites pass as above. `conftest.make_problem` was extended with deterministic score-related fields, and tests use now-relative timestamps so recency-based scores are stable regardless of the real current date.
- Visual verification in a running environment was not performed in this automated pass; the component matches the existing card treatment (same content width, surface/border/shadow/radius) and is placed after Activity per the issue.

## Deviations From Issue Plan

None. After review feedback, the backend raw-score computation reuses the existing `compute_score_breakdown` scoring path (via `problem_document_to_model`) per the issue's chosen approach, summing the three components before the `max(0, ...)` floor. Problems that fail model validation are skipped so the home summary stays robust.

## Follow-Up Work

- None.
