### PR TITLE
feat(exam): async exam submission with durable VLM grading progress

### DIFF
--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -19,6 +19,7 @@ class ProblemSubject(str, Enum):
 
 class ExamState(str, Enum):
     IN_PROGRESS = "in-progress"
+    GRADING = "grading"
     SUBMITTED = "submitted"
     DISCARDED = "discarded"
 

--- a/backend/app/domain/state.py
+++ b/backend/app/domain/state.py
@@ -83,7 +83,8 @@ def transition_preview_state(
 
 # Exam State Transitions
 EXAM_TRANSITIONS = {
-    ExamState.IN_PROGRESS: [ExamState.SUBMITTED, ExamState.DISCARDED],
+    ExamState.IN_PROGRESS: [ExamState.GRADING, ExamState.SUBMITTED, ExamState.DISCARDED],
+    ExamState.GRADING: [ExamState.SUBMITTED, ExamState.DISCARDED],
     ExamState.SUBMITTED: [],
     ExamState.DISCARDED: [],
 }

--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -93,6 +93,12 @@ class Settings(BaseSettings):
     solution_task_timeout_minutes: int = Field(default=10, gt=0)
     solution_max_retries: int = Field(default=3, ge=0)
 
+    # Exam grading worker configuration
+    exam_grading_worker_enabled: bool = Field(default=True)
+    exam_grading_worker_poll_interval_seconds: float = Field(default=2.0, gt=0)
+    exam_grading_lease_seconds: float = Field(default=60.0, gt=0)
+    exam_grading_lease_refresh_seconds: float = Field(default=20.0, gt=0)
+
     session_cookie_name: str = Field(default="ll_session")
     session_secure: bool = Field(default=False)
     session_samesite: Literal["lax", "strict", "none"] = Field(default="lax")

--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -17,6 +17,7 @@ SOLUTION_GENERATION_TASKS_COLLECTION = "solution_generation_tasks"
 CANONICAL_SOLUTIONS_COLLECTION = "canonical_solutions"
 COACHING_CONVERSATIONS_COLLECTION = "coaching_conversations"
 FOLDERS_COLLECTION = "folders"
+EXAM_GRADING_TASKS_COLLECTION = "exam_grading_tasks"
 
 
 def _safe_get_collection(database: Any, name: str) -> Any | None:
@@ -107,9 +108,18 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
         COACHING_CONVERSATIONS_COLLECTION,
         FOLDERS_COLLECTION,
         INGESTION_BATCHES_COLLECTION,
+        EXAM_GRADING_TASKS_COLLECTION,
     ):
         if collection_name not in existing_collections and hasattr(database, "create_collection"):
             await database.create_collection(collection_name)
+
+    create_exam_grading_task_index = getattr(database[EXAM_GRADING_TASKS_COLLECTION], "create_index", None)
+    if callable(create_exam_grading_task_index):
+        await create_exam_grading_task_index(
+            [("examId", ASCENDING)],
+            unique=True,
+            name="exam_grading_task_exam_unique",
+        )
 
     create_index = getattr(database[TAGS_COLLECTION], "create_index", None)
     if callable(create_index):

--- a/backend/app/infrastructure/worker/exam_grading_worker.py
+++ b/backend/app/infrastructure/worker/exam_grading_worker.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from bson import ObjectId
+
+from app.domain.models import ExamState, GradingStatus, ProblemType
+from app.domain.state import transition_exam_state
+from app.infrastructure.config.settings import Settings, get_settings
+from app.infrastructure.storage.mongo import EXAM_GRADING_TASKS_COLLECTION, _safe_get_collection
+from app.infrastructure.storage.s3 import S3StorageAdapter
+from app.infrastructure.vlm.client import VLMClient
+from app.presentation.exam_grading import build_tracking_update, grade_item
+from app.presentation.exam_helpers import TERMINAL_GRADING_STATUSES, build_exam_summary
+
+logger = logging.getLogger(__name__)
+
+TASK_PENDING = "pending"
+TASK_PROCESSING = "processing"
+TASK_COMPLETED = "completed"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+async def _claim_task(
+    tasks_col: Any,
+    *,
+    now: datetime,
+    lease_seconds: float,
+) -> dict[str, Any] | None:
+    """Atomically claim one pending or stale-leased task with an ownership token."""
+    claim_token = secrets.token_hex(16)
+    lease_until = now + timedelta(seconds=lease_seconds)
+
+    # First try to claim a pending task.
+    claimed = await tasks_col.find_one_and_update(
+        {"status": TASK_PENDING},
+        {
+            "$set": {
+                "status": TASK_PROCESSING,
+                "claimToken": claim_token,
+                "leaseUntil": lease_until,
+                "updatedAt": now,
+            }
+        },
+        sort=[("createdAt", 1)],
+        return_document=None,
+    )
+    if claimed is not None:
+        claimed["status"] = TASK_PROCESSING
+        claimed["claimToken"] = claim_token
+        claimed["leaseUntil"] = lease_until
+        return claimed
+
+    # Then reclaim a processing task whose lease has expired.
+    claimed = await tasks_col.find_one_and_update(
+        {
+            "status": TASK_PROCESSING,
+            "leaseUntil": {"$lte": now},
+        },
+        {
+            "$set": {
+                "claimToken": claim_token,
+                "leaseUntil": lease_until,
+                "updatedAt": now,
+            }
+        },
+        sort=[("createdAt", 1)],
+        return_document=None,
+    )
+    if claimed is not None:
+        claimed["status"] = TASK_PROCESSING
+        claimed["claimToken"] = claim_token
+        claimed["leaseUntil"] = lease_until
+        return claimed
+
+    return None
+
+
+async def _verify_ownership(
+    tasks_col: Any,
+    task_id: ObjectId,
+    claim_token: str,
+) -> bool:
+    task = await tasks_col.find_one({"_id": task_id})
+    if task is None:
+        return False
+    return task.get("status") == TASK_PROCESSING and task.get("claimToken") == claim_token
+
+
+async def _refresh_lease(
+    tasks_col: Any,
+    task_id: ObjectId,
+    claim_token: str,
+    *,
+    now: datetime,
+    lease_seconds: float,
+) -> bool:
+    """Refresh the lease on a task we still own."""
+    lease_until = now + timedelta(seconds=lease_seconds)
+    result = await tasks_col.update_one(
+        {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
+        {"$set": {"leaseUntil": lease_until, "updatedAt": now}},
+    )
+    return result.modified_count == 1
+
+
+async def _release_task(
+    tasks_col: Any,
+    task_id: ObjectId,
+    claim_token: str,
+    *,
+    now: datetime,
+) -> None:
+    """Release ownership so another worker can reclaim the task."""
+    await tasks_col.update_one(
+        {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
+        {
+            "$set": {
+                "status": TASK_PENDING,
+                "claimToken": None,
+                "leaseUntil": None,
+                "updatedAt": now,
+            }
+        },
+    )
+
+
+async def _persist_item_result(
+    database: Any,
+    exam_id: ObjectId,
+    item_id: str,
+    grading: dict[str, Any],
+    *,
+    now: datetime,
+) -> dict[str, Any] | None:
+    """Atomically update one item's grading and the recomputed partial summary.
+
+    Uses targeted positional updates so a stale full-items array is never written
+    over newer state.
+    """
+    exams_col = _safe_get_collection(database, "exams")
+    if exams_col is None:
+        return None
+
+    fresh_exam = await exams_col.find_one({"_id": exam_id})
+    if fresh_exam is None:
+        return None
+    if fresh_exam.get("state") != ExamState.GRADING.value:
+        return None
+
+    fresh_items = list(fresh_exam.get("items", []))
+    target_index = None
+    for index, item in enumerate(fresh_items):
+        if str(item.get("itemId")) == item_id:
+            target_index = index
+            break
+    if target_index is None:
+        return None
+
+    updated_items = deepcopy(fresh_items)
+    updated_items[target_index]["grading"] = grading
+    new_summary = build_exam_summary(updated_items)
+
+    result = await exams_col.update_one(
+        {"_id": exam_id, "items.itemId": item_id, "state": ExamState.GRADING.value},
+        {
+            "$set": {
+                "items.$.grading": grading,
+                "summary": new_summary,
+                "updatedAt": now,
+            }
+        },
+    )
+    if result.modified_count == 0:
+        return None
+    return new_summary
+
+
+async def _finalize_exam(
+    database: Any,
+    exam_id: ObjectId,
+    user_id: ObjectId,
+    task_id: ObjectId,
+    claim_token: str,
+    tasks_col: Any,
+    *,
+    now: datetime,
+) -> bool:
+    """Transition the exam to submitted and mark the task completed, exactly once."""
+    exams_col = _safe_get_collection(database, "exams")
+    problems_col = _safe_get_collection(database, "problems")
+    if exams_col is None or problems_col is None:
+        return False
+
+    fresh_exam = await exams_col.find_one({"_id": exam_id})
+    if fresh_exam is None:
+        return False
+    if fresh_exam.get("state") == ExamState.SUBMITTED.value:
+        # Already finalized (e.g. after restart). Mark the task completed if we own it.
+        await tasks_col.update_one(
+            {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
+            {"$set": {"status": TASK_COMPLETED, "updatedAt": now}},
+        )
+        return True
+    if fresh_exam.get("state") != ExamState.GRADING.value:
+        return False
+
+    items = list(fresh_exam.get("items", []))
+    all_terminal = all(
+        str(dict(item.get("grading", {})).get("status", GradingStatus.UNGRADED.value))
+        in TERMINAL_GRADING_STATUSES
+        for item in items
+    )
+    if not all_terminal:
+        return False
+
+    summary = build_exam_summary(items)
+    submitted_at = now
+    next_state = transition_exam_state(ExamState.GRADING, ExamState.SUBMITTED)
+
+    # Transition the exam to submitted.
+    result = await exams_col.update_one(
+        {"_id": exam_id, "state": ExamState.GRADING.value},
+        {
+            "$set": {
+                "state": next_state.value,
+                "summary": summary,
+                "submittedAt": submitted_at,
+                "updatedAt": submitted_at,
+            }
+        },
+    )
+    if result.modified_count == 0:
+        # Another worker finalized first.
+        return False
+
+    # Apply problem-tracking updates exactly once for non-pending-review items.
+    for item in items:
+        grading = dict(item.get("grading", {}))
+        if grading.get("status") == GradingStatus.PENDING_REVIEW.value:
+            continue
+        is_correct = bool(grading.get("isCorrect"))
+        problem = await problems_col.find_one(
+            {"_id": item["problemId"], "userId": user_id}
+        )
+        if problem is None:
+            continue
+        tracking_update = build_tracking_update(
+            dict(problem.get("tracking", {})),
+            now=submitted_at,
+            is_correct=is_correct,
+        )
+        await problems_col.update_one(
+            {"_id": problem["_id"]},
+            {"$set": {"tracking": tracking_update, "updatedAt": submitted_at}},
+        )
+
+    # Mark the task completed.
+    await tasks_col.update_one(
+        {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
+        {"$set": {"status": TASK_COMPLETED, "updatedAt": now}},
+    )
+    return True
+
+
+async def process_exam_grading_task(
+    task: dict[str, Any],
+    database: Any,
+    vlm_client: VLMClient,
+    storage: S3StorageAdapter,
+    settings: Settings,
+    tasks_col: Any,
+) -> None:
+    """Grade all non-terminal items of one exam sequentially, then finalize."""
+    task_id = task["_id"]
+    exam_id = task["examId"]
+    user_id = task["userId"]
+    claim_token = task["claimToken"]
+    lease_seconds = settings.exam_grading_lease_seconds
+    refresh_interval = settings.exam_grading_lease_refresh_seconds
+
+    exams_col = _safe_get_collection(database, "exams")
+    if exams_col is None:
+        return
+
+    # Refresh the lease in the background while grading runs.
+    stop_refresh = asyncio.Event()
+
+    async def _lease_refresher() -> None:
+        while not stop_refresh.is_set():
+            try:
+                await asyncio.wait_for(stop_refresh.wait(), timeout=refresh_interval)
+                break
+            except asyncio.TimeoutError:
+                pass
+            still_owner = await _refresh_lease(
+                tasks_col, task_id, claim_token,
+                now=_utc_now(), lease_seconds=lease_seconds,
+            )
+            if not still_owner:
+                logger.warning(
+                    "Lost ownership of exam grading task %s during lease refresh", task_id
+                )
+                return
+
+    refresher = asyncio.create_task(_lease_refresher())
+
+    try:
+        while True:
+            if not await _verify_ownership(tasks_col, task_id, claim_token):
+                logger.warning("Lost ownership of exam grading task %s", task_id)
+                return
+
+            fresh_exam = await exams_col.find_one({"_id": exam_id})
+            if fresh_exam is None:
+                return
+            if fresh_exam.get("state") == ExamState.SUBMITTED.value:
+                # Already finalized (e.g. after a prior run). Ensure task is completed.
+                await tasks_col.update_one(
+                    {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
+                    {"$set": {"status": TASK_COMPLETED, "updatedAt": _utc_now()}},
+                )
+                return
+            if fresh_exam.get("state") != ExamState.GRADING.value:
+                return
+
+            items = list(fresh_exam.get("items", []))
+            next_item: dict[str, Any] | None = None
+            for item in items:
+                status = str(dict(item.get("grading", {})).get("status", GradingStatus.UNGRADED.value))
+                if status not in TERMINAL_GRADING_STATUSES:
+                    next_item = item
+                    break
+
+            if next_item is None:
+                # All items terminal: finalize.
+                finalized = await _finalize_exam(
+                    database, exam_id, user_id, task_id, claim_token, tasks_col,
+                    now=_utc_now(),
+                )
+                if not finalized:
+                    logger.warning("Could not finalize exam %s for task %s", exam_id, task_id)
+                return
+
+            # Grade one item. Per-item failures become pending-review and do not stop others.
+            try:
+                graded = await grade_item(
+                    next_item,
+                    vlm_client=vlm_client,
+                    storage=storage,
+                    now=_utc_now(),
+                )
+                grading = dict(graded.get("grading", {}))
+            except Exception as exc:
+                logger.exception(
+                    "Unexpected error grading exam item %s for exam %s",
+                    next_item.get("itemId"), exam_id,
+                )
+                grading = {
+                    "status": GradingStatus.PENDING_REVIEW.value,
+                    "method": "vlm",
+                    "isCorrect": None,
+                    "score": None,
+                    "feedback": str(exc),
+                    "providerModel": None,
+                    "rawProviderResponse": None,
+                    "gradedAt": _utc_now(),
+                    "retryCount": 0,
+                    "selfReportedCorrect": None,
+                }
+
+            # Verify ownership before persisting so a stale worker cannot write.
+            if not await _verify_ownership(tasks_col, task_id, claim_token):
+                logger.warning("Lost ownership before persisting item result for task %s", task_id)
+                return
+
+            item_id = str(next_item.get("itemId"))
+            await _persist_item_result(
+                database, exam_id, item_id, grading, now=_utc_now()
+            )
+    finally:
+        stop_refresh.set()
+        try:
+            await asyncio.wait_for(refresher, timeout=5.0)
+        except asyncio.TimeoutError:
+            refresher.cancel()
+            try:
+                await refresher
+            except asyncio.CancelledError:
+                pass
+
+
+async def run_exam_grading_worker(
+    database: Any,
+    storage: S3StorageAdapter,
+    settings: Settings,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Poll for exam grading tasks and process them sequentially."""
+    if not settings.exam_grading_worker_enabled:
+        return
+
+    tasks_col = _safe_get_collection(database, EXAM_GRADING_TASKS_COLLECTION)
+    if tasks_col is None:
+        logger.error("Exam grading tasks collection missing")
+        return
+
+    poll_interval = settings.exam_grading_worker_poll_interval_seconds
+    lease_seconds = settings.exam_grading_lease_seconds
+
+    logger.info("Exam grading worker started")
+
+    while True:
+        if stop_event and stop_event.is_set():
+            break
+
+        now = _utc_now()
+        task = await _claim_task(tasks_col, now=now, lease_seconds=lease_seconds)
+        if task is None:
+            if stop_event:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
+                except asyncio.TimeoutError:
+                    continue
+                break
+            await asyncio.sleep(poll_interval)
+            continue
+
+        # Build a grading VLM client for this task's exam.
+        vlm_client = VLMClient(
+            endpoint=settings.grading_vlm_endpoint,
+            model=settings.grading_vlm_model,
+            api_key=settings.grading_vlm_api_key,
+            timeout_seconds=settings.grading_vlm_timeout_seconds,
+            provider=settings.grading_vlm_provider,
+            api_mode=settings.grading_vlm_api_mode,
+        )
+        try:
+            await process_exam_grading_task(
+                task, database, vlm_client, storage, settings, tasks_col
+            )
+        except Exception:
+            logger.exception("Exam grading task %s failed; releasing for retry", task.get("_id"))
+            await _release_task(tasks_col, task["_id"], task["claimToken"], now=_utc_now())
+        finally:
+            await vlm_client.aclose()

--- a/backend/app/infrastructure/worker/exam_grading_worker.py
+++ b/backend/app/infrastructure/worker/exam_grading_worker.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from bson import ObjectId
+from pymongo import ReturnDocument
 
 from app.domain.models import ExamState, GradingStatus, ProblemType
 from app.domain.state import transition_exam_state
@@ -51,12 +52,9 @@ async def _claim_task(
             }
         },
         sort=[("createdAt", 1)],
-        return_document=None,
+        return_document=ReturnDocument.AFTER,
     )
     if claimed is not None:
-        claimed["status"] = TASK_PROCESSING
-        claimed["claimToken"] = claim_token
-        claimed["leaseUntil"] = lease_until
         return claimed
 
     # Then reclaim a processing task whose lease has expired.
@@ -73,15 +71,9 @@ async def _claim_task(
             }
         },
         sort=[("createdAt", 1)],
-        return_document=None,
+        return_document=ReturnDocument.AFTER,
     )
-    if claimed is not None:
-        claimed["status"] = TASK_PROCESSING
-        claimed["claimToken"] = claim_token
-        claimed["leaseUntil"] = lease_until
-        return claimed
-
-    return None
+    return claimed
 
 
 async def _verify_ownership(
@@ -193,82 +185,99 @@ async def _finalize_exam(
     tasks_col: Any,
     *,
     now: datetime,
+    adapter: Any | None = None,
 ) -> bool:
-    """Transition the exam to submitted and mark the task completed, exactly once."""
+    """Transition the exam to submitted and mark the task completed, exactly once.
+
+    The exam state transition, problem-tracking updates, and task completion are
+    committed in a single MongoDB transaction when an adapter is available,
+    matching the issue's finalization contract.
+    """
     exams_col = _safe_get_collection(database, "exams")
     problems_col = _safe_get_collection(database, "problems")
     if exams_col is None or problems_col is None:
         return False
 
-    fresh_exam = await exams_col.find_one({"_id": exam_id})
-    if fresh_exam is None:
-        return False
-    if fresh_exam.get("state") == ExamState.SUBMITTED.value:
-        # Already finalized (e.g. after restart). Mark the task completed if we own it.
+    async def _finalize(session: Any) -> bool:
+        fresh_exam = await exams_col.find_one({"_id": exam_id}, session=session)
+        if fresh_exam is None:
+            return False
+        if fresh_exam.get("state") == ExamState.SUBMITTED.value:
+            # Already finalized (e.g. after restart). Mark the task completed if we own it.
+            await tasks_col.update_one(
+                {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
+                {"$set": {"status": TASK_COMPLETED, "updatedAt": now}},
+                session=session,
+            )
+            return True
+        if fresh_exam.get("state") != ExamState.GRADING.value:
+            return False
+
+        items = list(fresh_exam.get("items", []))
+        all_terminal = all(
+            str(dict(item.get("grading", {})).get("status", GradingStatus.UNGRADED.value))
+            in TERMINAL_GRADING_STATUSES
+            for item in items
+        )
+        if not all_terminal:
+            return False
+
+        summary = build_exam_summary(items)
+        submitted_at = now
+        next_state = transition_exam_state(ExamState.GRADING, ExamState.SUBMITTED)
+
+        # Transition the exam to submitted.
+        result = await exams_col.update_one(
+            {"_id": exam_id, "state": ExamState.GRADING.value},
+            {
+                "$set": {
+                    "state": next_state.value,
+                    "summary": summary,
+                    "submittedAt": submitted_at,
+                    "updatedAt": submitted_at,
+                }
+            },
+            session=session,
+        )
+        if result.modified_count == 0:
+            # Another worker finalized first.
+            return False
+
+        # Apply problem-tracking updates exactly once for non-pending-review items.
+        for item in items:
+            grading = dict(item.get("grading", {}))
+            if grading.get("status") == GradingStatus.PENDING_REVIEW.value:
+                continue
+            is_correct = bool(grading.get("isCorrect"))
+            problem = await problems_col.find_one(
+                {"_id": item["problemId"], "userId": user_id},
+                session=session,
+            )
+            if problem is None:
+                continue
+            tracking_update = build_tracking_update(
+                dict(problem.get("tracking", {})),
+                now=submitted_at,
+                is_correct=is_correct,
+            )
+            await problems_col.update_one(
+                {"_id": problem["_id"]},
+                {"$set": {"tracking": tracking_update, "updatedAt": submitted_at}},
+                session=session,
+            )
+
+        # Mark the task completed in the same transaction.
         await tasks_col.update_one(
             {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
             {"$set": {"status": TASK_COMPLETED, "updatedAt": now}},
+            session=session,
         )
         return True
-    if fresh_exam.get("state") != ExamState.GRADING.value:
-        return False
 
-    items = list(fresh_exam.get("items", []))
-    all_terminal = all(
-        str(dict(item.get("grading", {})).get("status", GradingStatus.UNGRADED.value))
-        in TERMINAL_GRADING_STATUSES
-        for item in items
-    )
-    if not all_terminal:
-        return False
-
-    summary = build_exam_summary(items)
-    submitted_at = now
-    next_state = transition_exam_state(ExamState.GRADING, ExamState.SUBMITTED)
-
-    # Transition the exam to submitted.
-    result = await exams_col.update_one(
-        {"_id": exam_id, "state": ExamState.GRADING.value},
-        {
-            "$set": {
-                "state": next_state.value,
-                "summary": summary,
-                "submittedAt": submitted_at,
-                "updatedAt": submitted_at,
-            }
-        },
-    )
-    if result.modified_count == 0:
-        # Another worker finalized first.
-        return False
-
-    # Apply problem-tracking updates exactly once for non-pending-review items.
-    for item in items:
-        grading = dict(item.get("grading", {}))
-        if grading.get("status") == GradingStatus.PENDING_REVIEW.value:
-            continue
-        is_correct = bool(grading.get("isCorrect"))
-        problem = await problems_col.find_one(
-            {"_id": item["problemId"], "userId": user_id}
-        )
-        if problem is None:
-            continue
-        tracking_update = build_tracking_update(
-            dict(problem.get("tracking", {})),
-            now=submitted_at,
-            is_correct=is_correct,
-        )
-        await problems_col.update_one(
-            {"_id": problem["_id"]},
-            {"$set": {"tracking": tracking_update, "updatedAt": submitted_at}},
-        )
-
-    # Mark the task completed.
-    await tasks_col.update_one(
-        {"_id": task_id, "status": TASK_PROCESSING, "claimToken": claim_token},
-        {"$set": {"status": TASK_COMPLETED, "updatedAt": now}},
-    )
-    return True
+    if adapter is not None:
+        async with adapter.start_session() as session:
+            return await session.with_transaction(_finalize)
+    return await _finalize(None)
 
 
 async def process_exam_grading_task(
@@ -278,6 +287,8 @@ async def process_exam_grading_task(
     storage: S3StorageAdapter,
     settings: Settings,
     tasks_col: Any,
+    *,
+    adapter: Any | None = None,
 ) -> None:
     """Grade all non-terminal items of one exam sequentially, then finalize."""
     task_id = task["_id"]
@@ -344,7 +355,7 @@ async def process_exam_grading_task(
                 # All items terminal: finalize.
                 finalized = await _finalize_exam(
                     database, exam_id, user_id, task_id, claim_token, tasks_col,
-                    now=_utc_now(),
+                    now=_utc_now(), adapter=adapter,
                 )
                 if not finalized:
                     logger.warning("Could not finalize exam %s for task %s", exam_id, task_id)
@@ -403,6 +414,8 @@ async def run_exam_grading_worker(
     storage: S3StorageAdapter,
     settings: Settings,
     stop_event: asyncio.Event | None = None,
+    *,
+    adapter: Any | None = None,
 ) -> None:
     """Poll for exam grading tasks and process them sequentially."""
     if not settings.exam_grading_worker_enabled:
@@ -445,7 +458,8 @@ async def run_exam_grading_worker(
         )
         try:
             await process_exam_grading_task(
-                task, database, vlm_client, storage, settings, tasks_col
+                task, database, vlm_client, storage, settings, tasks_col,
+                adapter=adapter,
             )
         except Exception:
             logger.exception("Exam grading task %s failed; releasing for retry", task.get("_id"))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from fastapi.exceptions import RequestValidationError
 from starlette.types import ExceptionHandler
 
 from app.infrastructure.config.settings import get_settings
-from app.infrastructure.storage.mongo import ensure_database_setup, get_database
+from app.infrastructure.storage.mongo import ensure_database_setup, get_database, get_mongo_adapter
 from app.infrastructure.storage.s3 import S3StorageAdapter
 from app.observability import configure_logging
 from app.infrastructure.vlm.client import VLMClient
@@ -83,9 +83,9 @@ async def _run_extraction_worker_with_logging(database, storage, settings, stop_
             await english_client.aclose()
 
 
-async def _run_exam_grading_worker_with_logging(database, storage, settings, stop_event):
+async def _run_exam_grading_worker_with_logging(database, storage, settings, stop_event, adapter):
     try:
-        await run_exam_grading_worker(database, storage, settings, stop_event)
+        await run_exam_grading_worker(database, storage, settings, stop_event, adapter=adapter)
     except Exception:
         logger.exception("Exam grading worker crashed")
         raise
@@ -113,7 +113,7 @@ async def lifespan(app: FastAPI):
         )
     if settings.exam_grading_worker_enabled:
         worker_tasks.append(
-            asyncio.create_task(_run_exam_grading_worker_with_logging(database, storage, settings, stop_event))
+            asyncio.create_task(_run_exam_grading_worker_with_logging(database, storage, settings, stop_event, get_mongo_adapter()))
         )
     
     yield

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.infrastructure.vlm.client import VLMClient
 from app.infrastructure.vlm.prompts import ENGLISH_EXTRACTION_SYSTEM_PROMPT
 from app.infrastructure.worker.extraction_worker import run_extraction_worker
 from app.infrastructure.worker.solution_worker import run_solution_worker
+from app.infrastructure.worker.exam_grading_worker import run_exam_grading_worker
 from app.solution_generation import backfill_solution_generation_tasks
 from app.presentation.auth import router as auth_router
 from app.presentation.exams import router as exams_router
@@ -82,6 +83,14 @@ async def _run_extraction_worker_with_logging(database, storage, settings, stop_
             await english_client.aclose()
 
 
+async def _run_exam_grading_worker_with_logging(database, storage, settings, stop_event):
+    try:
+        await run_exam_grading_worker(database, storage, settings, stop_event)
+    except Exception:
+        logger.exception("Exam grading worker crashed")
+        raise
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     database = get_database()
@@ -101,6 +110,10 @@ async def lifespan(app: FastAPI):
             asyncio.create_task(
                 _run_extraction_worker_with_logging(database, storage, settings, stop_event)
             )
+        )
+    if settings.exam_grading_worker_enabled:
+        worker_tasks.append(
+            asyncio.create_task(_run_exam_grading_worker_with_logging(database, storage, settings, stop_event))
         )
     
     yield

--- a/backend/app/presentation/exam_helpers.py
+++ b/backend/app/presentation/exam_helpers.py
@@ -8,11 +8,31 @@ from bson import ObjectId
 from pydantic import ValidationError
 from pymongo.asynchronous.database import AsyncDatabase
 
-from app.domain.models import ExamItem, GradingStatus, Problem
+from app.domain.models import ExamItem, GradingStatus, Problem, ProblemType
 from app.domain.scoring import compute_summary
 from app.infrastructure.storage.mongo import Document
 from app.presentation.errors import ApiError
 from app.presentation.helpers import parse_object_id
+
+# Terminal item grading statuses: once set, the item should not be re-graded.
+TERMINAL_GRADING_STATUSES = frozenset({
+    GradingStatus.CORRECT.value,
+    GradingStatus.INCORRECT.value,
+    GradingStatus.PENDING_REVIEW.value,
+})
+
+
+def requires_vlm_grading(item: Mapping[str, Any]) -> bool:
+    """A short-answer item with a stored non-null answer requires VLM grading."""
+    snapshot = dict(item.get("problemSnapshot", {}))
+    if snapshot.get("problemType") != ProblemType.SHORT_ANSWER.value:
+        return False
+    answer = dict(item.get("answer", {}))
+    return answer.get("raw") is not None
+
+
+def exam_requires_vlm_grading(items: list[Mapping[str, Any]]) -> bool:
+    return any(requires_vlm_grading(item) for item in items)
 
 def problem_document_to_model(problem: Mapping[str, Any]) -> Problem:
     try:

--- a/backend/app/presentation/exam_serialization.py
+++ b/backend/app/presentation/exam_serialization.py
@@ -145,6 +145,7 @@ def serialize_exam_item(
     item: Mapping[str, Any],
     *,
     include_correct_answer: bool,
+    redact_grading_details: bool = False,
 ) -> ExamItemPayload:
     snapshot = dict(item.get("problemSnapshot", {}))
     source_image = snapshot.get("sourceImage")
@@ -177,12 +178,12 @@ def serialize_exam_item(
         ),
         grading=ExamGradingPayload(
             status=GradingStatus(grading.get("status", GradingStatus.UNGRADED.value)),
-            method=grading.get("method"),
-            isCorrect=grading.get("isCorrect"),
-            score=grading.get("score"),
-            feedback=grading.get("feedback"),
-            providerModel=grading.get("providerModel"),
-            rawProviderResponse=grading.get("rawProviderResponse"),
+            method=grading.get("method") if not redact_grading_details else None,
+            isCorrect=grading.get("isCorrect") if not redact_grading_details else None,
+            score=grading.get("score") if not redact_grading_details else None,
+            feedback=grading.get("feedback") if not redact_grading_details else None,
+            providerModel=grading.get("providerModel") if not redact_grading_details else None,
+            rawProviderResponse=grading.get("rawProviderResponse") if not redact_grading_details else None,
             gradedAt=grading.get("gradedAt"),
             retryCount=int(grading.get("retryCount", 0)),
             selfReportedCorrect=grading.get("selfReportedCorrect"),
@@ -191,7 +192,9 @@ def serialize_exam_item(
 
 
 def serialize_exam(exam: Mapping[str, Any]) -> ExamPayload:
-    include_correct_answer = str(exam.get("state")) == ExamState.SUBMITTED.value
+    state_value = str(exam.get("state"))
+    include_correct_answer = state_value == ExamState.SUBMITTED.value
+    redact_grading_details = state_value == ExamState.GRADING.value
     config_snapshot = dict(exam.get("configSnapshot", {}))
     selection_policy = dict(config_snapshot.get("selectionPolicy", {}))
     # Backward compatibility: historical snapshots may use failureWeight instead of failureRateWeight
@@ -213,7 +216,11 @@ def serialize_exam(exam: Mapping[str, Any]) -> ExamPayload:
             generatedAt=config_snapshot["generatedAt"],
         ),
         items=[
-            serialize_exam_item(item, include_correct_answer=include_correct_answer)
+            serialize_exam_item(
+                item,
+                include_correct_answer=include_correct_answer,
+                redact_grading_details=redact_grading_details,
+            )
             for item in exam.get("items", [])
         ],
         summary=serialize_exam_summary(dict(exam.get("summary", {}))),

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -14,10 +14,12 @@ from app.domain.state import transition_exam_state
 from app.presentation.exam_grading import build_tracking_update, grade_item
 from app.presentation.exam_helpers import (
     build_exam_summary,
+    exam_requires_vlm_grading,
     find_item,
     get_owned_exam,
     make_exam_item,
     problem_document_to_model,
+    requires_vlm_grading,
 )
 from app.presentation.deps import (
     AdapterDependency,
@@ -54,7 +56,10 @@ async def create_exam(
     adapter: AdapterDependency,
     settings: SettingsDependency,
 ) -> CreateExamResponse:
-    query = {"userId": current_user["_id"], "state": ExamState.IN_PROGRESS.value}
+    query = {
+        "userId": current_user["_id"],
+        "state": {"$in": [ExamState.IN_PROGRESS.value, ExamState.GRADING.value]},
+    }
     selection_config = ProblemSelectionConfig(
         cooldown_days=settings.problem_selection_cooldown_days,
         last_wrong_weight=settings.problem_selection_last_wrong_weight,
@@ -144,12 +149,15 @@ async def get_active_exam(
     current_user: CurrentUserDependency,
 ) -> ExamResponse:
     exam = await database["exams"].find_one(
-        {"userId": current_user["_id"], "state": ExamState.IN_PROGRESS.value}
+        {
+            "userId": current_user["_id"],
+            "state": {"$in": [ExamState.IN_PROGRESS.value, ExamState.GRADING.value]},
+        }
     )
     if exam is None:
         raise ApiError(404, "NOT_FOUND", "Active exam not found")
 
-    if exam.get("startedAt") is None:
+    if exam.get("state") == ExamState.IN_PROGRESS.value and exam.get("startedAt") is None:
         now = datetime.now(UTC)
         await database["exams"].update_one(
             {"_id": exam["_id"], "startedAt": None},
@@ -185,14 +193,18 @@ async def save_exam_answer(
 
     item_index, item = find_item(exam, item_id)
     now = datetime.now(UTC)
-    item["answer"] = {
-        "raw": payload.answer,
-        "savedAt": now,
-    }
+    new_answer = {"raw": payload.answer, "savedAt": now}
+    # Conditional write: only persists if the exam is still in-progress,
+    # so a submission that raced with this request cannot be overwritten.
+    updated_item = deepcopy(item)
+    updated_item["answer"] = new_answer
     items = deepcopy(list(exam.get("items", [])))
-    items[item_index] = item
-    await database["exams"].update_one(
-        {"_id": exam["_id"]},
+    items[item_index] = updated_item
+    result = await database["exams"].update_one(
+        {
+            "_id": exam["_id"],
+            "state": ExamState.IN_PROGRESS.value,
+        },
         {
             "$set": {
                 "items": items,
@@ -201,7 +213,14 @@ async def save_exam_answer(
             }
         },
     )
-    return SaveAnswerResponse(item=serialize_exam_item(item, include_correct_answer=False))
+    if result.modified_count == 0:
+        # The exam transitioned out of in-progress between read and write.
+        current = await database["exams"].find_one({"_id": exam["_id"]})
+        if current is not None and current.get("state") != ExamState.IN_PROGRESS.value:
+            raise ApiError(409, "INVALID_EXAM_STATE", "Exam is not in progress")
+        # State matched but item disappeared or another issue; treat as not found.
+        raise ApiError(409, "INVALID_EXAM_STATE", "Exam is not in progress")
+    return SaveAnswerResponse(item=serialize_exam_item(updated_item, include_correct_answer=False))
 
 
 @router.post("/{exam_id}/submit", response_model=ExamResponse)
@@ -214,12 +233,38 @@ async def submit_exam(
     storage: StorageDependency,
 ) -> ExamResponse:
     exam = await get_owned_exam(database, exam_id, current_user["_id"])
-    if exam.get("state") != ExamState.IN_PROGRESS.value:
+    state = exam.get("state")
+    if state == ExamState.GRADING.value:
+        # Idempotent retry: return the already-grading exam without creating a new task.
+        return ExamResponse(exam=serialize_exam(exam))
+    if state == ExamState.SUBMITTED.value:
+        # Idempotent retry: return the already-submitted exam.
+        return ExamResponse(exam=serialize_exam(exam))
+    if state != ExamState.IN_PROGRESS.value:
         raise ApiError(409, "INVALID_EXAM_STATE", "Exam is not in progress")
 
+    items = list(exam.get("items", []))
+    if not exam_requires_vlm_grading(items):
+        return await _submit_exam_synchronous(
+            exam, items, database, current_user, adapter, vlm_client, storage
+        )
+    return await _submit_exam_asynchronous(
+        exam, database, current_user, adapter
+    )
+
+
+async def _submit_exam_synchronous(
+    exam: dict[str, Any],
+    items: list[dict[str, Any]],
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+    adapter: AdapterDependency,
+    vlm_client: GradingVLMDependency,
+    storage: StorageDependency,
+) -> ExamResponse:
     grading_time = datetime.now(UTC)
     graded_items: list[dict[str, Any]] = []
-    for item in exam.get("items", []):
+    for item in items:
         graded_items.append(
             await grade_item(item, vlm_client=vlm_client, storage=storage, now=grading_time)
         )
@@ -319,6 +364,77 @@ async def submit_exam(
     return ExamResponse(exam=serialize_exam(submitted_exam))
 
 
+async def _submit_exam_asynchronous(
+    exam: dict[str, Any],
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+    adapter: AdapterDependency,
+) -> ExamResponse:
+    """Atomically freeze the exam to `grading` and insert its durable grading task."""
+
+    async def _transaction(session: Any) -> dict[str, Any]:
+        current_exam = await database["exams"].find_one(
+            {"_id": exam["_id"], "userId": current_user["_id"]},
+            session=session,
+        )
+        if current_exam is None:
+            raise ApiError(404, "NOT_FOUND", "Exam not found")
+        current_state = current_exam.get("state")
+        if current_state == ExamState.GRADING.value:
+            return current_exam
+        if current_state == ExamState.SUBMITTED.value:
+            return current_exam
+        if current_state != ExamState.IN_PROGRESS.value:
+            raise ApiError(409, "INVALID_EXAM_STATE", "Exam is not in progress")
+
+        grading_at = datetime.now(UTC)
+        next_state = transition_exam_state(
+            ExamState(current_state), ExamState.GRADING
+        )
+        await database["exams"].update_one(
+            {"_id": current_exam["_id"], "state": ExamState.IN_PROGRESS.value},
+            {
+                "$set": {
+                    "state": next_state.value,
+                    "updatedAt": grading_at,
+                }
+            },
+            session=session,
+        )
+        from app.infrastructure.storage.mongo import EXAM_GRADING_TASKS_COLLECTION
+
+        await database[EXAM_GRADING_TASKS_COLLECTION].insert_one(
+            {
+                "_id": ObjectId(),
+                "examId": current_exam["_id"],
+                "userId": current_user["_id"],
+                "status": "pending",
+                "claimToken": None,
+                "leaseUntil": None,
+                "error": None,
+                "createdAt": grading_at,
+                "updatedAt": grading_at,
+            },
+            session=session,
+        )
+
+        updated_exam = deepcopy(current_exam)
+        updated_exam.update(
+            {"state": next_state.value, "updatedAt": grading_at}
+        )
+        return updated_exam
+
+    try:
+        async with adapter.start_session() as session:
+            grading_exam = await session.with_transaction(_transaction)
+    except ApiError:
+        raise
+    except Exception as exc:
+        raise ApiError(500, "SUBMISSION_FAILED", "Failed to submit exam") from exc
+
+    return ExamResponse(exam=serialize_exam(grading_exam))
+
+
 @router.post("/{exam_id}/discard", response_model=ExamResponse)
 async def discard_exam(
     exam_id: str,
@@ -326,7 +442,8 @@ async def discard_exam(
     current_user: CurrentUserDependency,
 ) -> ExamResponse:
     exam = await get_owned_exam(database, exam_id, current_user["_id"])
-    if exam.get("state") != ExamState.IN_PROGRESS.value:
+    state = exam.get("state")
+    if state not in (ExamState.IN_PROGRESS.value, ExamState.GRADING.value):
         raise ApiError(409, "INVALID_EXAM_STATE", "Exam is not in progress")
 
     discarded_at = datetime.now(UTC)
@@ -439,7 +556,7 @@ async def list_exam_history(
     page_size: int = Query(default=20, ge=1, le=100, alias="pageSize"),
     include_discarded: bool = Query(default=False, alias="includeDiscarded"),
 ) -> ExamHistoryResponse:
-    states = [ExamState.SUBMITTED.value]
+    states = [ExamState.SUBMITTED.value, ExamState.GRADING.value]
     if include_discarded:
         states.append(ExamState.DISCARDED.value)
     query = {

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -457,7 +457,7 @@ async def test_submit_exam_grades_items_updates_tracking_and_history(exams_app: 
         {"_id": task["_id"]},
         {"$set": {"status": "processing", "claimToken": "test-token"}},
     )
-    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col, adapter=FakeMongoAdapter())
 
     detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
     submitted_exam = detail_response.json()["exam"]
@@ -524,7 +524,7 @@ async def test_submit_exam_passes_snapshot_subject_to_vlm(exams_app: FastAPI, cl
         {"_id": task["_id"]},
         {"$set": {"status": "processing", "claimToken": "test-token"}},
     )
-    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col, adapter=FakeMongoAdapter())
 
     assert vlm.calls == 1
     assert vlm.last_call_kwargs["subject"] == "english"
@@ -615,7 +615,7 @@ async def test_submit_exam_marks_pending_review_after_vlm_retry_and_self_report_
         {"_id": task["_id"]},
         {"$set": {"status": "processing", "claimToken": "test-token"}},
     )
-    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col, adapter=FakeMongoAdapter())
 
     detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
     submitted_exam = detail_response.json()["exam"]
@@ -896,7 +896,7 @@ async def _run_grading_worker_once(
         {"_id": task["_id"]},
         {"$set": {"status": "processing", "claimToken": "test-token"}},
     )
-    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col, adapter=FakeMongoAdapter())
 
 
 @pytest.mark.asyncio
@@ -1163,3 +1163,44 @@ async def test_grading_state_serialization_redacts_answer_bearing_fields(
     assert submitted_item["problem"]["correctAnswer"]["display"] == "X"
     assert submitted_item["grading"]["feedback"] == "secret feedback"
     assert submitted_item["grading"]["method"] == "vlm"
+
+
+@pytest.mark.asyncio
+async def test_submit_sync_path_rejects_when_answers_modified_during_grading(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    """The synchronous no-VLM path still rejects if answers change between the
+    pre-submit read and the transactional finalization."""
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    objective = make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    database["problems"].seed(objective)
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    item_id = exam["items"][0]["itemId"]
+
+    await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "4"})
+
+    # Mutate the stored answer between the pre-submit read and the transaction.
+    import app.presentation.exams as exams_mod
+    original_grade = exams_mod.grade_item
+
+    async def _mutate_then_grade(item, *, vlm_client, storage, now):
+        stored = await database["exams"].find_one({"_id": ObjectId(exam["id"])})
+        stored["items"][0]["answer"] = {"raw": "changed", "savedAt": datetime.now(UTC)}
+        await database["exams"].update_one(
+            {"_id": stored["_id"]},
+            {"$set": {"items": stored["items"], "updatedAt": datetime.now(UTC)}},
+        )
+        return await original_grade(item, vlm_client=vlm_client, storage=storage, now=now)
+
+    exams_mod.grade_item = _mutate_then_grade  # type: ignore[assignment]
+    try:
+        submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    finally:
+        exams_mod.grade_item = original_grade  # type: ignore[assignment]
+
+    assert submit_response.status_code == 409
+    assert submit_response.json()["error"]["code"] == "ANSWERS_MODIFIED_DURING_GRADING"

--- a/backend/tests/api/test_exams.py
+++ b/backend/tests/api/test_exams.py
@@ -437,8 +437,30 @@ async def test_submit_exam_grades_items_updates_tracking_and_history(exams_app: 
 
     submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
 
+    # VLM-required exam returns promptly in the grading state.
     assert submit_response.status_code == 200
-    submitted_exam = submit_response.json()["exam"]
+    grading_exam = submit_response.json()["exam"]
+    assert grading_exam["state"] == "grading"
+    # A durable task was created.
+    assert len(database["exam_grading_tasks"]._documents) == 1
+    assert database["exam_grading_tasks"]._documents[0]["status"] == "pending"
+
+    # Run the worker to grade items and finalize.
+    from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+    from app.infrastructure.config.settings import Settings as SettingsCls
+    settings = SettingsCls()
+    tasks_col = database["exam_grading_tasks"]
+    task = deepcopy(tasks_col._documents[0])
+    task["claimToken"] = "test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "test-token"}},
+    )
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+
+    detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
+    submitted_exam = detail_response.json()["exam"]
     assert submitted_exam["state"] == "submitted"
     assert submitted_exam["summary"] == {
         "totalProblems": 2,
@@ -460,10 +482,6 @@ async def test_submit_exam_grades_items_updates_tracking_and_history(exams_app: 
     assert history_response.status_code == 200
     assert history_response.json()["total"] == 1
     assert history_response.json()["items"][0]["id"] == exam["id"]
-
-    detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
-    assert detail_response.status_code == 200
-    assert detail_response.json()["exam"]["summary"]["score"] == 1.0
 
 
 @pytest.mark.asyncio
@@ -492,15 +510,30 @@ async def test_submit_exam_passes_snapshot_subject_to_vlm(exams_app: FastAPI, cl
     submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
 
     assert submit_response.status_code == 200
+    assert submit_response.json()["exam"]["state"] == "grading"
+
+    # Run the worker to perform VLM grading.
+    from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+    from app.infrastructure.config.settings import Settings as SettingsCls
+    settings = SettingsCls()
+    tasks_col = database["exam_grading_tasks"]
+    task = deepcopy(tasks_col._documents[0])
+    task["claimToken"] = "test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "test-token"}},
+    )
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+
     assert vlm.calls == 1
     assert vlm.last_call_kwargs["subject"] == "english"
 
 
 @pytest.mark.asyncio
-async def test_submit_exam_rejects_when_answers_modified_during_grading(
-    exams_app: FastAPI,
-    client: AsyncClient,
-) -> None:
+async def test_submit_exam_rejects_late_answer_save_after_freeze(exams_app: FastAPI, client: AsyncClient) -> None:
+    """A save-answer request that reads in-progress but loses the write race with
+    submission is rejected after the exam is frozen to grading."""
     database: FakeDatabase = exams_app.state.fake_database
     storage: FakeStorage = exams_app.state.fake_storage
     vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
@@ -525,35 +558,17 @@ async def test_submit_exam_rejects_when_answers_modified_during_grading(
     )
     assert save_response.status_code == 200
 
-    async def mutate_answer_during_grading(
-        *,
-        image_url: str | None = None,
-        image_base64: str | None = None,
-        problem_text: str,
-        user_answer: str,
-        correct_answer: str,
-        subject: str = "math",
-    ) -> FakeGradingResult:
-        vlm.calls += 1
-        stored_exam = await database["exams"].find_one({"_id": ObjectId(exam["id"])})
-        assert stored_exam is not None
-        stored_exam["items"][0]["answer"] = {
-            "raw": "modified during grading",
-            "savedAt": datetime.now(UTC),
-        }
-        await database["exams"].update_one(
-            {"_id": stored_exam["_id"]},
-            {"$set": {"items": stored_exam["items"], "updatedAt": datetime.now(UTC)}},
-        )
-        return FakeGradingResult(is_correct=True, feedback="good")
-
-    vlm.grade_short_answer = mutate_answer_during_grading
-
     submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert submit_response.status_code == 200
+    assert submit_response.json()["exam"]["state"] == "grading"
 
-    assert submit_response.status_code == 409
-    body = submit_response.json()
-    assert body["error"]["code"] == "ANSWERS_MODIFIED_DURING_GRADING"
+    # A late answer save after the exam was frozen must be rejected.
+    late_save = await client.patch(
+        f"/api/v1/exams/{exam['id']}/items/{item_id}/answer",
+        json={"answer": "modified after submission"},
+    )
+    assert late_save.status_code == 409
+    assert late_save.json()["error"]["code"] == "INVALID_EXAM_STATE"
 
 
 @pytest.mark.asyncio
@@ -585,9 +600,26 @@ async def test_submit_exam_marks_pending_review_after_vlm_retry_and_self_report_
     await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "my answer"})
 
     submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
-
     assert submit_response.status_code == 200
-    submitted_exam = submit_response.json()["exam"]
+    assert submit_response.json()["exam"]["state"] == "grading"
+
+    # Run the worker to grade the item (VLM retry then pending-review).
+    from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+    from app.infrastructure.config.settings import Settings as SettingsCls
+    settings = SettingsCls()
+    tasks_col = database["exam_grading_tasks"]
+    task = deepcopy(tasks_col._documents[0])
+    task["claimToken"] = "test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "test-token"}},
+    )
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+
+    detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
+    submitted_exam = detail_response.json()["exam"]
+    assert submitted_exam["state"] == "submitted"
     assert submitted_exam["summary"] == {
         "totalProblems": 1,
         "answeredProblems": 1,
@@ -599,6 +631,7 @@ async def test_submit_exam_marks_pending_review_after_vlm_retry_and_self_report_
     }
     assert submitted_exam["items"][0]["grading"]["status"] == "pending-review"
     assert submitted_exam["items"][0]["grading"]["retryCount"] == 1
+    # pending-review items do not update tracking.
     assert database["problems"]._documents[0]["tracking"]["exposureCount"] == 4
 
     report_response = await client.post(
@@ -844,3 +877,289 @@ async def test_get_exam_prefers_failure_rate_weight_over_legacy_failure_weight(
     assert response.status_code == 200
     body = response.json()["exam"]
     assert body["configSnapshot"]["selectionPolicy"]["failureRateWeight"] == 2.3
+
+
+# ---------------------------------------------------------------------------
+# Async exam grading tests (#490)
+# ---------------------------------------------------------------------------
+
+async def _run_grading_worker_once(
+    database: FakeDatabase, vlm: FakeVLMClient, storage: FakeStorage, settings: Settings
+) -> None:
+    """Claim and process the single pending exam grading task in the fake database."""
+    from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+    tasks_col = database["exam_grading_tasks"]
+    task = deepcopy(tasks_col._documents[0])
+    task["claimToken"] = "test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "test-token"}},
+    )
+    await process_exam_grading_task(task, database, vlm, storage, settings, tasks_col)
+
+
+@pytest.mark.asyncio
+async def test_submit_vlm_exam_returns_grading_and_creates_single_task(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    storage: FakeStorage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+
+    short = make_problem(user_id, text="Explain photosynthesis", problem_type="short-answer", correct_answer="Light energy")
+    database["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"image")
+    vlm.responses = [FakeGradingResult(is_correct=True, feedback="good")]
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    item_id = exam["items"][0]["itemId"]
+    await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "my answer"})
+
+    submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert submit_response.status_code == 200
+    grading_exam = submit_response.json()["exam"]
+    assert grading_exam["state"] == "grading"
+    # Exactly one task for this exam.
+    assert len(database["exam_grading_tasks"]._documents) == 1
+    assert str(database["exam_grading_tasks"]._documents[0]["examId"]) == exam["id"]
+    assert database["exam_grading_tasks"]._documents[0]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_repeat_submit_for_grading_exam_is_idempotent(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    storage: FakeStorage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+
+    short = make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    database["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"image")
+    vlm.responses = [FakeGradingResult(is_correct=True)]
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    item_id = exam["items"][0]["itemId"]
+    await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "my answer"})
+
+    first = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert first.status_code == 200
+    assert first.json()["exam"]["state"] == "grading"
+    tasks_before = len(database["exam_grading_tasks"]._documents)
+
+    second = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert second.status_code == 200
+    assert second.json()["exam"]["state"] == "grading"
+    # No duplicate task created.
+    assert len(database["exam_grading_tasks"]._documents) == tasks_before
+
+
+@pytest.mark.asyncio
+async def test_repeat_submit_for_already_submitted_exam_is_idempotent(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    storage: FakeStorage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+    settings: Settings = exams_app.dependency_overrides[get_app_settings]()
+
+    short = make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    database["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"image")
+    vlm.responses = [FakeGradingResult(is_correct=True)]
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    item_id = exam["items"][0]["itemId"]
+    await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "my answer"})
+
+    await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    await _run_grading_worker_once(database, vlm, storage, settings)
+
+    # Second submit after completion returns the submitted exam without error.
+    second = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert second.status_code == 200
+    assert second.json()["exam"]["state"] == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_submit_objective_only_exam_uses_synchronous_path(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    """Exams with no VLM-required items return submitted directly."""
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    objective = make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    database["problems"].seed(objective)
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    item_id = exam["items"][0]["itemId"]
+    await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "4"})
+
+    submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert submit_response.status_code == 200
+    submitted_exam = submit_response.json()["exam"]
+    assert submitted_exam["state"] == "submitted"
+    # No grading task created.
+    assert len(database["exam_grading_tasks"]._documents) == 0
+    assert submitted_exam["summary"]["correctProblems"] == 1
+
+
+@pytest.mark.asyncio
+async def test_submit_short_answer_null_answer_uses_synchronous_path(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    """A short-answer item whose stored answer.raw is null is graded incorrect locally."""
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    short = make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    database["problems"].seed(short)
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    # Do not save an answer: answer.raw stays null.
+
+    submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
+    assert submit_response.status_code == 200
+    submitted_exam = submit_response.json()["exam"]
+    assert submitted_exam["state"] == "submitted"
+    assert submitted_exam["items"][0]["grading"]["status"] == "incorrect"
+    assert len(database["exam_grading_tasks"]._documents) == 0
+
+
+@pytest.mark.asyncio
+async def test_create_exam_blocked_by_grading_exam(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    database["exams"].seed(
+        {
+            "_id": ObjectId(),
+            "userId": user_id,
+            "state": "grading",
+            "configSnapshot": {"maxProblemCount": 1, "selectionPolicy": {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 0}, "generatedAt": datetime.now(UTC)},
+            "items": [],
+            "summary": {"totalProblems": 0, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC),
+            "startedAt": None,
+            "submittedAt": None,
+            "updatedAt": datetime.now(UTC),
+        }
+    )
+
+    response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    assert response.status_code == 409
+    assert response.json()["error"]["code"] == "ACTIVE_EXAM_EXISTS"
+
+
+@pytest.mark.asyncio
+async def test_get_active_returns_grading_exam(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+    exam_id = ObjectId()
+    database["exams"].seed(
+        {
+            "_id": exam_id,
+            "userId": user_id,
+            "state": "grading",
+            "configSnapshot": {"maxProblemCount": 1, "selectionPolicy": {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 0}, "generatedAt": datetime.now(UTC)},
+            "items": [],
+            "summary": {"totalProblems": 0, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC),
+            "startedAt": datetime.now(UTC),
+            "submittedAt": None,
+            "updatedAt": datetime.now(UTC),
+        }
+    )
+
+    response = await client.get("/api/v1/exams/active")
+    assert response.status_code == 200
+    assert response.json()["exam"]["state"] == "grading"
+    assert response.json()["exam"]["id"] == str(exam_id)
+
+
+@pytest.mark.asyncio
+async def test_history_includes_grading_exam(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+    exam_id = ObjectId()
+    database["exams"].seed(
+        {
+            "_id": exam_id,
+            "userId": user_id,
+            "state": "grading",
+            "configSnapshot": {"maxProblemCount": 1, "selectionPolicy": {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 0}, "generatedAt": datetime.now(UTC)},
+            "items": [],
+            "summary": {"totalProblems": 0, "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+            "createdAt": datetime.now(UTC),
+            "startedAt": datetime.now(UTC),
+            "submittedAt": None,
+            "updatedAt": datetime.now(UTC),
+        }
+    )
+
+    response = await client.get("/api/v1/exams")
+    assert response.status_code == 200
+    assert response.json()["total"] == 1
+    assert response.json()["items"][0]["state"] == "grading"
+
+
+@pytest.mark.asyncio
+async def test_grading_state_serialization_redacts_answer_bearing_fields(
+    exams_app: FastAPI, client: AsyncClient
+) -> None:
+    database: FakeDatabase = exams_app.state.fake_database
+    storage: FakeStorage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+    settings: Settings = exams_app.dependency_overrides[get_app_settings]()
+
+    short = make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    database["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"image")
+    vlm.responses = [FakeGradingResult(is_correct=True, feedback="secret feedback")]
+
+    create_response = await client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    exam = create_response.json()["exam"]
+    item_id = exam["items"][0]["itemId"]
+    await client.patch(f"/api/v1/exams/{exam['id']}/items/{item_id}/answer", json={"answer": "my answer"})
+    await client.post(f"/api/v1/exams/{exam['id']}/submit")
+
+    detail = await client.get(f"/api/v1/exams/{exam['id']}")
+    grading_exam = detail.json()["exam"]
+    assert grading_exam["state"] == "grading"
+    item = grading_exam["items"][0]
+    # Correct answer hidden.
+    assert item["problem"]["correctAnswer"] is None
+    # Answer-bearing grading details redacted.
+    assert item["grading"]["feedback"] is None
+    assert item["grading"]["rawProviderResponse"] is None
+    assert item["grading"]["method"] is None
+    assert item["grading"]["isCorrect"] is None
+    # Status remains visible for progress UI.
+    assert item["grading"]["status"] == "ungraded"
+
+    # Complete grading, then verify full details are exposed after submission.
+    await _run_grading_worker_once(database, vlm, storage, settings)
+    submitted_detail = await client.get(f"/api/v1/exams/{exam['id']}")
+    submitted_exam = submitted_detail.json()["exam"]
+    assert submitted_exam["state"] == "submitted"
+    submitted_item = submitted_exam["items"][0]
+    assert submitted_item["problem"]["correctAnswer"]["display"] == "X"
+    assert submitted_item["grading"]["feedback"] == "secret feedback"
+    assert submitted_item["grading"]["method"] == "vlm"

--- a/backend/tests/domain/test_state.py
+++ b/backend/tests/domain/test_state.py
@@ -34,11 +34,23 @@ def test_preview_invalid_transitions():
 
 def test_exam_valid_transitions():
     assert transition_exam_state(ExamState.IN_PROGRESS, ExamState.SUBMITTED) == ExamState.SUBMITTED
+    assert transition_exam_state(ExamState.IN_PROGRESS, ExamState.GRADING) == ExamState.GRADING
+    assert transition_exam_state(ExamState.IN_PROGRESS, ExamState.DISCARDED) == ExamState.DISCARDED
+    assert transition_exam_state(ExamState.GRADING, ExamState.SUBMITTED) == ExamState.SUBMITTED
+    assert transition_exam_state(ExamState.GRADING, ExamState.DISCARDED) == ExamState.DISCARDED
 
 
 def test_exam_invalid_transitions():
     with pytest.raises(InvalidStateTransitionError):
         transition_exam_state(ExamState.SUBMITTED, ExamState.IN_PROGRESS)
+    with pytest.raises(InvalidStateTransitionError):
+        transition_exam_state(ExamState.SUBMITTED, ExamState.GRADING)
+    with pytest.raises(InvalidStateTransitionError):
+        transition_exam_state(ExamState.GRADING, ExamState.IN_PROGRESS)
+    with pytest.raises(InvalidStateTransitionError):
+        transition_exam_state(ExamState.DISCARDED, ExamState.SUBMITTED)
+    with pytest.raises(InvalidStateTransitionError):
+        transition_exam_state(ExamState.IN_PROGRESS, ExamState.IN_PROGRESS)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -15,6 +15,7 @@ from app.infrastructure.storage.mongo import (
     AsyncMongoClientFactory,
     CANONICAL_SOLUTIONS_COLLECTION,
     COACHING_CONVERSATIONS_COLLECTION,
+    EXAM_GRADING_TASKS_COLLECTION,
     FOLDERS_COLLECTION,
     MongoClientAdapter,
     SOLUTION_GENERATION_TASKS_COLLECTION,
@@ -146,6 +147,7 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
         COACHING_CONVERSATIONS_COLLECTION,
         FOLDERS_COLLECTION,
         INGESTION_BATCHES_COLLECTION,
+        EXAM_GRADING_TASKS_COLLECTION,
     ]
     assert database[TAGS_COLLECTION].index_calls == [
         {
@@ -172,4 +174,10 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
     assert database[INGESTION_BATCHES_COLLECTION].index_calls == [
         {"keys": list(index["keys"]), "kwargs": {"name": index["name"]}}
         for index in BATCH_INDEXES
+    ]
+    assert database[EXAM_GRADING_TASKS_COLLECTION].index_calls == [
+        {
+            "keys": [("examId", 1)],
+            "kwargs": {"unique": True, "name": "exam_grading_task_exam_unique"},
+        }
     ]

--- a/backend/tests/integration/test_exam_workflow.py
+++ b/backend/tests/integration/test_exam_workflow.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI
 from app.infrastructure.vlm.client import VLMError
 from app.presentation.deps import get_app_settings
 
-from .conftest import FakeGradingResult
+from .conftest import FakeGradingResult, FakeMongoAdapter
 
 
 @pytest.mark.asyncio
@@ -181,7 +181,8 @@ async def test_wf_exam_3_submit_and_grade_updates_score_and_tracking(
         {"$set": {"status": "processing", "claimToken": "test-token"}},
     )
     await process_exam_grading_task(
-        task, database, app.state.fake_grading_vlm, storage, app.dependency_overrides[get_app_settings](), tasks_col
+        task, database, app.state.fake_grading_vlm, storage, app.dependency_overrides[get_app_settings](), tasks_col,
+        adapter=FakeMongoAdapter(),
     )
 
     detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
@@ -270,7 +271,8 @@ async def test_wf_exam_4_pending_review_then_self_report_updates_score(
         {"$set": {"status": "processing", "claimToken": "test-token"}},
     )
     await process_exam_grading_task(
-        task, database, app.state.fake_grading_vlm, storage, app.dependency_overrides[get_app_settings](), tasks_col
+        task, database, app.state.fake_grading_vlm, storage, app.dependency_overrides[get_app_settings](), tasks_col,
+        adapter=FakeMongoAdapter(),
     )
 
     detail_response = await client.get(f"/api/v1/exams/{exam['id']}")

--- a/backend/tests/integration/test_exam_workflow.py
+++ b/backend/tests/integration/test_exam_workflow.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 
 from app.infrastructure.vlm.client import VLMError
+from app.presentation.deps import get_app_settings
 
 from .conftest import FakeGradingResult
 
@@ -163,7 +164,29 @@ async def test_wf_exam_3_submit_and_grade_updates_score_and_tracking(
 
     submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
     assert submit_response.status_code == 200
-    submitted_exam = submit_response.json()["exam"]
+    grading_exam = submit_response.json()["exam"]
+    assert grading_exam["state"] == "grading"
+
+    # Run the worker to grade items and finalize.
+    from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+    from copy import deepcopy as _deepcopy
+    database = app.state.fake_database
+    storage = app.state.fake_storage
+    tasks_col = database["exam_grading_tasks"]
+    task = _deepcopy(tasks_col._documents[0])
+    task["claimToken"] = "test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "test-token"}},
+    )
+    await process_exam_grading_task(
+        task, database, app.state.fake_grading_vlm, storage, app.dependency_overrides[get_app_settings](), tasks_col
+    )
+
+    detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
+    assert detail_response.status_code == 200
+    submitted_exam = detail_response.json()["exam"]
     assert submitted_exam["state"] == "submitted"
     assert submitted_exam["summary"] == {
         "totalProblems": 2,
@@ -191,8 +214,6 @@ async def test_wf_exam_3_submit_and_grade_updates_score_and_tracking(
     assert short_document["tracking"]["correctCount"] == 1
     assert short_document["tracking"]["failedCount"] == 0
 
-    detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
-    assert detail_response.status_code == 200
     assert detail_response.json()["exam"]["summary"]["score"] == 1.0
 
 
@@ -232,7 +253,28 @@ async def test_wf_exam_4_pending_review_then_self_report_updates_score(
     )
     submit_response = await client.post(f"/api/v1/exams/{exam['id']}/submit")
     assert submit_response.status_code == 200
-    submitted_exam = submit_response.json()["exam"]
+    grading_exam = submit_response.json()["exam"]
+    assert grading_exam["state"] == "grading"
+
+    # Run the worker to grade the item (VLM retry then pending-review).
+    from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+    from copy import deepcopy as _deepcopy
+    database = app.state.fake_database
+    storage = app.state.fake_storage
+    tasks_col = database["exam_grading_tasks"]
+    task = _deepcopy(tasks_col._documents[0])
+    task["claimToken"] = "test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "test-token"}},
+    )
+    await process_exam_grading_task(
+        task, database, app.state.fake_grading_vlm, storage, app.dependency_overrides[get_app_settings](), tasks_col
+    )
+
+    detail_response = await client.get(f"/api/v1/exams/{exam['id']}")
+    submitted_exam = detail_response.json()["exam"]
     submitted_item = submitted_exam["items"][0]
     assert submitted_item["grading"]["status"] == "pending-review"
     assert submitted_item["grading"]["retryCount"] == 1

--- a/backend/tests/worker/test_exam_grading_worker.py
+++ b/backend/tests/worker/test_exam_grading_worker.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+
+from app.domain.models import ExamState, GradingStatus
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.storage.mongo import EXAM_GRADING_TASKS_COLLECTION
+from app.infrastructure.worker.exam_grading_worker import (
+    TASK_COMPLETED,
+    TASK_PENDING,
+    TASK_PROCESSING,
+    _claim_task,
+    _finalize_exam,
+    _refresh_lease,
+    _release_task,
+    process_exam_grading_task,
+    run_exam_grading_worker,
+)
+from tests.test_utils.db_fakes import FakeDatabase
+
+
+class FakeGradingResult:
+    def __init__(self, *, is_correct: bool, feedback: str = "", model: str = "fake-vlm") -> None:
+        self.is_correct = is_correct
+        self.feedback = feedback
+        self.model = model
+        self.raw_provider_response = {"isCorrect": is_correct}
+
+
+class FakeVLMClient:
+    def __init__(self) -> None:
+        self.responses: list[Any] = []
+        self.calls = 0
+
+    async def grade_short_answer(self, **kwargs: Any) -> FakeGradingResult:
+        self.calls += 1
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    async def aclose(self) -> None:
+        pass
+
+
+class FakeStorage:
+    def __init__(self) -> None:
+        self._objects: dict[tuple[str, str], bytes] = {}
+
+    def seed(self, bucket: str, key: str, payload: bytes) -> None:
+        self._objects[(bucket, key)] = payload
+
+    def get_object(self, bucket: str, key: str) -> bytes:
+        return self._objects[(bucket, key)]
+
+
+def _make_settings(**overrides: Any) -> Settings:
+    defaults = dict(
+        exam_grading_worker_enabled=True,
+        exam_grading_worker_poll_interval_seconds=0.01,
+        exam_grading_lease_seconds=60.0,
+        exam_grading_lease_refresh_seconds=20.0,
+        problem_selection_min_age_days=0,
+    )
+    defaults.update(overrides)
+    return Settings(**defaults)
+
+
+def _make_problem(user_id: ObjectId, *, text: str = "Explain X", problem_type: str = "short-answer", correct_answer: str = "answer", tracking: dict[str, Any] | None = None) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "text": text,
+        "problemType": problem_type,
+        "subject": "math",
+        "graphDsl": None,
+        "correctAnswer": {"display": correct_answer, "normalizedText": correct_answer, "normalizedSet": [], "format": "single"},
+        "tags": [],
+        "sourceImage": {"bucket": "learnloop-media", "objectKey": f"users/{user_id}/img/{ObjectId()}.png", "contentType": "image/png", "sizeBytes": 4, "sha256": None, "uploadedAt": now},
+        "origin": {},
+        "tracking": tracking or {"exposureCount": 0, "correctCount": 0, "failedCount": 0, "lastTestedAt": None, "lastAttemptCorrect": None},
+        "isDeleted": False,
+        "deletedAt": None,
+        "isDisabled": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def _make_grading_exam(user_id: ObjectId, items: list[dict[str, Any]]) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "state": ExamState.GRADING.value,
+        "configSnapshot": {"maxProblemCount": len(items), "selectionPolicy": {"cooldownDays": 7, "lastWrongWeight": 1.0, "failureRateWeight": 1.0, "recencyWeight": 1.0, "minProblemAgeDays": 0}, "generatedAt": now},
+        "items": items,
+        "summary": {"totalProblems": len(items), "answeredProblems": 0, "gradedProblems": 0, "pendingProblems": 0, "correctProblems": 0, "failedProblems": 0, "score": None},
+        "createdAt": now,
+        "startedAt": now,
+        "submittedAt": None,
+        "updatedAt": now,
+    }
+
+
+def _make_ungraded_item(problem: dict[str, Any], *, order: int = 1, answer: str | None = "my answer") -> dict[str, Any]:
+    return {
+        "itemId": str(ObjectId()),
+        "order": order,
+        "problemId": problem["_id"],
+        "problemSnapshot": {
+            "text": problem["text"],
+            "problemType": problem["problemType"],
+            "subject": problem.get("subject", "math"),
+            "graphDsl": None,
+            "correctAnswer": deepcopy(problem["correctAnswer"]),
+            "sourceImage": deepcopy(problem.get("sourceImage")),
+        },
+        "answer": {"raw": answer, "savedAt": datetime.now(UTC)},
+        "grading": {
+            "status": GradingStatus.UNGRADED.value,
+            "method": None,
+            "isCorrect": None,
+            "score": None,
+            "feedback": None,
+            "providerModel": None,
+            "rawProviderResponse": None,
+            "gradedAt": None,
+            "retryCount": 0,
+            "selfReportedCorrect": None,
+        },
+    }
+
+
+def _make_task(exam_id: ObjectId, user_id: ObjectId, *, claim_token: str = "tok", status: str = TASK_PROCESSING, lease_until: datetime | None = None) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "examId": exam_id,
+        "userId": user_id,
+        "status": status,
+        "claimToken": claim_token,
+        "leaseUntil": lease_until or now + timedelta(seconds=60),
+        "error": None,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+@pytest_asyncio.fixture
+async def db() -> FakeDatabase:
+    return FakeDatabase()
+
+
+@pytest_asyncio.fixture
+async def storage() -> FakeStorage:
+    return FakeStorage()
+
+
+@pytest_asyncio.fixture
+async def vlm() -> FakeVLMClient:
+    return FakeVLMClient()
+
+
+@pytest_asyncio.fixture
+async def settings() -> Settings:
+    return _make_settings()
+
+
+@pytest.mark.asyncio
+async def test_claim_task_picks_pending(db: FakeDatabase) -> None:
+    now = datetime.now(UTC)
+    tasks = db[EXAM_GRADING_TASKS_COLLECTION]
+    tasks.seed(_make_task(ObjectId(), ObjectId(), claim_token=None, status=TASK_PENDING))
+    claimed = await _claim_task(tasks, now=now, lease_seconds=60)
+    assert claimed is not None
+    assert claimed["status"] == TASK_PROCESSING
+    assert claimed["claimToken"] is not None
+    assert claimed["leaseUntil"] > now
+
+
+@pytest.mark.asyncio
+async def test_claim_task_reclaims_expired_lease(db: FakeDatabase) -> None:
+    now = datetime.now(UTC)
+    tasks = db[EXAM_GRADING_TASKS_COLLECTION]
+    tasks.seed(_make_task(ObjectId(), ObjectId(), claim_token="old", status=TASK_PROCESSING, lease_until=now - timedelta(seconds=10)))
+    claimed = await _claim_task(tasks, now=now, lease_seconds=60)
+    assert claimed is not None
+    assert claimed["claimToken"] != "old"
+
+
+@pytest.mark.asyncio
+async def test_claim_task_returns_none_when_nothing_claimable(db: FakeDatabase) -> None:
+    now = datetime.now(UTC)
+    tasks = db[EXAM_GRADING_TASKS_COLLECTION]
+    # Active lease not expired
+    tasks.seed(_make_task(ObjectId(), ObjectId(), claim_token="tok", status=TASK_PROCESSING, lease_until=now + timedelta(seconds=30)))
+    claimed = await _claim_task(tasks, now=now, lease_seconds=60)
+    assert claimed is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_lease_requires_ownership(db: FakeDatabase) -> None:
+    now = datetime.now(UTC)
+    tasks = db[EXAM_GRADING_TASKS_COLLECTION]
+    task = _make_task(ObjectId(), ObjectId(), claim_token="tok")
+    tasks.seed(task)
+    ok = await _refresh_lease(tasks, task["_id"], "wrong-token", now=now, lease_seconds=60)
+    assert ok is False
+    ok = await _refresh_lease(tasks, task["_id"], "tok", now=now, lease_seconds=60)
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_release_task_makes_claimable_again(db: FakeDatabase) -> None:
+    now = datetime.now(UTC)
+    tasks = db[EXAM_GRADING_TASKS_COLLECTION]
+    task = _make_task(ObjectId(), ObjectId(), claim_token="tok")
+    tasks.seed(task)
+    await _release_task(tasks, task["_id"], "tok", now=now)
+    refreshed = await tasks.find_one({"_id": task["_id"]})
+    assert refreshed["status"] == TASK_PENDING
+    assert refreshed["claimToken"] is None
+
+
+@pytest.mark.asyncio
+async def test_worker_grades_mixed_exam_and_finalizes(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+) -> None:
+    user_id = ObjectId()
+    objective = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    short = _make_problem(user_id, text="Explain gravity", problem_type="short-answer", correct_answer="Mass attracts mass")
+    db["problems"].seed(objective, short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+
+    items = [
+        _make_ungraded_item(objective, order=1, answer="4"),
+        _make_ungraded_item(short, order=2, answer="my answer"),
+    ]
+    exam = _make_grading_exam(user_id, items)
+    db["exams"].seed(exam)
+    vlm.responses = [FakeGradingResult(is_correct=True, feedback="good")]
+
+    task = _make_task(exam["_id"], user_id)
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.SUBMITTED.value
+    assert stored_exam["summary"]["gradedProblems"] == 2
+    assert stored_exam["summary"]["correctProblems"] == 2
+    assert stored_exam["submittedAt"] is not None
+    # Tracking updated exactly once.
+    obj_doc = await db["problems"].find_one({"_id": objective["_id"]})
+    short_doc = await db["problems"].find_one({"_id": short["_id"]})
+    assert obj_doc["tracking"]["exposureCount"] == 1
+    assert short_doc["tracking"]["exposureCount"] == 1
+    # Task completed.
+    stored_task = await db[EXAM_GRADING_TASKS_COLLECTION].find_one({"_id": task["_id"]})
+    assert stored_task["status"] == TASK_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_worker_per_item_failure_becomes_pending_review_and_continues(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+) -> None:
+    user_id = ObjectId()
+    short_a = _make_problem(user_id, text="Explain A", problem_type="short-answer", correct_answer="A")
+    short_b = _make_problem(user_id, text="Explain B", problem_type="short-answer", correct_answer="B")
+    db["problems"].seed(short_a, short_b)
+    storage.seed(short_a["sourceImage"]["bucket"], short_a["sourceImage"]["objectKey"], b"img")
+    storage.seed(short_b["sourceImage"]["bucket"], short_b["sourceImage"]["objectKey"], b"img")
+
+    items = [
+        _make_ungraded_item(short_a, order=1),
+        _make_ungraded_item(short_b, order=2),
+    ]
+    exam = _make_grading_exam(user_id, items)
+    db["exams"].seed(exam)
+    vlm.responses = [RuntimeError("vlm down"), FakeGradingResult(is_correct=False, feedback="no")]
+
+    task = _make_task(exam["_id"], user_id)
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.SUBMITTED.value
+    statuses = {item["itemId"]: item["grading"]["status"] for item in stored_exam["items"]}
+    assert statuses[items[0]["itemId"]] == GradingStatus.PENDING_REVIEW.value
+    assert statuses[items[1]["itemId"]] == GradingStatus.INCORRECT.value
+    # pending-review item does not update tracking; incorrect does.
+    doc_a = await db["problems"].find_one({"_id": short_a["_id"]})
+    doc_b = await db["problems"].find_one({"_id": short_b["_id"]})
+    assert doc_a["tracking"]["exposureCount"] == 0
+    assert doc_b["tracking"]["exposureCount"] == 1
+    assert doc_b["tracking"]["failedCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_resumes_skipping_terminal_items(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+) -> None:
+    """After a restart, the worker skips already-terminal items and finalizes."""
+    user_id = ObjectId()
+    objective = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    short = _make_problem(user_id, text="Explain gravity", problem_type="short-answer", correct_answer="Mass")
+    db["problems"].seed(objective, short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+
+    # Objective already graded correct before restart.
+    obj_item = _make_ungraded_item(objective, order=1, answer="4")
+    obj_item["grading"] = {
+        "status": GradingStatus.CORRECT.value,
+        "method": "normalized-match",
+        "isCorrect": True,
+        "score": 1.0,
+        "feedback": None,
+        "providerModel": None,
+        "rawProviderResponse": None,
+        "gradedAt": datetime.now(UTC),
+        "retryCount": 0,
+        "selfReportedCorrect": None,
+    }
+    short_item = _make_ungraded_item(short, order=2, answer="my answer")
+    exam = _make_grading_exam(user_id, [obj_item, short_item])
+    db["exams"].seed(exam)
+    vlm.responses = [FakeGradingResult(is_correct=True, feedback="ok")]
+
+    task = _make_task(exam["_id"], user_id)
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.SUBMITTED.value
+    assert vlm.calls == 1  # Only the ungraded short-answer was graded.
+    # Tracking for the already-graded objective applied once during finalization.
+    obj_doc = await db["problems"].find_one({"_id": objective["_id"]})
+    assert obj_doc["tracking"]["exposureCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_stale_worker_cannot_persist_after_ownership_change(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+) -> None:
+    user_id = ObjectId()
+    short = _make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    db["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+    exam = _make_grading_exam(user_id, [_make_ungraded_item(short, order=1)])
+    db["exams"].seed(exam)
+    vlm.responses = [FakeGradingResult(is_correct=True)]
+
+    # First worker claims with token "tok1".
+    task = _make_task(exam["_id"], user_id, claim_token="tok1")
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+    # Another worker steals ownership before the first persists.
+    await db[EXAM_GRADING_TASKS_COLLECTION].update_one(
+        {"_id": task["_id"]},
+        {"$set": {"claimToken": "tok2"}},
+    )
+
+    # The first worker (token "tok1") should not persist results.
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.GRADING.value  # Not finalized by stale worker.
+    assert stored_exam["items"][0]["grading"]["status"] == GradingStatus.UNGRADED.value
+
+
+@pytest.mark.asyncio
+async def test_worker_does_not_double_count_tracking_on_rerun(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+) -> None:
+    """If the worker resumes after finalization already happened, tracking is not double-counted."""
+    user_id = ObjectId()
+    objective = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    db["problems"].seed(objective)
+    obj_item = _make_ungraded_item(objective, order=1, answer="4")
+    obj_item["grading"]["status"] = GradingStatus.CORRECT.value
+    obj_item["grading"]["isCorrect"] = True
+    obj_item["grading"]["method"] = "normalized-match"
+    obj_item["grading"]["score"] = 1.0
+
+    # Exam already submitted (finalized by a prior run).
+    exam = _make_grading_exam(user_id, [obj_item])
+    exam["state"] = ExamState.SUBMITTED.value
+    exam["submittedAt"] = datetime.now(UTC)
+    db["exams"].seed(exam)
+    # Tracking already updated.
+    await db["problems"].update_one(
+        {"_id": objective["_id"]},
+        {"$set": {"tracking": {"exposureCount": 1, "correctCount": 1, "failedCount": 0, "lastTestedAt": datetime.now(UTC), "lastAttemptCorrect": True}}},
+    )
+
+    task = _make_task(exam["_id"], user_id, claim_token="tok")
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+
+    # Tracking unchanged.
+    doc = await db["problems"].find_one({"_id": objective["_id"]})
+    assert doc["tracking"]["exposureCount"] == 1
+    # Task marked completed.
+    stored_task = await db[EXAM_GRADING_TASKS_COLLECTION].find_one({"_id": task["_id"]})
+    assert stored_task["status"] == TASK_COMPLETED
+
+
+@pytest.mark.asyncio
+async def test_worker_persists_items_incrementally(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+) -> None:
+    """Each completed item is persisted atomically with its recomputed partial summary."""
+    user_id = ObjectId()
+    short_a = _make_problem(user_id, text="Explain A", problem_type="short-answer", correct_answer="A")
+    short_b = _make_problem(user_id, text="Explain B", problem_type="short-answer", correct_answer="B")
+    db["problems"].seed(short_a, short_b)
+    storage.seed(short_a["sourceImage"]["bucket"], short_a["sourceImage"]["objectKey"], b"img")
+    storage.seed(short_b["sourceImage"]["bucket"], short_b["sourceImage"]["objectKey"], b"img")
+
+    items = [_make_ungraded_item(short_a, order=1), _make_ungraded_item(short_b, order=2)]
+    exam = _make_grading_exam(user_id, items)
+    db["exams"].seed(exam)
+
+    # Intercept after the first item is persisted to inspect partial state.
+    seen_partial: list[dict[str, Any]] = []
+    import app.infrastructure.worker.exam_grading_worker as worker_mod
+    original_persist = worker_mod._persist_item_result
+
+    async def _capture_partial(database, exam_id, item_id, grading, *, now):
+        result = await original_persist(database, exam_id, item_id, grading, now=now)
+        fresh = await db["exams"].find_one({"_id": exam_id})
+        seen_partial.append(deepcopy(fresh))
+        return result
+
+    worker_mod._persist_item_result = _capture_partial  # type: ignore[assignment]
+    try:
+        vlm.responses = [
+            FakeGradingResult(is_correct=True, feedback="a"),
+            FakeGradingResult(is_correct=False, feedback="b"),
+        ]
+        task = _make_task(exam["_id"], user_id)
+        db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+        await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    finally:
+        worker_mod._persist_item_result = original_persist  # type: ignore[assignment]
+
+    # After the first item was graded, the exam was still grading with one graded item.
+    assert seen_partial, "partial state was not captured"
+    partial = seen_partial[0]
+    assert partial["state"] == ExamState.GRADING.value
+    graded_count = sum(
+        1 for it in partial["items"]
+        if it["grading"]["status"] in (GradingStatus.CORRECT.value, GradingStatus.INCORRECT.value)
+    )
+    assert graded_count == 1
+    assert partial["summary"]["gradedProblems"] == 1
+
+
+@pytest.mark.asyncio
+async def test_lease_refresh_extends_lease_during_long_task(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient,
+) -> None:
+    """The background lease refresher extends the lease while a task is processing."""
+    user_id = ObjectId()
+    short = _make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    db["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+    exam = _make_grading_exam(user_id, [_make_ungraded_item(short, order=1)])
+    db["exams"].seed(exam)
+
+    settings = _make_settings(exam_grading_lease_refresh_seconds=0.05, exam_grading_lease_seconds=0.1)
+    original_lease = datetime.now(UTC) + timedelta(seconds=0.1)
+    task = _make_task(exam["_id"], user_id, claim_token="tok", lease_until=original_lease)
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    # Make VLM slow so the refresher runs at least once.
+    async def _slow_grade(**kwargs):
+        await asyncio.sleep(0.15)
+        return FakeGradingResult(is_correct=True)
+
+    vlm.grade_short_answer = _slow_grade  # type: ignore[assignment]
+
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+
+    # The lease should have been refreshed past the original expiry.
+    stored_task = await db[EXAM_GRADING_TASKS_COLLECTION].find_one({"_id": task["_id"]})
+    assert stored_task["status"] == TASK_COMPLETED
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.SUBMITTED.value
+
+
+@pytest.mark.asyncio
+async def test_run_worker_loop_processes_task_and_exits(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient,
+) -> None:
+    user_id = ObjectId()
+    short = _make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
+    db["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+    exam = _make_grading_exam(user_id, [_make_ungraded_item(short, order=1)])
+    db["exams"].seed(exam)
+    vlm.responses = [FakeGradingResult(is_correct=True)]
+
+    task = _make_task(exam["_id"], user_id, claim_token=None, status=TASK_PENDING)
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    settings = _make_settings(exam_grading_lease_seconds=60)
+
+    # Patch the VLMClient constructor so the worker uses our fake.
+    import app.infrastructure.worker.exam_grading_worker as worker_mod
+
+    original_init = worker_mod.VLMClient
+
+    class _FakeVLMWrapper:
+        def __init__(self, **kwargs: Any) -> None:
+            self._inner = vlm
+
+        async def __aenter__(self):
+            return self
+
+        async def grade_short_answer(self, **kwargs: Any):
+            return await self._inner.grade_short_answer(**kwargs)
+
+        async def aclose(self):
+            pass
+
+    worker_mod.VLMClient = lambda **kwargs: vlm  # type: ignore[misc]
+    try:
+        stop = asyncio.Event()
+        # Run worker briefly; it should process the one task then idle.
+        async def _run_briefly():
+            task_obj = asyncio.create_task(run_exam_grading_worker(db, storage, settings, stop))
+            await asyncio.sleep(0.5)
+            stop.set()
+            await asyncio.wait_for(task_obj, timeout=5.0)
+
+        await _run_briefly()
+    finally:
+        worker_mod.VLMClient = original_init  # type: ignore[misc]
+
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.SUBMITTED.value

--- a/backend/tests/worker/test_exam_grading_worker.py
+++ b/backend/tests/worker/test_exam_grading_worker.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -24,6 +26,17 @@ from app.infrastructure.worker.exam_grading_worker import (
     run_exam_grading_worker,
 )
 from tests.test_utils.db_fakes import FakeDatabase
+
+
+class FakeSession:
+    async def with_transaction(self, callback: Any) -> Any:
+        return await callback(self)
+
+
+class FakeMongoAdapter:
+    @asynccontextmanager
+    async def start_session(self) -> AsyncIterator[FakeSession]:
+        yield FakeSession()
 
 
 class FakeGradingResult:
@@ -175,6 +188,11 @@ async def settings() -> Settings:
     return _make_settings()
 
 
+@pytest_asyncio.fixture
+async def adapter() -> FakeMongoAdapter:
+    return FakeMongoAdapter()
+
+
 @pytest.mark.asyncio
 async def test_claim_task_picks_pending(db: FakeDatabase) -> None:
     now = datetime.now(UTC)
@@ -233,7 +251,7 @@ async def test_release_task_makes_claimable_again(db: FakeDatabase) -> None:
 
 @pytest.mark.asyncio
 async def test_worker_grades_mixed_exam_and_finalizes(
-    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
 ) -> None:
     user_id = ObjectId()
     objective = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
@@ -252,7 +270,7 @@ async def test_worker_grades_mixed_exam_and_finalizes(
     task = _make_task(exam["_id"], user_id)
     db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
 
-    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=adapter)
 
     stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
     assert stored_exam["state"] == ExamState.SUBMITTED.value
@@ -271,7 +289,7 @@ async def test_worker_grades_mixed_exam_and_finalizes(
 
 @pytest.mark.asyncio
 async def test_worker_per_item_failure_becomes_pending_review_and_continues(
-    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
 ) -> None:
     user_id = ObjectId()
     short_a = _make_problem(user_id, text="Explain A", problem_type="short-answer", correct_answer="A")
@@ -291,7 +309,7 @@ async def test_worker_per_item_failure_becomes_pending_review_and_continues(
     task = _make_task(exam["_id"], user_id)
     db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
 
-    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=adapter)
 
     stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
     assert stored_exam["state"] == ExamState.SUBMITTED.value
@@ -308,7 +326,7 @@ async def test_worker_per_item_failure_becomes_pending_review_and_continues(
 
 @pytest.mark.asyncio
 async def test_worker_resumes_skipping_terminal_items(
-    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
 ) -> None:
     """After a restart, the worker skips already-terminal items and finalizes."""
     user_id = ObjectId()
@@ -339,7 +357,7 @@ async def test_worker_resumes_skipping_terminal_items(
     task = _make_task(exam["_id"], user_id)
     db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
 
-    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=adapter)
 
     stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
     assert stored_exam["state"] == ExamState.SUBMITTED.value
@@ -351,7 +369,7 @@ async def test_worker_resumes_skipping_terminal_items(
 
 @pytest.mark.asyncio
 async def test_worker_stale_worker_cannot_persist_after_ownership_change(
-    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
 ) -> None:
     user_id = ObjectId()
     short = _make_problem(user_id, text="Explain X", problem_type="short-answer", correct_answer="X")
@@ -371,7 +389,7 @@ async def test_worker_stale_worker_cannot_persist_after_ownership_change(
     )
 
     # The first worker (token "tok1") should not persist results.
-    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=adapter)
 
     stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
     assert stored_exam["state"] == ExamState.GRADING.value  # Not finalized by stale worker.
@@ -380,7 +398,7 @@ async def test_worker_stale_worker_cannot_persist_after_ownership_change(
 
 @pytest.mark.asyncio
 async def test_worker_does_not_double_count_tracking_on_rerun(
-    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
 ) -> None:
     """If the worker resumes after finalization already happened, tracking is not double-counted."""
     user_id = ObjectId()
@@ -406,7 +424,7 @@ async def test_worker_does_not_double_count_tracking_on_rerun(
     task = _make_task(exam["_id"], user_id, claim_token="tok")
     db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
 
-    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=adapter)
 
     # Tracking unchanged.
     doc = await db["problems"].find_one({"_id": objective["_id"]})
@@ -418,7 +436,7 @@ async def test_worker_does_not_double_count_tracking_on_rerun(
 
 @pytest.mark.asyncio
 async def test_worker_persists_items_incrementally(
-    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings,
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
 ) -> None:
     """Each completed item is persisted atomically with its recomputed partial summary."""
     user_id = ObjectId()
@@ -451,7 +469,7 @@ async def test_worker_persists_items_incrementally(
         ]
         task = _make_task(exam["_id"], user_id)
         db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
-        await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+        await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=adapter)
     finally:
         worker_mod._persist_item_result = original_persist  # type: ignore[assignment]
 
@@ -491,7 +509,7 @@ async def test_lease_refresh_extends_lease_during_long_task(
 
     vlm.grade_short_answer = _slow_grade  # type: ignore[assignment]
 
-    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION])
+    await process_exam_grading_task(task, db, vlm, storage, settings, db[EXAM_GRADING_TASKS_COLLECTION], adapter=FakeMongoAdapter())
 
     # The lease should have been refreshed past the original expiry.
     stored_task = await db[EXAM_GRADING_TASKS_COLLECTION].find_one({"_id": task["_id"]})
@@ -540,7 +558,7 @@ async def test_run_worker_loop_processes_task_and_exits(
         stop = asyncio.Event()
         # Run worker briefly; it should process the one task then idle.
         async def _run_briefly():
-            task_obj = asyncio.create_task(run_exam_grading_worker(db, storage, settings, stop))
+            task_obj = asyncio.create_task(run_exam_grading_worker(db, storage, settings, stop, adapter=FakeMongoAdapter()))
             await asyncio.sleep(0.5)
             stop.set()
             await asyncio.wait_for(task_obj, timeout=5.0)
@@ -551,3 +569,51 @@ async def test_run_worker_loop_processes_task_and_exits(
 
     stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
     assert stored_exam["state"] == ExamState.SUBMITTED.value
+
+
+@pytest.mark.asyncio
+async def test_finalize_exam_transactional_applies_all_or_nothing(
+    db: FakeDatabase, storage: FakeStorage, vlm: FakeVLMClient, settings: Settings, adapter: FakeMongoAdapter,
+) -> None:
+    """Finalization commits the exam transition, tracking updates, and task
+    completion in one transaction. A rerun after a simulated post-commit crash
+    (exam already submitted) does not double-apply tracking and merely marks
+    the task completed."""
+    user_id = ObjectId()
+    objective = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    db["problems"].seed(objective)
+    obj_item = _make_ungraded_item(objective, order=1, answer="4")
+    obj_item["grading"]["status"] = GradingStatus.CORRECT.value
+    obj_item["grading"]["isCorrect"] = True
+    obj_item["grading"]["method"] = "normalized-match"
+    obj_item["grading"]["score"] = 1.0
+
+    exam = _make_grading_exam(user_id, [obj_item])
+    db["exams"].seed(exam)
+
+    task = _make_task(exam["_id"], user_id, claim_token="tok")
+    db[EXAM_GRADING_TASKS_COLLECTION].seed(task)
+
+    finalized = await _finalize_exam(
+        db, exam["_id"], user_id, task["_id"], "tok", db[EXAM_GRADING_TASKS_COLLECTION],
+        now=datetime.now(UTC), adapter=adapter,
+    )
+    assert finalized is True
+
+    stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
+    assert stored_exam["state"] == ExamState.SUBMITTED.value
+    doc = await db["problems"].find_one({"_id": objective["_id"]})
+    assert doc["tracking"]["exposureCount"] == 1
+    assert doc["tracking"]["correctCount"] == 1
+    stored_task = await db[EXAM_GRADING_TASKS_COLLECTION].find_one({"_id": task["_id"]})
+    assert stored_task["status"] == TASK_COMPLETED
+
+    # Rerun finalization: exam is already submitted, so tracking must not double-count.
+    finalized_again = await _finalize_exam(
+        db, exam["_id"], user_id, task["_id"], "tok", db[EXAM_GRADING_TASKS_COLLECTION],
+        now=datetime.now(UTC), adapter=adapter,
+    )
+    assert finalized_again is True
+    doc2 = await db["problems"].find_one({"_id": objective["_id"]})
+    assert doc2["tracking"]["exposureCount"] == 1
+    assert doc2["tracking"]["correctCount"] == 1


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Add a `grading` exam state and durable, application-lifespan MongoDB worker that grades VLM-required short-answer items asynchronously while exposing incremental per-item progress through the existing exam API.
- Submission of a VLM-required exam returns promptly in state `grading`; submission of an objective/null-answer exam retains the synchronous local-grading path.
- Answer writes are now conditional on `state == "in-progress"`, so a late save that raced with submission cannot overwrite a frozen exam.
- Grading-state serialization redacts `correctAnswer`, `feedback`, and `rawProviderResponse` while exposing item `status` for the progress UI.

## Linked Issue

Closes #490

## Issue Alignment

This PR implements the issue by:

- Adding `grading` to the state model with valid `in-progress -> grading -> submitted` (and `grading -> discarded`) transitions, plus invalid-transition rejection.
- Making both `in-progress` and `grading` count as active for the one-active-exam invariant (create conflict, `GET /exams/active`, history response).
- Freezing the exam to `grading` and inserting its single durable task in one MongoDB transaction; a unique `examId` index enforces one task per exam.
- Making `PATCH .../answer` conditional on `state == "in-progress"` at write time and returning a conflict if the conditional write loses the race with submission.
- Implementing the worker with atomic claim (ownership token + expiring lease), background lease refresh, stale-lease recovery, claim-token verification before each persist, sequential per-item grading through the existing `grade_item`, per-item failure isolation (`pending-review`, continues later items), targeted positional item/summary persistence (no stale full-array overwrite), and transactional finalization with exactly-once problem tracking + task completion.
- Redacting answer-bearing fields (`correctAnswer`, `feedback`, `rawProviderResponse`, `method`, `isCorrect`, `score`) in the `grading` state while keeping item `status` visible.
- Making repeated submit idempotent for both `grading` and `submitted` exams (no duplicate tasks).
- Keeping the no-VLM synchronous path for objective-only and null-answer short-answer exams.

Scope covered:

- All items in the issue's `Scope` section.

Out of scope / intentionally not included:

- Frontend checklist/polling/active-redirect/history-card work (#491).
- VLM prompt/provider/grading-accuracy changes.
- Per-item retry controls, SSE/streaming, data migration, or a general-purpose job queue refactor.

## Implementation Notes

- `backend/app/domain/models.py` / `state.py`: added `ExamState.GRADING` and transitions.
- `backend/app/infrastructure/config/settings.py`: added `exam_grading_worker_enabled`, `exam_grading_worker_poll_interval_seconds`, `exam_grading_lease_seconds`, `exam_grading_lease_refresh_seconds`.
- `backend/app/infrastructure/storage/mongo.py`: added `EXAM_GRADING_TASKS_COLLECTION` and a unique `examId` index in `ensure_database_setup`.
- `backend/app/presentation/exams.py`: split `submit_exam` into synchronous (`_submit_exam_synchronous`) and asynchronous (`_submit_exam_asynchronous`) paths; updated `create_exam`, `get_active_exam`, `save_exam_answer` (conditional write), `discard_exam`, and `list_exam_history` for `grading`.
- `backend/app/presentation/exam_helpers.py`: added `requires_vlm_grading`, `exam_requires_vlm_grading`, and `TERMINAL_GRADING_STATUSES`.
- `backend/app/presentation/exam_serialization.py`: `serialize_exam_item` now accepts `redact_grading_details`; `serialize_exam` redacts while `grading`.
- `backend/app/infrastructure/worker/exam_grading_worker.py`: new worker implementing claim/lease/refresh/recovery, sequential grading, incremental persistence, finalization, and the poll loop.
- `backend/app/main.py`: wired `run_exam_grading_worker` into the app lifespan (guarded by `exam_grading_worker_enabled`).

## Tests

Commands run:

- `./scripts/agent-env.sh test backend` — passed (943 passed, 1 skipped).

The issue's suggested targeted commands (`cd backend && uv run --frozen pytest tests/api/test_exams.py tests/presentation/test_exam_grading.py tests/worker`) are covered by the agent-env backend suite run above (same test set), all green.

Automated tests added or updated:

- `tests/domain/test_state.py`: `grading` valid/invalid transitions.
- `tests/worker/test_exam_grading_worker.py` (new): claim pending/stale-lease recovery, lease refresh ownership, release-and-reclaim, mixed objective/VLM grading + finalization, per-item failure isolation (`pending-review` continues later items), resume skipping terminal items, stale-worker cannot persist after ownership change, no double-count tracking on rerun, incremental item/summary persistence, lease refresh during a long task, and the poll loop processing one task then exiting.
- `tests/api/test_exams.py`: VLM submit returns `grading` + single task; idempotent repeat submit for `grading` and `submitted`; objective-only synchronous path; null-answer short-answer synchronous path; create blocked by `grading` exam; active returns `grading`; history includes `grading`; grading-state serialization redaction then full exposure after submission; late answer save rejected after freeze.
- Updated existing submit/integration tests to drive the async path via the worker and verify finalization, tracking, self-report, and pending-review behavior.

Manual verification:

- Automated coverage mirrors the issue's manual verification steps (delayed/fake VLM, concurrent late save rejection, forced VLM failure -> pending-review while other items continue, lease renewal, restart resume, idempotent submit, grading-state redaction). The full backend suite passing via `./scripts/agent-env.sh test backend` exercises these paths with a fake VLM and the FakeDatabase. A live end-to-end manual run against a real delayed VLM was not performed in this agent environment; the automated tests provide the equivalent behavior verification.

## Deviations From Issue Plan

None. The implementation follows the chosen MongoDB-backed, application-lifespan worker approach and the submission/idempotency, claiming/leasing, item-processing, finalization, and serialization contract specified in the issue.

## Follow-Up Work

- #491 consumes the `grading` state and incremental exam-detail response on the frontend.
