### PR TITLE
Expand detected bulk-ingestion boxes with image-relative margins

### DIFF
--- a/frontend/src/components/BulkIngestionWizard.test.tsx
+++ b/frontend/src/components/BulkIngestionWizard.test.tsx
@@ -463,7 +463,7 @@ describe("BulkIngestionWizard", () => {
     expect(mocks.uploadBatchImages).toHaveBeenCalledWith("batch-new", [file]);
   });
 
-  it("runs detection for an uploaded image", async () => {
+  it("runs detection, expands boxes, and persists them", async () => {
     mocks.getActiveBatch.mockResolvedValue({
       batch: makeBatch({
         images: [
@@ -488,7 +488,25 @@ describe("BulkIngestionWizard", () => {
             status: "ready",
             order: 0,
             sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            subject: "math",
             boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.saveImageBoxes.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 5, y: 8, width: 30, height: 24 }],
             detection: { model: "model" },
             createdAt: "2026-07-03T00:00:00Z",
             updatedAt: "2026-07-03T00:00:00Z",
@@ -507,6 +525,74 @@ describe("BulkIngestionWizard", () => {
     await waitFor(() => {
       expect(mocks.detectImageBoxes).toHaveBeenCalledWith("batch-1", "img-1");
     });
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledWith(
+        "batch-1",
+        "img-1",
+        [{ boxId: "box-1", x: 5, y: 8, width: 30, height: 24 }],
+        "math",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-commit-img-1")).toBeInTheDocument();
+    });
+  });
+
+  it("retains the detection response when saving expanded boxes fails", async () => {
+    mocks.getActiveBatch.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "uploaded",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            boxes: [],
+            detection: {},
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.detectImageBoxes.mockResolvedValue({
+      batch: makeBatch({
+        images: [
+          {
+            imageId: "img-1",
+            status: "ready",
+            order: 0,
+            sourceImage: { bucket: "b", objectKey: "k", width: 100, height: 100 },
+            subject: "math",
+            boxes: [{ boxId: "box-1", x: 10, y: 10, width: 20, height: 20 }],
+            detection: { model: "model" },
+            createdAt: "2026-07-03T00:00:00Z",
+            updatedAt: "2026-07-03T00:00:00Z",
+          },
+        ],
+      }),
+    });
+    mocks.saveImageBoxes.mockRejectedValue(new Error("Save failed"));
+
+    render(<BulkIngestionWizard />);
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-detect-image-img-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("bulk-detect-run-img-1"));
+
+    await waitFor(() => {
+      expect(mocks.saveImageBoxes).toHaveBeenCalledWith(
+        "batch-1",
+        "img-1",
+        [{ boxId: "box-1", x: 5, y: 8, width: 30, height: 24 }],
+        "math",
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("bulk-wizard-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Save failed")).toBeInTheDocument();
   });
 
   it("commits an image after reviewing boxes", async () => {

--- a/frontend/src/components/BulkIngestionWizard.tsx
+++ b/frontend/src/components/BulkIngestionWizard.tsx
@@ -22,6 +22,7 @@ import type {
   BulkImageBox,
   BulkWizardStep,
 } from "@/types/bulkIngestion";
+import { expandBoxWithMargins } from "@/utils/boxGeometry";
 import { BulkUploadStep } from "./BulkUploadStep";
 import { BulkDetectStep } from "./BulkDetectStep";
 import { BulkReviewStep } from "./BulkReviewStep";
@@ -242,7 +243,38 @@ export function BulkIngestionWizard({
       setError("");
       try {
         const response = await detectImageBoxes(batch.id, imageId);
-        setBatchAndStep(response.batch);
+        const detectedImage = response.batch.images.find(
+          (image) => image.imageId === imageId,
+        );
+        const imageWidth = detectedImage?.sourceImage?.width;
+        const imageHeight = detectedImage?.sourceImage?.height;
+
+        if (
+          detectedImage &&
+          detectedImage.status === "ready" &&
+          detectedImage.boxes.length > 0 &&
+          typeof imageWidth === "number" &&
+          typeof imageHeight === "number"
+        ) {
+          const expandedBoxes = detectedImage.boxes.map((box) =>
+            expandBoxWithMargins(box, imageWidth, imageHeight),
+          );
+          try {
+            const saveResponse = await saveImageBoxes(
+              batch.id,
+              imageId,
+              expandedBoxes,
+              detectedImage.subject,
+            );
+            setBatchAndStep(saveResponse.batch);
+          } catch (saveErr) {
+            // Retain the unexpanded detection response and surface the save error.
+            setBatchAndStep(response.batch);
+            await handleMutationError(saveErr, "Failed to save expanded boxes");
+          }
+        } else {
+          setBatchAndStep(response.batch);
+        }
       } catch (err) {
         await handleMutationError(err, "Failed to detect boxes");
       }

--- a/frontend/src/utils/boxGeometry.test.ts
+++ b/frontend/src/utils/boxGeometry.test.ts
@@ -3,6 +3,7 @@ import type { BulkImageBox } from "@/types/bulkIngestion";
 import {
   clampBox,
   createBox,
+  expandBoxWithMargins,
   naturalBoxToRender,
   naturalPointToRender,
   resetBoxIdCounter,
@@ -69,6 +70,71 @@ describe("boxGeometry", () => {
       y: 40,
       width: 50,
       height: 40,
+    });
+  });
+
+  describe("expandBoxWithMargins", () => {
+    it("expands a centered box by 5% horizontal and 2% vertical margin per side", () => {
+      const box: BulkImageBox = {
+        boxId: "box-1",
+        x: 100,
+        y: 50,
+        width: 100,
+        height: 50,
+      };
+      expect(expandBoxWithMargins(box, 400, 200)).toEqual({
+        boxId: "box-1",
+        x: 80,
+        y: 46,
+        width: 140,
+        height: 58,
+      });
+    });
+
+    it("clamps expansion to image bounds on every side", () => {
+      const box: BulkImageBox = {
+        boxId: "box-edge",
+        x: 4,
+        y: 1,
+        width: 92,
+        height: 49,
+      };
+      expect(expandBoxWithMargins(box, 100, 50)).toEqual({
+        boxId: "box-edge",
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 50,
+      });
+    });
+
+    it("preserves extra box properties", () => {
+      const box: BulkImageBox = {
+        boxId: "box-extra",
+        x: 50,
+        y: 50,
+        width: 20,
+        height: 20,
+        page: 2,
+        label: "problem",
+      };
+      const expanded = expandBoxWithMargins(box, 200, 200);
+      expect(expanded.boxId).toBe("box-extra");
+      expect(expanded.page).toBe(2);
+      expect(expanded.label).toBe("problem");
+    });
+
+    it("returns the same box when image dimensions are missing or invalid", () => {
+      const box: BulkImageBox = {
+        boxId: "box-missing",
+        x: 10,
+        y: 10,
+        width: 20,
+        height: 20,
+      };
+      expect(expandBoxWithMargins(box, 0, 100)).toEqual(box);
+      expect(expandBoxWithMargins(box, 100, 0)).toEqual(box);
+      expect(expandBoxWithMargins(box, -10, 100)).toEqual(box);
     });
   });
 });

--- a/frontend/src/utils/boxGeometry.ts
+++ b/frontend/src/utils/boxGeometry.ts
@@ -42,6 +42,38 @@ export function naturalBoxToRender(
   };
 }
 
+const HORIZONTAL_MARGIN_RATIO = 0.05;
+const VERTICAL_MARGIN_RATIO = 0.02;
+
+export function expandBoxWithMargins(
+  box: BulkImageBox,
+  imageWidth: number,
+  imageHeight: number,
+): BulkImageBox {
+  if (imageWidth <= 0 || imageHeight <= 0) {
+    return box;
+  }
+
+  const horizontalMargin = imageWidth * HORIZONTAL_MARGIN_RATIO;
+  const verticalMargin = imageHeight * VERTICAL_MARGIN_RATIO;
+
+  let x = box.x - horizontalMargin;
+  let y = box.y - verticalMargin;
+  let width = box.width + horizontalMargin * 2;
+  let height = box.height + verticalMargin * 2;
+
+  x = Math.max(0, x);
+  y = Math.max(0, y);
+  if (x + width > imageWidth) {
+    width = imageWidth - x;
+  }
+  if (y + height > imageHeight) {
+    height = imageHeight - y;
+  }
+
+  return { ...box, x, y, width, height };
+}
+
 const MIN_BOX_SIZE = 4;
 
 export function clampBox(


### PR DESCRIPTION
Model-Signature: kimi-k2.7-code

## Summary

Post-process newly detected bulk-ingestion boxes in the frontend by adding a 5% horizontal and 2% vertical source-image margin on every side, clamping to image bounds, and persisting the expanded boxes through the existing `saveImageBoxes` API call before review.

## Linked Issue

Closes #479

## Issue Alignment

This PR implements the issue by:

- Adding a pure `expandBoxWithMargins` helper in `frontend/src/utils/boxGeometry.ts`.
- Expanding boxes by 5% of image width per horizontal side and 2% of image height per vertical side.
- Clamping expanded boxes to source-image bounds and preserving box IDs and other properties.
- Automatically expanding and persisting boxes immediately after a successful `detectImageBoxes` response.
- Using the `saveImageBoxes` response as the next batch state.
- Retaining the unexpanded detection response and surfacing the mutation error if the follow-up save fails.
- Updating tests for the helper and the wizard detection-to-save flow.

Scope covered:

- Frontend box-expansion helper.
- Automatic expansion and persistence after successful detection.
- Unit and component tests for expansion and persistence.

Out of scope / intentionally not included:

- Backend detection prompt, model, API contract, or validation changes.
- Changing raw VLM provider output.
- Expanding manually created, moved, or resized boxes.
- Backfilling or altering boxes in existing batches.
- Overlap detection, merging, or collision avoidance between expanded boxes.

## Implementation Notes

- `expandBoxWithMargins` is intentionally a pure function so it can be tested independently.
- The detection success path finds the detected image in the returned batch, verifies `sourceImage.width` and `sourceImage.height` are available, expands each box, and calls `saveImageBoxes(batch.id, imageId, expandedBoxes, detectedImage.subject)`.
- The follow-up save only happens when detection produced a `"ready"` image with at least one box; this avoids extra API calls and prevents fake-VLM test overrides from being consumed by the save instead of detection.
- If `saveImageBoxes` throws, the wizard reverts to the unexpanded detection batch and calls the existing `handleMutationError`, so the UI does not represent unsaved expanded coordinates as persisted.
- No API contract changes were made; `saveImageBoxes` is reused as-is.

## Tests

Commands run:

- `cd frontend && npm test -- boxGeometry.test.ts BulkIngestionWizard.test.tsx --run` — 46 passed, 0 failed.
- `cd frontend && npm test -- --run` — 531 passed, 0 failed.
- `cd frontend && npm run build` — succeeded (TypeScript compilation and Vite build both passed).

Automated tests added or updated:

- `frontend/src/utils/boxGeometry.test.ts`: added `expandBoxWithMargins` tests for centered expansion, boundary clamping, property preservation, and invalid-dimension handling.
- `frontend/src/components/BulkIngestionWizard.test.tsx`: renamed `runs detection for an uploaded image` to `runs detection, expands boxes, and persists them` and added assertions that `saveImageBoxes` receives the expanded payload and the save response drives the UI. Added `retains the detection response when saving expanded boxes fails` to verify the error path.

Manual verification:

- Verified `expandBoxWithMargins({ boxId: "b", x: 10, y: 10, width: 20, height: 20 }, 100, 100)` produces `{ boxId: "b", x: 5, y: 8, width: 30, height: 24 }`.
- Verified `expandBoxWithMargins({ boxId: "b", x: 4, y: 1, width: 92, height: 49 }, 100, 50)` clamps to `{ boxId: "b", x: 0, y: 0, width: 100, height: 50 }`.
- Verified `expandBoxWithMargins(box, 0, 100)` and `expandBoxWithMargins(box, -10, 100)` return the original box unchanged.
- Did not perform live browser/manual overlay verification because the local Playwright/E2E environment was not running; unit, component, and CI E2E tests cover the behavior.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
