### PR TITLE
fix(solution): include JSON instruction for Responses API mode

### DIFF
--- a/backend/app/infrastructure/vlm/solution_coaching_prompts.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_prompts.py
@@ -42,7 +42,7 @@ def build_solution_user_prompt(*, problem_text: str, correct_answer: str, graph_
         "answerKey": correct_answer,
         "graphDsl": graph_section,
     }
-    return "Solve the problem using the following task data:\n" f"{json.dumps(data, ensure_ascii=False)}"
+    return "Solve the problem and return valid JSON using the following task data:\n" f"{json.dumps(data, ensure_ascii=False)}"
 
 
 MATH_COACHING_SYSTEM_PROMPT = """You are a Chinese primary-school / middle-school math tutor.

--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -701,6 +701,8 @@ async def test_solution_vlm_client_responses_mode_happy_path() -> None:
         assert kwargs["input"][0]["role"] == "user"
         assert kwargs["input"][0]["content"][0]["type"] == "input_text"
         assert kwargs["text"] == {"format": {"type": "json_object"}}
+        input_text = kwargs["input"][0]["content"][0]["text"]
+        assert "json" in input_text.lower()
         
         return _mock_responses_response(
             json.dumps({


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Update `build_solution_user_prompt()` to explicitly request valid JSON in the user input, mirroring the coaching fix in PR #485.
- Add a regression assertion in the Responses-mode happy-path test verifying the user input contains "json" (case-insensitive).

## Linked Issue

Closes #486

## Issue Alignment

This PR implements the issue by:

- Updating the shared solution user prompt prefix from "Solve the problem using the following task data:" to "Solve the problem and return valid JSON using the following task data:" so the user `input` content contains the word `json`.
- Extending `test_solution_vlm_client_responses_mode_happy_path` to inspect `kwargs["input"][0]["content"][0]["text"]` and assert it contains `json` case-insensitively, while retaining the existing `text.format.type = json_object` assertion.

Scope covered:

- Solution user prompt prefix change.
- Responses-mode regression test assertion.

Out of scope / intentionally not included:

- Coaching prompt or test changes (PR #485 owns the coaching fix).
- VLM client abstraction refactoring.
- JSON Schema / Structured Outputs replacement.
- Solution output field, parsing, or retry policy changes.

## Implementation Notes

The fix is identical in shape to PR #485's coaching fix: a one-word addition to the user prompt prefix so that OpenAI-compatible providers requiring the word `json` in user input when `text.format.type = json_object` no longer reject the request with HTTP 400. The system `instructions` already request JSON output, but the observed provider validation checks the user `input` content.

## Tests

Commands run:

- `docker exec -w /app learnloop-app /app/.venv/bin/python -m pytest tests/infrastructure/test_solution_coaching_client.py` — passed (43 passed in 0.19s)

Automated tests added or updated:

- `test_solution_vlm_client_responses_mode_happy_path` — added assertion that `kwargs["input"][0]["content"][0]["text"]` contains `json` (case-insensitive).

Manual verification:

- Verified the regression assertion fails with the old prompt: the old prefix "Solve the problem using the following task data:" does not contain "json", so `"json" in input_text.lower()` would be `False`.
- Verified the new prefix "Solve the problem and return valid JSON using the following task data:" contains "json", so the assertion passes.
- All 43 tests in the focused test file pass with the change.
- No unrelated prompt or VLM configuration changes included.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.