### PR TITLE
fix: wrap OpenAI Responses API input in role-wrapped user messages and pass text.format

### DIFF
--- a/backend/app/infrastructure/vlm/base_client.py
+++ b/backend/app/infrastructure/vlm/base_client.py
@@ -116,6 +116,7 @@ class BaseVLMClient:
                 model=self._effective_model,
                 instructions=payload.get("instructions"),
                 input=payload.get("input"),
+                text=payload.get("text"),
                 api_base=self._endpoint,
                 api_key=self._api_key,
                 timeout=self._timeout_seconds,

--- a/backend/app/infrastructure/vlm/client.py
+++ b/backend/app/infrastructure/vlm/client.py
@@ -485,7 +485,7 @@ class VLMClient(BaseVLMClient):
 
         return {
             "instructions": request.prompt,
-            "input": input_items,
+            "input": [{"role": "user", "content": input_items}],
             "text": {
                 "format": {
                     "type": "json_object",

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -347,7 +347,7 @@ class SolutionVLMClient(_BaseSolutionCoachingVLMClient):
 
         return {
             "instructions": instructions,
-            "input": input_items,
+            "input": [{"role": "user", "content": input_items}],
             "text": {
                 "format": {
                     "type": "json_object",
@@ -608,7 +608,12 @@ class CoachingVLMClient(_BaseSolutionCoachingVLMClient):
         if self._api_mode == "responses":
             payload = {
                 "instructions": system_prompt,
-                "input": [{"type": "input_text", "text": user_prompt}],
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": user_prompt}],
+                    }
+                ],
                 "text": {"format": {"type": "json_object"}},
             }
             raw_provider_response = await self._send_responses_request(payload)

--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -113,6 +113,7 @@ async def test_coaching_vlm_client_selects_english_settings_and_prompt() -> None
         english_coaching_vlm_model="english-model",
         english_coaching_vlm_api_key="english-key",
         english_coaching_vlm_timeout_seconds=88,
+        english_coaching_vlm_api_mode="responses",
     )
     client = CoachingVLMClient(
         settings=settings, subject="english", responses_fn=responses_fn

--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -99,11 +99,14 @@ def test_solution_vlm_client_selects_english_settings_and_prompt() -> None:
 
 @pytest.mark.asyncio
 async def test_coaching_vlm_client_selects_english_settings_and_prompt() -> None:
-    async def completion_fn(**kwargs):
+    async def responses_fn(**kwargs):
         assert kwargs["model"] == "openai/english-model"
-        assert kwargs["messages"][0]["role"] == "system"
-        assert "English" in kwargs["messages"][0]["content"]
-        return _mock_response(json.dumps({"text": "hi"}))
+        assert "instructions" in kwargs
+        assert kwargs["input"][0]["role"] == "user"
+        assert kwargs["input"][0]["content"][0]["type"] == "input_text"
+        assert "English" in kwargs["instructions"]
+        assert kwargs["text"] == {"format": {"type": "json_object"}}
+        return _mock_responses_response(json.dumps({"text": "hi"}))
 
     settings = Settings(
         english_coaching_vlm_endpoint="https://english-coaching.example/api",
@@ -111,13 +114,16 @@ async def test_coaching_vlm_client_selects_english_settings_and_prompt() -> None
         english_coaching_vlm_api_key="english-key",
         english_coaching_vlm_timeout_seconds=88,
     )
-    client = CoachingVLMClient(settings=settings, subject="english", completion_fn=completion_fn)
+    client = CoachingVLMClient(
+        settings=settings, subject="english", responses_fn=responses_fn
+    )
 
     assert client._endpoint == "https://english-coaching.example/api"
     assert client._model == "english-model"
     assert client._api_key == "english-key"
     assert client._timeout_seconds == 88
     assert client._subject == "english"
+    assert client._api_mode == "responses"
 
     result = await client.send_message(
         CoachingVLMRequest(
@@ -691,7 +697,9 @@ async def test_solution_vlm_client_responses_mode_happy_path() -> None:
         # Verify Responses API structure
         assert "instructions" in kwargs
         assert "input" in kwargs
-        assert kwargs["input"][0]["type"] == "input_text"
+        assert kwargs["input"][0]["role"] == "user"
+        assert kwargs["input"][0]["content"][0]["type"] == "input_text"
+        assert kwargs["text"] == {"format": {"type": "json_object"}}
         
         return _mock_responses_response(
             json.dumps({
@@ -734,6 +742,9 @@ async def test_coaching_vlm_client_responses_mode_happy_path() -> None:
         # Verify Responses API structure
         assert "instructions" in kwargs
         assert "input" in kwargs
+        assert kwargs["input"][0]["role"] == "user"
+        assert kwargs["input"][0]["content"][0]["type"] == "input_text"
+        assert kwargs["text"] == {"format": {"type": "json_object"}}
         
         return _mock_responses_response(
             json.dumps({

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -970,9 +970,12 @@ async def test_vlm_responses_mode_extraction_happy_path() -> None:
         # Verify Responses API structure
         assert "instructions" in kwargs
         assert "input" in kwargs
-        assert kwargs["input"][0]["type"] == "input_text"
-        assert kwargs["input"][1]["type"] == "input_image"
-        assert "image_url" in kwargs["input"][1]
+        assert kwargs["input"][0]["role"] == "user"
+        content = kwargs["input"][0]["content"]
+        assert content[0]["type"] == "input_text"
+        assert content[1]["type"] == "input_image"
+        assert "image_url" in content[1]
+        assert kwargs["text"] == {"format": {"type": "json_object"}}
         
         return _mock_responses_response(
             json.dumps(
@@ -1002,9 +1005,9 @@ async def test_vlm_responses_mode_extraction_happy_path() -> None:
 async def test_vlm_responses_mode_with_base64_image() -> None:
     """Responses mode with base64 image should use input_image with data URL."""
     async def responses_fn(**kwargs):
-        input_items = kwargs["input"]
-        assert input_items[1]["type"] == "input_image"
-        assert input_items[1]["image_url"].startswith("data:image/png;base64,")
+        content = kwargs["input"][0]["content"]
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
         
         return _mock_responses_response(
             json.dumps(


### PR DESCRIPTION
Wraps the OpenAI Responses API request payload correctly: wraps input items under a role-wrapped user message, passes text.format.json_object through _send_responses_request, updates solution/coaching clients and tests, and fixes the english coaching settings test to mock responses_fn since the default api mode is responses.