### PR TITLE
feat(exam): show live TODO-style progress during VLM grading

### DIFF
--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -289,6 +289,10 @@ describe("ActiveExamPage", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ exam: { ...baseExam, state: "submitted" } }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ exam: { ...baseExam, state: "submitted" } }),
       });
 
     renderActiveExamPage();
@@ -306,12 +310,12 @@ describe("ActiveExamPage", () => {
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const submitCall = mockFetch.mock.calls.find((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/submit")
+      );
+      expect(submitCall).toBeDefined();
+      expect(submitCall![1].method).toBe("POST");
     });
-
-    const submitCall = mockFetch.mock.calls[1];
-    expect(submitCall[0]).toContain("/api/v1/exams/exam123/submit");
-    expect(submitCall[1].method).toBe("POST");
 
     expect(mockNavigate).toHaveBeenCalledWith("/exams/exam123");
   });
@@ -400,6 +404,49 @@ describe("ActiveExamPage", () => {
     expect(previewItems).toHaveLength(2);
     expect(previewItems[0]).toHaveTextContent("First question?");
     expect(previewItems[1]).toHaveTextContent("Second question?");
+  });
+
+  it("redirects to exam detail page when active exam is in grading state", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: { ...baseExam, state: "grading" } }),
+    });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/exams/exam123", { replace: true });
+    });
+  });
+
+  it("invalidates active-exam cache and navigates to detail on submit success", async () => {
+    const user = userEvent.setup();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ exam: baseExam }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ exam: { ...baseExam, state: "submitted" } }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ exam: baseExam }),
+      });
+
+    renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Submit Exam" }));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/exams/exam123");
+    });
   });
 
   it("renders a graph preview for problems with graphDsl and full-width text for problems without", async () => {

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -63,6 +63,13 @@ export function ActiveExamPage() {
   });
 
   const exam = examData?.exam;
+
+  useEffect(() => {
+    if (exam?.state === "grading") {
+      navigate(`/exams/${exam.id}`, { replace: true });
+    }
+  }, [exam?.state, exam?.id, navigate]);
+
   const items = exam?.items || [];
   const currentItem: ExamItem | undefined = items[currentItemIndex];
 
@@ -86,6 +93,7 @@ export function ActiveExamPage() {
   const submitExamMutation = useMutation({
     mutationFn: (examId: string) => submitExam(examId),
     onSuccess: (data) => {
+      queryClient.removeQueries({ queryKey: ["active-exam"] });
       queryClient.invalidateQueries({ queryKey: ["exams"] });
       navigate(`/exams/${data.exam.id}`);
     },

--- a/frontend/src/pages/ExamDetailPage.test.tsx
+++ b/frontend/src/pages/ExamDetailPage.test.tsx
@@ -359,4 +359,270 @@ describe("ExamDetailPage", () => {
 
     expect(screen.queryByTestId("explain-button-item1")).not.toBeInTheDocument();
   });
+
+  it("renders grading checklist when exam state is grading", async () => {
+    const gradingExam = {
+      ...baseExam,
+      state: "grading",
+      items: [
+        {
+          itemId: "sa1",
+          order: 1,
+          problemId: "prob1",
+          problem: { text: "Explain photosynthesis", problemType: "short-answer" },
+          answer: { raw: "plants make food", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "ungraded", retryCount: 0 },
+        },
+        {
+          itemId: "sa2",
+          order: 2,
+          problemId: "prob2",
+          problem: { text: "Explain gravity", problemType: "short-answer" },
+          answer: { raw: "things fall", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "correct", retryCount: 0 },
+        },
+        {
+          itemId: "sa3",
+          order: 3,
+          problemId: "prob3",
+          problem: { text: "Explain relativity", problemType: "short-answer" },
+          answer: { raw: "e=mc2", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "incorrect", retryCount: 0 },
+        },
+        {
+          itemId: "sa4",
+          order: 4,
+          problemId: "prob4",
+          problem: { text: "Explain quantum", problemType: "short-answer" },
+          answer: { raw: "particles", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "pending-review", retryCount: 0 },
+        },
+        {
+          itemId: "mc1",
+          order: 5,
+          problemId: "prob5",
+          problem: { text: "What is 2+2?", problemType: "fill-in-the-blank", correctAnswer: { display: "4", normalizedText: "4", normalizedSet: ["4"], format: "single" } },
+          answer: { raw: "4", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "correct", retryCount: 0 },
+        },
+        {
+          itemId: "sa5",
+          order: 6,
+          problemId: "prob6",
+          problem: { text: "Explain nothing", problemType: "short-answer" },
+          answer: { raw: null, savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "ungraded", retryCount: 0 },
+        },
+      ],
+    };
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: gradingExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    // Only VLM-required items (short-answer with non-null raw answer) are listed
+    expect(screen.getByTestId("grading-indicator-sa1")).toBeInTheDocument();
+    expect(screen.getByTestId("grading-indicator-sa2")).toBeInTheDocument();
+    expect(screen.getByTestId("grading-indicator-sa3")).toBeInTheDocument();
+    expect(screen.getByTestId("grading-indicator-sa4")).toBeInTheDocument();
+    // Objective item (fill-in-the-blank) excluded
+    expect(screen.queryByTestId("grading-indicator-mc1")).not.toBeInTheDocument();
+    // Null-answer short-answer excluded
+    expect(screen.queryByTestId("grading-indicator-sa5")).not.toBeInTheDocument();
+  });
+
+  it("shows neutral indicator and 'Waiting for grading' for ungraded items", async () => {
+    const gradingExam = {
+      ...baseExam,
+      state: "grading",
+      items: [
+        {
+          itemId: "sa1",
+          order: 1,
+          problemId: "prob1",
+          problem: { text: "Explain photosynthesis", problemType: "short-answer" },
+          answer: { raw: "plants", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "ungraded", retryCount: 0 },
+        },
+      ],
+    };
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: gradingExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("grading-status-sa1")).toHaveTextContent("Waiting for grading");
+  });
+
+  it("shows green indicator for both correct and incorrect as 'Grading completed'", async () => {
+    const gradingExam = {
+      ...baseExam,
+      state: "grading",
+      items: [
+        {
+          itemId: "sa1",
+          order: 1,
+          problemId: "prob1",
+          problem: { text: "Correct answer", problemType: "short-answer" },
+          answer: { raw: "right", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "correct", retryCount: 0 },
+        },
+        {
+          itemId: "sa2",
+          order: 2,
+          problemId: "prob2",
+          problem: { text: "Incorrect answer", problemType: "short-answer" },
+          answer: { raw: "wrong", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "incorrect", retryCount: 0 },
+        },
+      ],
+    };
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: gradingExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    // Both correct and incorrect show "Grading completed" — not correctness
+    expect(screen.getByTestId("grading-status-sa1")).toHaveTextContent("Grading completed");
+    expect(screen.getByTestId("grading-status-sa2")).toHaveTextContent("Grading completed");
+    // The checklist must NOT reveal correctness via text
+    expect(screen.queryByText("Correct")).not.toBeInTheDocument();
+    expect(screen.queryByText("Incorrect")).not.toBeInTheDocument();
+  });
+
+  it("shows red indicator and failure message for pending-review items", async () => {
+    const gradingExam = {
+      ...baseExam,
+      state: "grading",
+      items: [
+        {
+          itemId: "sa1",
+          order: 1,
+          problemId: "prob1",
+          problem: { text: "Failed answer", problemType: "short-answer" },
+          answer: { raw: "something", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "pending-review", retryCount: 0 },
+        },
+      ],
+    };
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: gradingExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("grading-status-sa1")).toHaveTextContent("Automatic grading failed; review will be available after submission");
+  });
+
+  it("transitions from grading checklist to results view when exam becomes submitted", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({
+        exam: {
+          ...baseExam,
+          state: "grading",
+          items: [
+            {
+              itemId: "sa1",
+              order: 1,
+              problemId: "prob1",
+              problem: { text: "Explain something", problemType: "short-answer" },
+              answer: { raw: "answer", savedAt: "2024-01-01T00:00:00Z" },
+              grading: { status: "ungraded", retryCount: 0 },
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ exam: baseExam })
+      .mockResolvedValue({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Results")).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    expect(screen.queryByText("Grading in Progress")).not.toBeInTheDocument();
+  });
+
+  it("does not show summary score or submitted date during grading", async () => {
+    const gradingExam = {
+      ...baseExam,
+      state: "grading",
+      items: [
+        {
+          itemId: "sa1",
+          order: 1,
+          problemId: "prob1",
+          problem: { text: "Explain something", problemType: "short-answer" },
+          answer: { raw: "answer", savedAt: "2024-01-01T00:00:00Z" },
+          grading: { status: "ungraded", retryCount: 0 },
+        },
+      ],
+    };
+    vi.mocked(api.get).mockResolvedValueOnce({ exam: gradingExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    // Should not show the submitted results view elements
+    expect(screen.queryByText("Exam Results")).not.toBeInTheDocument();
+    expect(screen.queryByText("Summary")).not.toBeInTheDocument();
+    expect(screen.queryByText("Questions")).not.toBeInTheDocument();
+  });
+
+  it("preserves submitted results view with self-report and reveal controls after grading completes", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({
+        exam: {
+          ...baseExam,
+          state: "grading",
+          items: [
+            {
+              itemId: "item3",
+              order: 3,
+              problemId: "prob3",
+              problem: { ...baseExam.items[0].problem },
+              answer: { raw: "test", savedAt: "2024-01-01T00:00:00Z" },
+              grading: { status: "pending-review", retryCount: 0 },
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({ exam: baseExam })
+      .mockResolvedValue({ exam: baseExam });
+
+    renderExamDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Grading in Progress")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Exam Results")).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    expect(screen.getByText("Summary")).toBeInTheDocument();
+    expect(screen.getByText("Questions")).toBeInTheDocument();
+    expect(screen.getByText("Pending Review:")).toBeInTheDocument();
+    expect(screen.getByText("I was correct")).toBeInTheDocument();
+    expect(screen.getByText("I was incorrect")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/pages/ExamDetailPage.tsx
+++ b/frontend/src/pages/ExamDetailPage.tsx
@@ -7,7 +7,7 @@ import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { LatexText } from "@/components/LatexText";
 import { TeacherPasswordModal } from "@/components/TeacherPasswordModal";
-import type { ExamItem, ExamResponse, SelfReportRequest, SelfReportResponse } from "@/types/exam";
+import type { Exam, ExamItem, ExamResponse, SelfReportRequest, SelfReportResponse } from "@/types/exam";
 
 async function fetchExam(examId: string): Promise<ExamResponse> {
   return api.get<ExamResponse>(`/exams/${examId}`);
@@ -291,6 +291,109 @@ function ExamItemReview({
   );
 }
 
+function isVlmRequired(item: ExamItem): boolean {
+  return item.problem.problemType === "short-answer" && item.answer.raw != null;
+}
+
+function GradingChecklist({ exam }: { exam: Exam }) {
+  const vlmItems = exam.items
+    .filter(isVlmRequired)
+    .sort((a, b) => a.order - b.order);
+
+  const pageCanvasStyle: React.CSSProperties = {
+    minHeight: "calc(100vh - 60px)",
+    backgroundColor: "var(--color-bg)",
+    color: "var(--color-text)",
+    padding: "2rem 1.5rem",
+  };
+
+  const contentWrapperStyle: React.CSSProperties = {
+    maxWidth: "800px",
+    margin: "0 auto",
+  };
+
+  return (
+    <main style={pageCanvasStyle}>
+      <div style={contentWrapperStyle}>
+        <div style={{ marginBottom: "2rem" }}>
+          <h1 style={{ margin: 0, fontSize: "2rem", fontWeight: 800, letterSpacing: "-0.02em" }}>Grading in Progress</h1>
+          <p style={{ color: "var(--color-text-muted)", margin: "0.5rem 0 0", fontSize: "0.9rem", fontWeight: 500 }}>
+            Your answers are being graded. This page will update automatically.
+          </p>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+          {vlmItems.map((item) => {
+            const status = item.grading.status;
+            const isWaiting = status === "ungraded";
+            const isCompleted = status === "correct" || status === "incorrect";
+            const isFailed = status === "pending-review";
+
+            const indicatorColor = isCompleted
+              ? "var(--color-success)"
+              : isFailed
+                ? "var(--color-danger)"
+                : "var(--color-text-muted)";
+
+            const statusLabel = isWaiting
+              ? "Waiting for grading"
+              : isCompleted
+                ? "Grading completed"
+                : isFailed
+                  ? "Automatic grading failed; review will be available after submission"
+                  : status;
+
+            return (
+              <div
+                key={item.itemId}
+                className="card-premium"
+                style={{
+                  border: "1px solid var(--color-border)",
+                  background: "var(--color-surface)",
+                  padding: "1.25rem",
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: "1rem",
+                }}
+              >
+                <span
+                  aria-label={statusLabel}
+                  data-testid={`grading-indicator-${item.itemId}`}
+                  style={{
+                    display: "inline-block",
+                    width: "1.25rem",
+                    height: "1.25rem",
+                    borderRadius: "50%",
+                    border: `2px solid ${indicatorColor}`,
+                    backgroundColor: isCompleted || isFailed ? indicatorColor : "transparent",
+                    flexShrink: 0,
+                    marginTop: "0.125rem",
+                  }}
+                />
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: "0.8125rem", fontWeight: 700, color: "var(--color-text-muted)", textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>
+                    Question {item.order}
+                  </div>
+                  <LatexText
+                    text={item.problem.text}
+                    style={{ fontSize: "1rem", lineHeight: "1.5", whiteSpace: "pre-wrap", color: "var(--color-text)" }}
+                  />
+                  <div
+                    data-testid={`grading-status-${item.itemId}`}
+                    style={{ fontSize: "0.875rem", color: "var(--color-text-muted)", marginTop: "0.5rem", fontWeight: 500 }}
+                  >
+                    {statusLabel}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </main>
+  );
+}
+
 export function ExamDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -307,6 +410,10 @@ export function ExamDetailPage() {
     queryKey: ["exam", id],
     queryFn: () => fetchExam(id!),
     enabled: !!id,
+    refetchInterval: (query) => {
+      const state = query.state.data?.exam?.state;
+      return state === "grading" ? 2000 : false;
+    },
   });
 
   const selfReportMutation = useMutation({
@@ -388,6 +495,10 @@ export function ExamDetailPage() {
         </div>
       </main>
     );
+  }
+
+  if (exam.state === "grading") {
+    return <GradingChecklist exam={exam} />;
   }
 
   const hasPendingReview = exam.items.some((item) => item.grading.status === "pending-review");

--- a/frontend/src/pages/ExamsPage.test.tsx
+++ b/frontend/src/pages/ExamsPage.test.tsx
@@ -9,6 +9,15 @@ import { ExamsPage } from "./ExamsPage";
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -72,6 +81,7 @@ function createExamResponse() {
 describe("ExamsPage", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockNavigate.mockReset();
   });
 
   it("shows the discarded toggle even when submitted exam history is empty", async () => {
@@ -266,5 +276,117 @@ describe("ExamsPage", () => {
 
     expect(await screen.findByText("An active exam already exists. Would you like to continue it?")).toBeInTheDocument();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders grading exam card with grading label and hidden final metrics", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: "exam-grading",
+            state: "grading",
+            createdAt: "2024-01-01T00:00:00Z",
+            summary: {
+              totalProblems: 3,
+              answeredProblems: 3,
+              gradedProblems: 1,
+              pendingProblems: 0,
+              correctProblems: 1,
+              failedProblems: 0,
+              score: 0.33,
+            },
+          },
+        ],
+        page: 1,
+        pageSize: 10,
+        total: 1,
+      }),
+    });
+
+    renderExamsPage();
+
+    expect(await screen.findByText("Exam exam-grading")).toBeInTheDocument();
+
+    // Badge should show "grading"
+    expect(screen.getByText("grading")).toBeInTheDocument();
+
+    // Should show "Grading" label, not "Submitted"
+    expect(screen.getByText("Grading")).toBeInTheDocument();
+    // Should not show submitted date — grading has no submittedAt
+    // The date and metric columns show "—" for grading
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+  });
+
+  it("navigates to exam detail when clicking a grading exam card", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: "exam-grading",
+            state: "grading",
+            createdAt: "2024-01-01T00:00:00Z",
+            summary: {
+              totalProblems: 1,
+              answeredProblems: 1,
+              gradedProblems: 0,
+              pendingProblems: 0,
+              correctProblems: 0,
+              failedProblems: 0,
+              score: null,
+            },
+          },
+        ],
+        page: 1,
+        pageSize: 10,
+        total: 1,
+      }),
+    });
+
+    renderExamsPage();
+
+    const card = await screen.findByText("Exam exam-grading");
+    await user.click(card.closest("button")!);
+
+    expect(mockNavigate).toHaveBeenCalledWith("/exams/exam-grading");
+  });
+
+  it("renders submitted exam card normally without grading label", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            id: "exam-submitted",
+            state: "submitted",
+            createdAt: "2024-01-01T00:00:00Z",
+            submittedAt: "2024-01-01T01:00:00Z",
+            summary: {
+              totalProblems: 2,
+              answeredProblems: 2,
+              gradedProblems: 2,
+              pendingProblems: 0,
+              correctProblems: 1,
+              failedProblems: 1,
+              score: 0.5,
+            },
+          },
+        ],
+        page: 1,
+        pageSize: 10,
+        total: 1,
+      }),
+    });
+
+    renderExamsPage();
+
+    expect(await screen.findByText("Exam exam-submitted")).toBeInTheDocument();
+
+    // Should show "Submitted" label, not "Grading"
+    expect(screen.getByText("Submitted")).toBeInTheDocument();
+    // Should show the actual score
+    expect(screen.getByText("50%")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -105,7 +105,7 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
         </div>
         <div>
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Incorrect</div>
-          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: isDiscarded || isGrading ? "var(--color-text-danger)" : "var(--color-text-danger)" }}>{isDiscarded || isGrading ? "—" : exam.summary.failedProblems}</div>
+          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: isDiscarded || isGrading ? "var(--color-text-muted)" : "var(--color-text-danger)" }}>{isDiscarded || isGrading ? "—" : exam.summary.failedProblems}</div>
         </div>
       </div>
     </button>

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -18,6 +18,8 @@ function getStateStyleClass(state: string) {
       return "badge-success";
     case "discarded":
       return "badge-danger";
+    case "grading":
+      return "badge-warning";
     default:
       return "badge-warning";
   }
@@ -25,8 +27,10 @@ function getStateStyleClass(state: string) {
 
 function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () => void }) {
   const stateClass = getStateStyleClass(exam.state);
-  const completionDate = exam.state === "discarded" ? exam.discardedAt : exam.submittedAt;
-  const completionLabel = exam.state === "discarded" ? "Discarded" : "Submitted";
+  const isGrading = exam.state === "grading";
+  const isDiscarded = exam.state === "discarded";
+  const completionDate = isDiscarded ? exam.discardedAt : exam.submittedAt;
+  const completionLabel = isDiscarded ? "Discarded" : isGrading ? "Grading" : "Submitted";
 
   return (
     <button
@@ -85,11 +89,11 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
       >
         <div>
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>{completionLabel}</div>
-          <div style={{ fontSize: "0.9rem", fontWeight: 600 }}>{formatDate(completionDate)}</div>
+          <div style={{ fontSize: "0.9rem", fontWeight: 600 }}>{isGrading ? "—" : formatDate(completionDate)}</div>
         </div>
         <div>
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Score</div>
-          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: exam.state === "discarded" ? "var(--color-text-muted)" : "var(--color-primary-text)" }}>{exam.state === "discarded" ? "—" : formatScore(exam.summary.score)}</div>
+          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: isDiscarded || isGrading ? "var(--color-text-muted)" : "var(--color-primary-text)" }}>{isDiscarded || isGrading ? "—" : formatScore(exam.summary.score)}</div>
         </div>
         <div>
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Total</div>
@@ -97,11 +101,11 @@ function ExamHistoryCard({ exam, onOpen }: { exam: ExamHistoryItem; onOpen: () =
         </div>
         <div>
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Correct</div>
-          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: exam.state === "discarded" ? "var(--color-text-muted)" : "var(--color-success)" }}>{exam.state === "discarded" ? "—" : exam.summary.correctProblems}</div>
+          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: isDiscarded || isGrading ? "var(--color-text-muted)" : "var(--color-success)" }}>{isDiscarded || isGrading ? "—" : exam.summary.correctProblems}</div>
         </div>
         <div>
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.725rem", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.05em", marginBottom: "0.25rem" }}>Incorrect</div>
-          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: exam.state === "discarded" ? "var(--color-text-muted)" : "var(--color-text-danger)" }}>{exam.state === "discarded" ? "—" : exam.summary.failedProblems}</div>
+          <div style={{ fontSize: "1.1rem", fontWeight: 800, color: isDiscarded || isGrading ? "var(--color-text-danger)" : "var(--color-text-danger)" }}>{isDiscarded || isGrading ? "—" : exam.summary.failedProblems}</div>
         </div>
       </div>
     </button>

--- a/frontend/src/types/exam.ts
+++ b/frontend/src/types/exam.ts
@@ -4,7 +4,7 @@ export type ProblemType =
   | "fill-in-the-blank"
   | "short-answer";
 
-export type ExamState = "in-progress" | "submitted" | "discarded";
+export type ExamState = "in-progress" | "grading" | "submitted" | "discarded";
 
 export type GradingStatus =
   | "ungraded"


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Add a `grading` exam state to frontend types and render a TODO-list-style grading checklist in `ExamDetailPage` when the exam is in the `grading` state.
- The checklist shows only VLM-required items (`short-answer` with non-null `answer.raw`), with neutral/green/red circle indicators and accessible text labels: neutral = "Waiting for grading", green = "Grading completed" (for both correct and incorrect), red = "Automatic grading failed; review will be available after submission" (for pending-review).
- `ActiveExamPage` redirects to the exam detail route when `GET /exams/active` returns a grading exam, and removes stale `active-exam` cache on submit success.
- `ExamDetailPage` polls the exam detail query at a 2s interval only while `state === "grading"` and stops polling when the exam becomes `submitted`, automatically transitioning to the existing results view.
- `ExamsPage` history cards for grading exams show a "Grading" label, hide final score/correct/incorrect metrics and submitted date, and open the detail checklist route.

## Linked Issue

Closes #491

## Issue Alignment

This PR implements the issue by:

- Extending `ExamState` with `grading`.
- Preserving the existing submit-success navigation and removing stale `active-exam` cache data.
- Redirecting `ActiveExamPage` to `/exams/{id}` when `GET /exams/active` returns a grading exam.
- Adding a grading-state branch to `ExamDetailPage` using the existing exam detail route and API.
- Filtering only VLM-required rows (`problemType === "short-answer" && answer.raw != null`), excluding objective and null-answer items without client-side trimming.
- Mapping server-backed item states to neutral, green, and red visual states with accessible text labels.
- Polling at a fixed 2s interval only while `state === "grading"`; stopping at terminal `submitted`.
- Automatically transitioning from the checklist to the existing results view without navigation.
- Updating `ExamsPage` history cards: grading label, no submitted date, no final-score presentation, clickable to detail checklist.
- Preserving existing submitted results layout, self-report, answer reveal, and AI Explain controls.

Scope covered:

- All items in the issue's `Scope` section.

Out of scope / intentionally not included:

- Backend task creation, worker implementation, state transitions, leasing, or serialization (#490).
- New API endpoint, SSE/streaming transport, or client-side-only progress state.
- Per-item retry controls.
- Changing scoring, VLM prompts, grading semantics, or self-report behavior.
- Replacing the existing submitted-exam results layout.

## Implementation Notes

- `frontend/src/types/exam.ts`: added `grading` to `ExamState`.
- `frontend/src/pages/ActiveExamPage.tsx`: added `useEffect` redirect when `exam.state === "grading"`; `submitExamMutation.onSuccess` now calls `queryClient.removeQueries({ queryKey: ["active-exam"] })` to prevent stale cache reuse.
- `frontend/src/pages/ExamDetailPage.tsx`: added `refetchInterval` to poll at 2000ms while `state === "grading"`; added `isVlmRequired` helper and `GradingChecklist` component; renders checklist when `exam.state === "grading"` before the submitted results view.
- `frontend/src/pages/ExamsPage.tsx`: `getStateStyleClass` handles `grading`; `ExamHistoryCard` shows "—" for score/correct/incorrect and hides submitted date for grading exams.

## Tests

Commands run:

- `./scripts/agent-env.sh test frontend` — passed (543 passed, 34 test files).
- `npx tsc -b && npx vite build` — passed (type-check and build succeeded).

Automated tests added or updated:

- `ActiveExamPage.test.tsx`:
  - `redirects to exam detail page when active exam is in grading state`
  - `invalidates active-exam cache and navigates to detail on submit success`
  - Updated existing submit test to handle cache-removal-triggered refetch.
- `ExamDetailPage.test.tsx`:
  - `renders grading checklist when exam state is grading` (filtering, VLM-required only)
  - `shows neutral indicator and 'Waiting for grading' for ungraded items`
  - `shows green indicator for both correct and incorrect as 'Grading completed'` (correctness not revealed)
  - `shows red indicator and failure message for pending-review items`
  - `transitions from grading checklist to results view when exam becomes submitted`
  - `does not show summary score or submitted date during grading`
  - `preserves submitted results view with self-report and reveal controls after grading completes`
- `ExamsPage.test.tsx`:
  - `renders grading exam card with grading label and hidden final metrics`
  - `navigates to exam detail when clicking a grading exam card`
  - `renders submitted exam card normally without grading label`

Manual verification:

- Automated tests cover the issue's manual verification steps 1-2 and 7 (routing, cache behavior, history rendering). Steps 3-6 and 8-9 involve live VLM behavior and were not performed in the agent environment. The automated tests with mocked API responses provide equivalent behavior verification for the frontend rendering and polling logic.

## Deviations From Issue Plan

None. The implementation follows the chosen approach of reusing the existing `ExamDetailPage` route and TanStack Query data source with conditional polling and a server-backed checklist.

## Follow-Up Work

None.
