### PR TITLE
fix(coaching): include 'json' in English coaching user prompt for Responses API

### DIFF
--- a/backend/app/infrastructure/vlm/solution_coaching_prompts.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_prompts.py
@@ -170,4 +170,4 @@ def build_coaching_user_prompt(
         "conversationHistory": conversation_history,
         "studentNewMessage": new_message,
     }
-    return "Tutor the student using the following task data:\n" f"{json.dumps(data, ensure_ascii=False)}"
+    return "Tutor the student and return valid JSON using the following task data:\n" f"{json.dumps(data, ensure_ascii=False)}"


### PR DESCRIPTION
## Problem\n\nAsking a question to the English coaching tutor returned the error:\n\n> Coaching service is currently unavailable. Please try again later.\n\nBackend logs showed the VLM provider was rejecting the request with HTTP 400:\n\n> Response input messages must contain the word 'json' in some form to use 'text.format' of type 'json_object'.\n\nThe English coaching VLM is configured to use the OpenAI Responses API (`ENGLISH_COACHING_VLM_API_MODE=responses`). That provider requires every user input message to include the word **json** whenever `text.format.type=json_object` is requested. The previous prompt, "Tutor the student using the following task data:", did not contain that word.\n\n## Change\n\nUpdate `build_coaching_user_prompt` in `backend/app/infrastructure/vlm/solution_coaching_prompts.py` to read:\n\n> Tutor the student and return valid JSON using the following task data:\n\nThis satisfies the provider's input-content check without changing the prompt structure or the expected response schema.\n\n## Verification\n\n- Rebuilt the `learnloop-app` Docker image and restarted the container.\n- Tested both English and math coaching VLM clients; both return successful responses.\n- Confirmed frontend and backend health endpoints are `ok`.\n\nFixes the coaching failure at http://127.0.0.1:8080/coaching/6a45da558caec8a1a3423cee for user Torran_English.