### PR TITLE
feat: split score-distribution chart into cooldown and min-aged categories

### DIFF
--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
-from app.domain.selection import ProblemSelectionConfig, compute_score_breakdown
+from app.domain.selection import ProblemSelectionConfig, compute_score_breakdown, ensure_utc
 from app.presentation.deps import CurrentUserDependency, DatabaseDependency, SettingsDependency
 from app.presentation.exam_helpers import problem_document_to_model
 
@@ -50,7 +50,9 @@ class HomeActivity(BaseModel):
 class ScoreDistributionBucket(BaseModel):
     start: int
     neverTested: int
+    minAged: int
     tested: int
+    cooldown: int
 
 
 class ScoreDistribution(BaseModel):
@@ -87,6 +89,9 @@ def _build_score_distribution(
     meaningful. Problems that fail model validation are skipped so a malformed
     document does not break the home summary.
     """
+    # Category indexes: 0=neverTested, 1=minAged, 2=tested, 3=cooldown.
+    cooldown_cutoff = now - timedelta(days=config.cooldown_days)
+    age_cutoff = now - timedelta(days=config.min_problem_age_days)
     counts: dict[int, list[int]] = {}
     for doc in problem_documents:
         try:
@@ -97,11 +102,16 @@ def _build_score_distribution(
         raw = breakdown.recency + breakdown.failure + breakdown.last_wrong
         bucket = math.floor(raw)
         if bucket not in counts:
-            counts[bucket] = [0, 0]
-        if problem.tracking.lastTestedAt is None:
-            counts[bucket][0] += 1
+            counts[bucket] = [0, 0, 0, 0]
+        last_tested = problem.tracking.lastTestedAt
+        if last_tested is not None:
+            # Parent-status split: tested problems never classify as Min aged.
+            idx = 3 if ensure_utc(last_tested) > cooldown_cutoff else 2
+        elif ensure_utc(problem.createdAt) > age_cutoff:
+            idx = 1
         else:
-            counts[bucket][1] += 1
+            idx = 0
+        counts[bucket][idx] += 1
 
     if not counts:
         return ScoreDistribution(buckets=[])
@@ -111,8 +121,10 @@ def _build_score_distribution(
     buckets = [
         ScoreDistributionBucket(
             start=start,
-            neverTested=counts.get(start, [0, 0])[0],
-            tested=counts.get(start, [0, 0])[1],
+            neverTested=counts.get(start, [0, 0, 0, 0])[0],
+            minAged=counts.get(start, [0, 0, 0, 0])[1],
+            tested=counts.get(start, [0, 0, 0, 0])[2],
+            cooldown=counts.get(start, [0, 0, 0, 0])[3],
         )
         for start in range(lowest, highest + 1)
     ]

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -18,9 +18,12 @@ from tests.api.conftest import FakeDatabase, make_problem, make_user
 
 @pytest.fixture
 def home_app() -> FastAPI:
+    return _build_home_application(Settings(problem_selection_min_age_days=0))
+
+
+def _build_home_application(settings: Settings) -> FastAPI:
     application = create_app()
     database = FakeDatabase()
-    settings = Settings(problem_selection_min_age_days=0)
     user = make_user(ObjectId(), "student")
 
     application.state.fake_database = database
@@ -35,6 +38,18 @@ def home_app() -> FastAPI:
 @pytest_asyncio.fixture
 async def client(home_app: FastAPI) -> AsyncIterator[AsyncClient]:
     transport = ASGITransport(app=home_app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+        yield async_client
+
+
+@pytest.fixture
+def home_app_with_min_age() -> FastAPI:
+    return _build_home_application(Settings(problem_selection_min_age_days=3))
+
+
+@pytest_asyncio.fixture
+async def client_with_min_age(home_app_with_min_age: FastAPI) -> AsyncIterator[AsyncClient]:
+    transport = ASGITransport(app=home_app_with_min_age)
     async with AsyncClient(transport=transport, base_url="http://testserver") as async_client:
         yield async_client
 
@@ -824,18 +839,18 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     assert list(by_start.keys()) == [2, 3, 4, 5, 6, 7]
 
     # Raw score 2.0 lands in bucket 2 (boundary: exact integer belongs to its own bucket).
-    assert by_start[2] == {"start": 2, "neverTested": 1, "tested": 0}
+    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 0, "cooldown": 0}
 
     # Raw score 3.5 lands in bucket 3.
-    assert by_start[3] == {"start": 3, "neverTested": 0, "tested": 1}
+    assert by_start[3] == {"start": 3, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
 
     # Raw score 7.0 lands in bucket 7 (exact integer boundary).
-    assert by_start[7] == {"start": 7, "neverTested": 0, "tested": 1}
+    assert by_start[7] == {"start": 7, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
 
     # Empty intermediate buckets emitted contiguously.
-    assert by_start[4] == {"start": 4, "neverTested": 0, "tested": 0}
-    assert by_start[5] == {"start": 5, "neverTested": 0, "tested": 0}
-    assert by_start[6] == {"start": 6, "neverTested": 0, "tested": 0}
+    assert by_start[4] == {"start": 4, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
+    assert by_start[5] == {"start": 5, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
+    assert by_start[6] == {"start": 6, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
 
 
 @pytest.mark.asyncio
@@ -951,3 +966,164 @@ async def test_summary_score_distribution_single_bucket_for_one_problem(
     assert len(buckets) == 1
     assert buckets[0]["start"] == 2
     assert buckets[0]["neverTested"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_four_categories(
+    home_app_with_min_age: FastAPI, client_with_min_age: AsyncClient
+) -> None:
+    """Each of Cooldown, Tested, Min aged, and Never tested gets one problem."""
+    database: FakeDatabase = home_app_with_min_age.state.fake_database
+    user_id = home_app_with_min_age.state.user["_id"]
+    now = datetime.now(UTC)
+    one_day_ago = now - timedelta(days=1)       # newer than now-3d -> min aged (untested only)
+    three_days_ago = now - timedelta(days=3)     # newer than now-7d -> cooldown
+    thirty_days_ago = now - timedelta(days=30)  # older than now-7d -> tested
+    hundred_days_ago = now - timedelta(days=100)  # older than now-3d -> never tested
+
+    cooldown_p = make_problem(
+        user_id,
+        last_tested_at=three_days_ago,
+        last_attempt_correct=True,
+        created_at=hundred_days_ago,
+    )
+    tested_p = make_problem(
+        user_id,
+        last_tested_at=thirty_days_ago,
+        last_attempt_correct=True,
+        created_at=thirty_days_ago,
+    )
+    min_aged_p = make_problem(user_id, created_at=one_day_ago)
+    never_tested_p = make_problem(user_id, created_at=hundred_days_ago)
+    database.seed("problems", [cooldown_p, tested_p, min_aged_p, never_tested_p])
+
+    response = await client_with_min_age.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+
+    assert sum(b["cooldown"] for b in buckets) == 1
+    assert sum(b["tested"] for b in buckets) == 1
+    assert sum(b["minAged"] for b in buckets) == 1
+    assert sum(b["neverTested"] for b in buckets) == 1
+    # Invariant: each problem counted exactly once across all buckets.
+    bucket_total = sum(
+        b["neverTested"] + b["minAged"] + b["tested"] + b["cooldown"] for b in buckets
+    )
+    assert bucket_total == 4
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_cooldown_cutoff_boundary(
+    home_app_with_min_age: FastAPI, client_with_min_age: AsyncClient
+) -> None:
+    """At exact cooldown cutoff classify as Tested; just newer -> Cooldown (strict >)."""
+    database: FakeDatabase = home_app_with_min_age.state.fake_database
+    user_id = home_app_with_min_age.state.user["_id"]
+    now = datetime.now(UTC)
+    deep_past = now - timedelta(days=100)
+
+    exactly_cutoff = make_problem(
+        user_id,
+        last_tested_at=now - timedelta(days=7),
+        last_attempt_correct=True,
+        created_at=deep_past,
+    )
+    just_inside = make_problem(
+        user_id,
+        last_tested_at=now - timedelta(days=7) + timedelta(minutes=5),
+        last_attempt_correct=True,
+        created_at=deep_past,
+    )
+    database.seed("problems", [exactly_cutoff, just_inside])
+
+    response = await client_with_min_age.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    assert sum(b["tested"] for b in buckets) == 1
+    assert sum(b["cooldown"] for b in buckets) == 1
+    assert sum(b["minAged"] for b in buckets) == 0
+    assert sum(b["neverTested"] for b in buckets) == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_min_age_cutoff_boundary(
+    home_app_with_min_age: FastAPI, client_with_min_age: AsyncClient
+) -> None:
+    """At exact min-age cutoff classify as Never tested; just newer -> Min aged (strict >)."""
+    database: FakeDatabase = home_app_with_min_age.state.fake_database
+    user_id = home_app_with_min_age.state.user["_id"]
+    now = datetime.now(UTC)
+
+    exactly_cutoff = make_problem(user_id, created_at=now - timedelta(days=3))
+    just_inside = make_problem(
+        user_id,
+        created_at=now - timedelta(days=3) + timedelta(minutes=5),
+    )
+    database.seed("problems", [exactly_cutoff, just_inside])
+
+    response = await client_with_min_age.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    assert sum(b["neverTested"] for b in buckets) == 1
+    assert sum(b["minAged"] for b in buckets) == 1
+    assert sum(b["tested"] for b in buckets) == 0
+    assert sum(b["cooldown"] for b in buckets) == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_recently_created_tested_problem_not_min_aged(
+    home_app_with_min_age: FastAPI, client_with_min_age: AsyncClient
+) -> None:
+    """A recently created and recently tested problem stays in the tested parent split (Cooldown)."""
+    database: FakeDatabase = home_app_with_min_age.state.fake_database
+    user_id = home_app_with_min_age.state.user["_id"]
+    one_day_ago = datetime.now(UTC) - timedelta(days=1)
+
+    problem = make_problem(
+        user_id,
+        last_tested_at=one_day_ago,
+        last_attempt_correct=True,
+        created_at=one_day_ago,
+    )
+    database.seed("problems", [problem])
+
+    response = await client_with_min_age.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    assert sum(b["cooldown"] for b in buckets) == 1
+    assert sum(b["minAged"] for b in buckets) == 0
+    assert sum(b["tested"] for b in buckets) == 0
+    assert sum(b["neverTested"] for b in buckets) == 0
+
+
+@pytest.mark.asyncio
+async def test_summary_score_distribution_disabled_included_deleted_other_users_excluded_categories(
+    home_app_with_min_age: FastAPI, client_with_min_age: AsyncClient
+) -> None:
+    """Disabled problems are bucketed by category; deleted/other-user problems are excluded."""
+    database: FakeDatabase = home_app_with_min_age.state.fake_database
+    user_id = home_app_with_min_age.state.user["_id"]
+    other_user_id = ObjectId()
+    one_day_ago = datetime.now(UTC) - timedelta(days=1)
+
+    disabled_cooldown = make_problem(
+        user_id,
+        is_disabled=True,
+        last_tested_at=one_day_ago,
+        last_attempt_correct=True,
+        created_at=one_day_ago,
+    )
+    deleted_cooldown = make_problem(
+        user_id,
+        is_deleted=True,
+        last_tested_at=one_day_ago,
+        last_attempt_correct=True,
+        created_at=one_day_ago,
+    )
+    other_min_aged = make_problem(other_user_id, created_at=one_day_ago)
+    database.seed("problems", [disabled_cooldown, deleted_cooldown, other_min_aged])
+
+    response = await client_with_min_age.get("/api/v1/home/summary")
+    buckets = response.json()["scoreDistribution"]["buckets"]
+    bucket_total = sum(
+        b["neverTested"] + b["minAged"] + b["tested"] + b["cooldown"] for b in buckets
+    )
+    assert bucket_total == 1
+    assert sum(b["cooldown"] for b in buckets) == 1
+    assert sum(b["minAged"] for b in buckets) == 0

--- a/frontend/src/pages/HomePage.test.tsx
+++ b/frontend/src/pages/HomePage.test.tsx
@@ -40,7 +40,7 @@ function summaryResponse(overrides: Partial<{
   firstPassCorrect: number;
   firstPassPercentage: number;
   days: { date: string; count: number }[];
-  scoreDistributionBuckets: { start: number; neverTested: number; tested: number }[];
+  scoreDistributionBuckets: { start: number; neverTested: number; minAged: number; tested: number; cooldown: number }[];
 }> = {}) {
   const today = new Date();
   const days: { date: string; count: number }[] = [];
@@ -543,7 +543,7 @@ describe("HomePage", () => {
   it("renders the score distribution card after the activity card", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => summaryResponse({ scoreDistributionBuckets: [{ start: 0, neverTested: 0, tested: 1 }] }),
+      json: async () => summaryResponse({ scoreDistributionBuckets: [{ start: 0, neverTested: 0, minAged: 0, tested: 1, cooldown: 0 }] }),
     });
     renderHomePage();
     await waitFor(() => {
@@ -557,9 +557,9 @@ describe("HomePage", () => {
 
   it("renders score distribution bucket labels and stacked counts in ascending order", async () => {
     const buckets = [
-      { start: -1, neverTested: 1, tested: 0 },
-      { start: 0, neverTested: 0, tested: 2 },
-      { start: 2, neverTested: 3, tested: 1 },
+      { start: -1, neverTested: 1, minAged: 0, tested: 0, cooldown: 0 },
+      { start: 0, neverTested: 0, minAged: 0, tested: 2, cooldown: 0 },
+      { start: 2, neverTested: 3, minAged: 1, tested: 1, cooldown: 0 },
     ];
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -577,17 +577,21 @@ describe("HomePage", () => {
     expect(columns.map((c) => c.getAttribute("data-start"))).toEqual(["-1", "0", "2"]);
 
     const legend = screen.getAllByTestId("home-score-distribution-legend").map((el) => el.textContent?.trim());
-    expect(legend).toEqual(["Tested", "Never tested"]);
+    expect(legend).toEqual(["Never tested", "Min aged", "Tested", "Cooldown"]);
 
-    const testedSwatch = screen.getByTestId("home-score-distribution-legend-tested");
     const neverTestedSwatch = screen.getByTestId("home-score-distribution-legend-never-tested");
-    expect(testedSwatch.style.backgroundColor).toBe("var(--color-primary)");
+    const minAgedSwatch = screen.getByTestId("home-score-distribution-legend-min-aged");
+    const testedSwatch = screen.getByTestId("home-score-distribution-legend-tested");
+    const cooldownSwatch = screen.getByTestId("home-score-distribution-legend-cooldown");
     expect(neverTestedSwatch.style.backgroundColor).toBe("var(--color-border)");
+    expect(minAgedSwatch.style.backgroundColor).toBe("var(--color-text-muted)");
+    expect(testedSwatch.style.backgroundColor).toBe("var(--color-primary)");
+    expect(cooldownSwatch.style.backgroundColor).toBe("var(--color-warning)");
   });
 
   it("renders score distribution count values for tested and never-tested counts", async () => {
     const buckets = [
-      { start: 0, neverTested: 2, tested: 3 },
+      { start: 0, neverTested: 2, minAged: 0, tested: 3, cooldown: 0 },
     ];
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -602,6 +606,28 @@ describe("HomePage", () => {
       expect(screen.getByTestId("home-score-distribution-tested-count-value").textContent).toBe("3");
     });
     expect(screen.getByTestId("home-score-distribution-never-tested-count-value").textContent).toBe("2");
+  });
+
+  it("renders all four category segments with count values and accessible labels", async () => {
+    const buckets = [
+      { start: 0, neverTested: 1, minAged: 1, tested: 1, cooldown: 1 },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => summaryResponse({ scoreDistributionBuckets: buckets }),
+    });
+    renderHomePage();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-score-distribution-plot")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("home-score-distribution-cooldown-count-value").textContent).toBe("1");
+    expect(screen.getByTestId("home-score-distribution-tested-count-value").textContent).toBe("1");
+    expect(screen.getByTestId("home-score-distribution-min-aged-count-value").textContent).toBe("1");
+    expect(screen.getByTestId("home-score-distribution-never-tested-count-value").textContent).toBe("1");
+
+    const column = screen.getByTestId("home-score-distribution-column");
+    expect(column.getAttribute("aria-label")).toBe("0\u2013+1: 1 cooldown, 1 tested, 1 min aged, 1 never tested");
   });
 
   it("renders an empty state when there are no score distribution buckets", async () => {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -36,7 +36,9 @@ interface HomeActivity {
 interface ScoreDistributionBucket {
   start: number;
   neverTested: number;
+  minAged: number;
   tested: number;
+  cooldown: number;
 }
 
 interface ScoreDistribution {
@@ -421,7 +423,8 @@ function formatBucketNum(n: number): string {
 
 function ScoreDistributionCard({ buckets }: { buckets: ScoreDistributionBucket[] }) {
   const maxTotal = buckets.reduce(
-    (max, b) => Math.max(max, b.neverTested + b.tested),
+    (max, b) =>
+      Math.max(max, b.neverTested + b.minAged + b.tested + b.cooldown),
     0,
   );
 
@@ -452,31 +455,29 @@ function ScoreDistributionCard({ buckets }: { buckets: ScoreDistributionBucket[]
             aria-label="Legend: problem test status"
             style={{ display: "flex", gap: "1rem", marginBottom: "0.75rem", fontSize: "0.8rem", color: "var(--color-text-muted)" }}
           >
-            <span role="listitem" data-testid="home-score-distribution-legend" style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem" }}>
-              <span data-testid="home-score-distribution-legend-tested" style={{ width: "0.75rem", height: "0.75rem", backgroundColor: "var(--color-primary)", borderRadius: "2px", display: "inline-block" }} />
-              Tested
-            </span>
-            <span role="listitem" data-testid="home-score-distribution-legend" style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem" }}>
-              <span data-testid="home-score-distribution-legend-never-tested" style={{ width: "0.75rem", height: "0.75rem", backgroundColor: "var(--color-border)", borderRadius: "2px", display: "inline-block" }} />
-              Never tested
-            </span>
+            {LEGEND.map((item) => (
+              <span key={item.label} role="listitem" data-testid="home-score-distribution-legend" style={{ display: "inline-flex", alignItems: "center", gap: "0.375rem" }}>
+                <span data-testid={`home-score-distribution-legend-${item.swatchTestIdSuffix}`} style={{ width: "0.75rem", height: "0.75rem", backgroundColor: item.color, borderRadius: "2px", display: "inline-block" }} />
+                {item.label}
+              </span>
+            ))}
           </div>
 
           <div data-testid="home-score-distribution-plot" style={{ overflowX: "auto" }}>
             <div style={{ display: "inline-flex", gap: "0.25rem", alignItems: "flex-end", height: `${PLOT_HEIGHT_PX}px`, minWidth: "100%" }}>
               {buckets.map((bucket) => {
-                const total = bucket.neverTested + bucket.tested;
+                const total =
+                  bucket.neverTested + bucket.minAged + bucket.tested + bucket.cooldown;
                 const heightPct = maxTotal > 0 ? total / maxTotal : 0;
-                const testedPct = total > 0 ? (bucket.tested / total) * 100 : 0;
-                const neverTestedPct = total > 0 ? (bucket.neverTested / total) * 100 : 0;
                 const label = bucketLabel(bucket.start);
+                const topFilledIdx = STACK_ORDER.findIndex((seg) => bucket[seg.key] > 0);
                 return (
                   <div
                     key={bucket.start}
                     data-testid="home-score-distribution-column"
                     data-start={bucket.start}
                     role="figure"
-                    aria-label={`${label}: ${bucket.tested} tested, ${bucket.neverTested} never tested`}
+                    aria-label={`${label}: ${bucket.cooldown} cooldown, ${bucket.tested} tested, ${bucket.minAged} min aged, ${bucket.neverTested} never tested`}
                     style={{
                       display: "flex",
                       flexDirection: "column",
@@ -485,26 +486,24 @@ function ScoreDistributionCard({ buckets }: { buckets: ScoreDistributionBucket[]
                       height: "100%",
                     }}
                   >
-                    <div
-                      data-testid="home-score-distribution-tested-count"
-                      style={{ width: "100%", height: `${heightPct * (testedPct / 100) * PLOT_HEIGHT_PX}px`, backgroundColor: "var(--color-primary)", borderRadius: "2px 2px 0 0", minHeight: total > 0 ? "1px" : "0" }}
-                    >
-                      {bucket.tested > 0 && (
-                        <span data-testid="home-score-distribution-tested-count-value" style={{ display: "block", textAlign: "center", fontSize: "0.625rem", color: "var(--color-text)" }}>
-                          {bucket.tested}
-                        </span>
-                      )}
-                    </div>
-                    <div
-                      data-testid="home-score-distribution-never-tested-count"
-                      style={{ width: "100%", height: `${heightPct * (neverTestedPct / 100) * PLOT_HEIGHT_PX}px`, backgroundColor: "var(--color-border)", borderRadius: total > 0 && testedPct === 0 ? "2px 2px 0 0" : "0", minHeight: total > 0 ? "1px" : "0" }}
-                    >
-                      {bucket.neverTested > 0 && (
-                        <span data-testid="home-score-distribution-never-tested-count-value" style={{ display: "block", textAlign: "center", fontSize: "0.625rem", color: "var(--color-text)" }}>
-                          {bucket.neverTested}
-                        </span>
-                      )}
-                    </div>
+                    {STACK_ORDER.map((seg, idx) => {
+                      const count = bucket[seg.key];
+                      const pct = total > 0 ? (count / total) * 100 : 0;
+                      const rounded = idx === topFilledIdx;
+                      return (
+                        <div
+                          key={seg.key}
+                          data-testid={`home-score-distribution-${seg.testIdSuffix}-count`}
+                          style={{ width: "100%", height: `${heightPct * (pct / 100) * PLOT_HEIGHT_PX}px`, backgroundColor: seg.color, borderRadius: rounded ? "2px 2px 0 0" : "0", minHeight: total > 0 ? "1px" : "0" }}
+                        >
+                          {count > 0 && (
+                            <span data-testid={`home-score-distribution-${seg.testIdSuffix}-count-value`} style={{ display: "block", textAlign: "center", fontSize: "0.625rem", color: "var(--color-text)" }}>
+                              {count}
+                            </span>
+                          )}
+                        </div>
+                      );
+                    })}
                     <div data-testid="home-score-distribution-bucket-label" style={{ marginTop: "0.25rem", fontSize: "0.625rem", color: "var(--color-text-muted)", textAlign: "center", whiteSpace: "nowrap" }}>
                       {label}
                     </div>
@@ -518,3 +517,21 @@ function ScoreDistributionCard({ buckets }: { buckets: ScoreDistributionBucket[]
     </section>
   );
 }
+
+type CategoryKey = "cooldown" | "tested" | "minAged" | "neverTested";
+
+// Stack order from top to bottom of each column. Matches the bottom-to-top
+// order Never tested -> Min aged -> Tested -> Cooldown requested in the spec.
+const STACK_ORDER: { key: CategoryKey; testIdSuffix: string; color: string }[] = [
+  { key: "cooldown", testIdSuffix: "cooldown", color: "var(--color-warning)" },
+  { key: "tested", testIdSuffix: "tested", color: "var(--color-primary)" },
+  { key: "minAged", testIdSuffix: "min-aged", color: "var(--color-text-muted)" },
+  { key: "neverTested", testIdSuffix: "never-tested", color: "var(--color-border)" },
+];
+
+const LEGEND = [
+  { swatchTestIdSuffix: "never-tested", label: "Never tested", color: "var(--color-border)" },
+  { swatchTestIdSuffix: "min-aged", label: "Min aged", color: "var(--color-text-muted)" },
+  { swatchTestIdSuffix: "tested", label: "Tested", color: "var(--color-primary)" },
+  { swatchTestIdSuffix: "cooldown", label: "Cooldown", color: "var(--color-warning)" },
+];


### PR DESCRIPTION
## Summary

- Extend the home-summary score-distribution buckets from two counts (`neverTested`, `tested`) to four mutually exclusive counts: `neverTested`, `minAged`, `tested`, `cooldown`.
- Classify each non-deleted owned problem into exactly one category using the configured cooldown and minimum-age settings with the existing strict eligibility comparisons, so exact cutoff timestamps classify as Tested or Never tested (consistent with `app/domain/selection.py`).
- Apply the agreed parent-status rule: a tested problem is counted as Cooldown or Tested, never as Min aged. Min aged subdivides only Never tested.
- Render a four-segment stacked column chart with a matching legend (Never tested, Min aged, Tested, Cooldown) and accessible per-column labels in the existing full-width card below Activity on the Home page.

## Linked Issue

Closes #472

## Issue Alignment

This PR implements the issue by:

- Adding `minAged` and `cooldown` fields to `ScoreDistributionBucket` and populating them in `_build_score_distribution` using a single shared UTC `now` and the existing cooldown/minimum-age settings from `ProblemSelectionConfig`.
- Preserving the existing raw-score bucket range, problem population, and disabled-problem inclusion / deleted-and-other-user exclusion behavior from #470.
- Rendering all four segments, legend entries, per-column counts, and accessible labels in `HomePage.tsx`.

Scope covered:

- Backend model + aggregation for four categories.
- Frontend four-segment stack, legend, segment heights, accessible labels, empty behavior.
- API and component tests for the four-category stack.

Out of scope / intentionally not included:

- Changes to raw-score bucket generation, selection scoring, cooldown duration, minimum-age duration, or selection eligibility behavior.
- Changes to chart location, width, interaction model, or addition of a charting dependency.
- Changes to coverage, conquest, first-pass, or activity metrics.

## Implementation Notes

- The backend classification mirrors `get_eligible_problems` in `app/domain/selection.py`: it computes `cooldown_cutoff = now - cooldown_days` and `age_cutoff = now - min_problem_age_days` once per request and uses strict `>` comparisons via `ensure_utc`, so at an exact cutoff timestamp the problem classifies as Tested (if `lastTestedAt` is present) or Never tested (if not), matching existing eligibility comparisons.
- The parent-status rule is enforced by branching first on the presence of `lastTestedAt`; only problems with no `lastTestedAt` may be Min aged.
- The frontend renders segments from a single typed `STACK_ORDER` array (top to bottom: Cooldown, Tested, Min aged, Never tested) so the bottom-to-top stack order is Never tested, Min aged, Tested, Cooldown as requested. Colors reuse existing theme tokens: Never tested `var(--color-border)`, Min aged `var(--color-text-muted)`, Tested `var(--color-primary)`, Cooldown `var(--color-warning)`.
- Only the topmost non-empty segment receives rounded top corners via `topFilledIdx`, replacing the previous two-segment corner logic with a small generalization.

## Tests

Commands run:

- `cd backend && uv run --frozen --extra dev pytest tests/api/test_home.py` — passed (42 passed)
- `cd frontend && npm test -- --run src/pages/HomePage.test.tsx` — passed (26 passed)
- `cd frontend && npx tsc -b` — passed (no errors)

Automated tests added or updated:

- Backend (`backend/tests/api/test_home.py`):
  - Updated `test_summary_score_distribution_negative_zero_positive_buckets` expectations to include the new `minAged`/`cooldown` fields.
  - Added `test_summary_score_distribution_four_categories` covering one problem in each of the four categories plus the invariant that the four category counts sum to the bucket total.
  - Added `test_summary_score_distribution_cooldown_cutoff_boundary` covering the exact cooldown cutoff (Tested) and a value just newer (Cooldown).
  - Added `test_summary_score_distribution_min_age_cutoff_boundary` covering the exact min-age cutoff (Never tested) and a value just newer (Min aged).
  - Added `test_summary_score_distribution_recently_created_tested_problem_not_min_aged` for the overlapping-state regression.
  - Added `test_summary_score_distribution_disabled_included_deleted_other_users_excluded_categories` covering disabled-problem inclusion and deleted/other-user exclusion for the new categories.
  - Refactored the home test fixtures into a shared `_build_home_application(settings)` helper and added a `home_app_with_min_age` / `client_with_min_age` pair to configure non-zero cooldown/min-age.
- Frontend (`frontend/src/pages/HomePage.test.tsx`):
  - Updated the `summaryResponse` helper and existing distribution tests to include the new bucket fields.
  - Updated the legend expectation to `["Never tested", "Min aged", "Tested", "Cooldown"]` and asserted all four legend swatch colors.
  - Added `renders all four category segments with count values and accessible labels` covering the four segment counts and the per-column aria-label.

Manual verification:

- Backend and frontend unit tests are run via ephemeral containers using the existing `learnloop-app` image for the backend and the local Node toolchain for the frontend; both pass.
- The chart continues to render below Activity in the Home page with the existing empty-state behavior preserved (covered by the `home-score-distribution-empty` test). I did not perform browser-based manual verification beyond the rendered assertions, since the component tests cover the four-segment stack, legend, accessible labels, and empty behavior.

## Deviations From Issue Plan

- Minor implementation detail: I generalized the corner-rounding logic to round only the topmost non-empty segment instead of keeping the previous two-segment conditional. This preserves the existing visual behavior where the highest present category draws rounded top corners, and is required for the four-segment stack.
- I reused existing theme tokens (including `var(--color-warning)` for Cooldown and `var(--color-text-muted)` for Min aged) rather than introducing new colors, consistent with the issue's "existing theme styling approach".

## Follow-Up Work

None.