### PR TITLE
Raise JSXGraph DSL cap to 16,384 characters

### DIFF
--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -479,8 +479,11 @@ def _validate_dsl_create_call(call: str, declared_names: set[str]) -> bool:
     return True
 
 
+_MAX_DSL_LENGTH = 16384
+
+
 def _is_allowed_graph_dsl(dsl: str) -> bool:
-    if len(dsl) > 5000:
+    if len(dsl) > _MAX_DSL_LENGTH:
         return False
     unquoted = _strip_quoted_strings(dsl)
     if re.search(r"=>|`|//|/\*|\*/|\+\+|--", unquoted):

--- a/backend/tests/domain/test_graph_dsl_sanitizer.py
+++ b/backend/tests/domain/test_graph_dsl_sanitizer.py
@@ -119,7 +119,15 @@ class TestIsAllowedGraphDsl:
     def test_rejects_arithmetic_expressions(self) -> None:
         assert _is_allowed_graph_dsl("board.create('point', [1 + 2, 0]);") is False
 
-    def test_rejects_too_long_dsl(self) -> None:
+    def test_allows_dsl_at_maximum_length(self) -> None:
+        prefix = "board.create('text', [0, 0, '"
+        suffix = "']);"
+        padding_length = 16384 - len(prefix) - len(suffix)
+        dsl = f"{prefix}{'x' * padding_length}{suffix}"
+        assert len(dsl) == 16384
+        assert _is_allowed_graph_dsl(dsl) is True
+
+    def test_rejects_dsl_above_maximum_length(self) -> None:
         assert _is_allowed_graph_dsl("board.create('point', [0, 0]);" * 1000) is False
 
     def test_rejects_arrow_function_syntax(self) -> None:

--- a/frontend/src/components/GraphSandbox.test.tsx
+++ b/frontend/src/components/GraphSandbox.test.tsx
@@ -104,8 +104,13 @@ describe("GraphSandbox", () => {
     expect(validateDsl(dsl)).toBeNull();
   });
 
-  it("rejects DSL that is too long", () => {
-    const dsl = "x".repeat(5001);
+  it("accepts DSL at the maximum length", () => {
+    const dsl = "x".repeat(16384);
+    expect(validateDsl(dsl)).toBeNull();
+  });
+
+  it("rejects DSL that exceeds the maximum length", () => {
+    const dsl = "x".repeat(16385);
     expect(validateDsl(dsl)).toBe("DSL is too long");
   });
 

--- a/frontend/src/components/GraphSandbox.tsx
+++ b/frontend/src/components/GraphSandbox.tsx
@@ -20,6 +20,8 @@ export interface GraphSandboxProps {
   onRender?: () => void;
 }
 
+const MAX_DSL_LENGTH = 16384;
+
 /**
  * Validates JSXGraph DSL with lightweight checks.
  * Returns null if valid, error message if invalid.
@@ -29,7 +31,7 @@ export function validateDsl(dsl: string): string | null {
   if (!stripped) {
     return null;
   }
-  if (stripped.length > 5000) {
+  if (stripped.length > MAX_DSL_LENGTH) {
     return "DSL is too long";
   }
   return null;


### PR DESCRIPTION
Model-Signature: kimi-k2.7-code

## Summary

Raise the permitted JSXGraph DSL length from 5,000 to 16,384 characters in both the frontend `GraphSandbox` renderer and the backend coaching whiteboard sanitizer, with boundary tests updated for the new cap.

## Linked Issue

Closes #478

## Issue Alignment

This PR implements the issue by:

- Replacing the 5,000-character comparison in `frontend/src/components/GraphSandbox.tsx` with a 16,384-character comparison.
- Replacing the 5,000-character comparison in `backend/app/infrastructure/vlm/solution_coaching_client.py` with a 16,384-character comparison.
- Updating `frontend/src/components/GraphSandbox.test.tsx` to cover acceptance at 16,384 and rejection at 16,385.
- Updating `backend/tests/domain/test_graph_dsl_sanitizer.py` to cover the corresponding backend boundary.

Scope covered:

- Frontend and backend DSL size validation cap increase.
- Boundary tests for the new maximum.

Out of scope / intentionally not included:

- Runtime configurability of the limit.
- Changes to allowed JSXGraph DSL syntax or backend sanitization rules.
- Changes to iframe CSP, sandbox permissions, rendering timeout, or prompt behavior.

## Implementation Notes

- Introduced a local `MAX_DSL_LENGTH = 16384` constant in `GraphSandbox.tsx` and a local `_MAX_DSL_LENGTH = 16384` in `solution_coaching_client.py`, keeping the threshold local to each layer as requested.
- The backend boundary test builds a valid 16,384-character DSL by padding a `board.create('text', ...)` call with a long quoted string so the sanitizer's statement parser still accepts it.

## Tests

Commands run:

- `cd frontend && npm test -- GraphSandbox.test.tsx --run` — 18 passed, 0 failed (warnings are pre-existing `act(...)` warnings unrelated to this change).
- `cd backend && /home/rlan/anaconda3/bin/python -m pytest tests/domain/test_graph_dsl_sanitizer.py -q --confcutdir=tests/domain` — 60 passed, 0 failed.

Note: the issue-suggested `uv run pytest tests/domain/test_graph_dsl_sanitizer.py` could not complete here because `uv sync` timed out while downloading dependencies. I ran the focused test file with the available Python environment and `--confcutdir=tests/domain` to avoid pulling in the root `conftest.py` that imports the full FastAPI app.

Automated tests added or updated:

- `frontend/src/components/GraphSandbox.test.tsx`: added `accepts DSL at the maximum length` (16,384 chars) and changed `rejects DSL that is too long` to `rejects DSL that exceeds the maximum length` (16,385 chars).
- `backend/tests/domain/test_graph_dsl_sanitizer.py`: added `test_allows_dsl_at_maximum_length` and renamed `test_rejects_too_long_dsl` to `test_rejects_dsl_above_maximum_length`.

Manual verification:

- Verified `validateDsl('x'.repeat(16384))` returns `null` and `validateDsl('x'.repeat(16385))` returns `"DSL is too long"`.
- Verified `_is_allowed_graph_dsl(dsl)` returns `True` for a valid 16,384-character DSL and `False` for a DSL above the limit.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
