### PR TITLE
fix(agent): scope agent-env cleanup to LearnLoop resources by default

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -203,25 +203,42 @@ The agent environment:
 
 #### Disk cleanup
 
-Over time, agent sessions accumulate Docker volumes, old `learnloop-agent-tools:*` images, dangling layers, and build cache. Use `scripts/agent-env-cleanup.sh` to reclaim disk space:
+Over time, agent sessions accumulate Docker volumes, old `learnloop-agent-tools:*` images, dangling layers, and build cache. Use `scripts/agent-env-cleanup.sh` to reclaim disk space.
+
+By default the script is **scoped to LearnLoop agent resources only**: it removes unused `learnloop-agent-*` volumes, old `learnloop-agent-tools:*` images, and stale git worktree metadata in this repository. It does not touch dangling images or build cache from other projects.
 
 ```bash
 # Preview what would be cleaned up without removing anything
 ./scripts/agent-env-cleanup.sh --dry-run
 
 # Remove unused agent volumes, old tools images (keeping 2 most recent),
-# dangling images, build cache, and stale git worktrees
+# and stale git worktree metadata
 ./scripts/agent-env-cleanup.sh
 
 # Keep a different number of recent tools images
 ./scripts/agent-env-cleanup.sh --keep-images 3
 ```
 
+Daemon-wide Docker cleanup (dangling images and shared build-cache pruning) is opt-in and affects the entire Docker daemon, including resources from **other projects**. Use it only when you intend to reclaim disk across all projects on this machine:
+
+```bash
+# Preview daemon-wide cleanup (dangling images + build cache)
+./scripts/agent-env-cleanup.sh --dry-run --global-prune
+
+# Run daemon-wide cleanup with a fixed 30-day age filter and 10 GB cache reservation
+./scripts/agent-env-cleanup.sh --global-prune
+```
+
 The script:
-- Removes volumes matching `learnloop-agent-*` that are not in use by any container.
+
+- Removes unused volumes whose names **strictly start with** `learnloop-agent-` and are not referenced by any container (running or stopped). A name that merely contains the substring (e.g. `backup-learnloop-agent-data`) is never removed.
 - Keeps the N most recent `learnloop-agent-tools:*` images (default 2) and removes the rest.
-- Prunes dangling images and build cache via native Docker commands.
-- Prunes stale git worktrees via `git worktree prune`.
+- Prunes stale git worktrees via `git worktree prune` (dry-run uses `git worktree prune --dry-run --verbose`).
+- Requires Docker to be reachable; aborts non-zero before any cleanup if the daemon is unavailable.
+- With `--global-prune`, additionally runs `docker image prune -f` and a guarded build-cache prune that keeps a 10 GB reservation and prunes cache older than 30 days. It selects the prune command by Docker/buildx CLI capability (preferring `docker buildx prune -f --filter 'until=720h' --reserved-space 10GB`, falling back to `docker builder prune -f --filter 'until=720h' --keep-storage 10GB`) and fails rather than running an unbounded prune if neither capacity flag is supported.
+- `--help` works without a Docker daemon.
+
+> CAUTION: `--global-prune` removes dangling images and build cache from the whole Docker daemon, including images/cache belonging to other projects. It is off by default and must be requested explicitly.
 
 Docker Compose smoke validation tests (requires running Compose stack):
 

--- a/scripts/agent-env-cleanup.sh
+++ b/scripts/agent-env-cleanup.sh
@@ -2,12 +2,22 @@
 #
 # Disk cleanup for agent environment artifacts left by scripts/agent-env.sh.
 #
+# By default this script is SCOPED to LearnLoop agent resources only:
+# unused volumes whose names start with "learnloop-agent-", old
+# learnloop-agent-tools images, and stale git worktree metadata in this repo.
+#
+# Daemon-wide Docker cleanup (dangling images and shared build-cache pruning)
+# is opt-in via --global-prune and may affect OTHER projects on this machine.
+#
 # Usage: scripts/agent-env-cleanup.sh [options]
 #
 # Options:
-#   --dry-run          Preview actions without removing anything.
-#   --keep-images N    Keep the N most recent learnloop-agent-tools images (default: 2).
-#   --help, -h         Show usage.
+#   --dry-run            Preview actions without removing anything.
+#   --keep-images N      Keep the N most recent learnloop-agent-tools images (default: 2).
+#   --global-prune       Also run daemon-wide docker image prune and build-cache
+#                        pruning (30-day age, 10 GB reservation). Affects other
+#                        projects. Off by default.
+#   --help, -h           Show usage. Works without a Docker daemon.
 #
 # See DEVELOPMENT.md for full documentation.
 
@@ -16,15 +26,33 @@ set -euo pipefail
 DRY_RUN=false
 KEEP_IMAGES=2
 HELP_REQUESTED=false
+GLOBAL_PRUNE=false
+
+VOLUME_PREFIX="learnloop-agent-"
+IMAGE_REF="learnloop-agent-tools"
+# Fixed policy for opt-in build-cache pruning: 30 days, 10 GB reserved.
+CACHE_UNTIL="720h"
+CACHE_RESERVE="10GB"
 
 usage() {
   cat <<'EOF'
 Usage: scripts/agent-env-cleanup.sh [options]
 
+By default only LearnLoop agent resources are cleaned up:
+unused learnloop-agent-* volumes, old learnloop-agent-tools images,
+and stale git worktree metadata in this repository.
+
 Options:
-  --dry-run          Preview actions without removing anything.
-  --keep-images N    Keep the N most recent learnloop-agent-tools images (default: 2).
-  --help, -h         Show this message.
+  --dry-run            Preview actions without removing anything.
+  --keep-images N      Keep the N most recent learnloop-agent-tools images (default: 2).
+  --global-prune       ALSO run daemon-wide docker image prune and build-cache
+                       pruning. Affects OTHER projects on this Docker daemon.
+                       Uses a fixed 30-day age filter and a 10 GB cache reservation.
+  --help, -h           Show this message. Does not require a working Docker daemon.
+
+CAUTION: --global-prune removes dangling images and build cache from the whole
+Docker daemon, including images/cache belonging to other projects. It is off
+by default and must be requested explicitly.
 EOF
 }
 
@@ -42,6 +70,9 @@ parse_args() {
         KEEP_IMAGES="$2"
         shift
         ;;
+      --global-prune)
+        GLOBAL_PRUNE=true
+        ;;
       --help|-h)
         HELP_REQUESTED=true
         ;;
@@ -55,6 +86,15 @@ parse_args() {
   done
 }
 
+# Fail fast if the Docker daemon is not reachable. Called after help/arg
+# parsing and before any resource discovery or removal.
+docker_preflight() {
+  if ! docker info >/dev/null 2>&1; then
+    printf 'Error: Docker daemon is not available. Aborting before any cleanup.\n' >&2
+    return 1
+  fi
+}
+
 # Check if a Docker volume is in use by any container (running or stopped).
 # Returns 0 (true) if in use, 1 (false) if not. Safe under set -e.
 volume_in_use() {
@@ -63,24 +103,43 @@ volume_in_use() {
   [[ -n "$names" ]]
 }
 
-# List agent volumes (matching learnloop-agent-) not in use by any container.
+# Emit unused agent volumes with a strict prefix check. Docker's volume name
+# filter is a substring match, so we re-validate each name in shell to avoid
+# deleting unrelated volumes whose names merely contain the prefix text.
+# Failures from docker volume ls propagate via the captured exit status.
 list_unused_agent_volumes() {
+  local raw rc
+  raw="$(docker volume ls --filter "name=${VOLUME_PREFIX}" --format '{{.Name}}' 2>&1)" || {
+    rc=$?
+    printf 'Error: docker volume ls failed: %s\n' "$raw" >&2
+    return "$rc"
+  }
   local vol
   while IFS= read -r vol; do
     [[ -z "$vol" ]] && continue
+    # Strict prefix check; Docker's --filter is a substring match.
+    case "$vol" in
+      "${VOLUME_PREFIX}"*) ;;
+      *) continue ;;
+    esac
     if volume_in_use "$vol"; then
       continue
     fi
     printf '%s\n' "$vol"
-  done < <(docker volume ls --filter "name=learnloop-agent-" --format '{{.Name}}')
+  done <<< "$raw"
 }
 
 # List learnloop-agent-tools images, newest first by creation time.
+# Failures from docker images propagate via the captured exit status.
 list_agent_tools_images() {
-  docker images --filter "reference=learnloop-agent-tools:*" \
-    --format '{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}' \
-    | sort -t$'\t' -k1,1 -r \
-    | cut -f2
+  local raw rc
+  raw="$(docker images --filter "reference=${IMAGE_REF}:*" \
+    --format '{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}' 2>&1)" || {
+    rc=$?
+    printf 'Error: docker images failed: %s\n' "$raw" >&2
+    return "$rc"
+  }
+  printf '%s' "$raw" | sort -t$'\t' -k1,1 -r | cut -f2
 }
 
 prune_agent_volumes() {
@@ -101,7 +160,7 @@ prune_agent_volumes() {
 }
 
 prune_old_images() {
-  local images=() i
+  local images=() i line
   while IFS= read -r line; do
     [[ -n "$line" ]] && images+=("$line")
   done < <(list_agent_tools_images)
@@ -125,19 +184,90 @@ prune_old_images() {
   done
 }
 
+# Detect whether a Docker CLI subcommand supports a given flag by scanning its
+# --help output for an exact flag token. Args: <flag> <command...>.
+# Returns 0 if supported, 1 otherwise.
+supports_flag() {
+  local flag="$1"; shift
+  local help_out
+  help_out="$("$@" --help 2>&1)" || return 1
+  printf '%s\n' "$help_out" | grep -Eq "(^|[[:space:]])${flag}([[:space:]]|=|\$)"
+}
+
+# Choose the guarded build-cache prune command by capability, not by OS.
+# Prefer buildx --reserved-space; fall back to builder --keep-storage; fail
+# if neither capacity flag is available. Emits the chosen command text.
+select_cache_prune_cmd() {
+  local cmd
+  if docker buildx version >/dev/null 2>&1 \
+    && supports_flag --reserved-space docker buildx prune; then
+    cmd="docker buildx prune -f --filter 'until=${CACHE_UNTIL}' --reserved-space ${CACHE_RESERVE}"
+  elif supports_flag --keep-storage docker builder prune; then
+    cmd="docker builder prune -f --filter 'until=${CACHE_UNTIL}' --keep-storage ${CACHE_RESERVE}"
+  else
+    printf 'Error: --global-prune requires a Docker/buildx CLI that supports either\n' >&2
+    printf '       "--reserved-space" (buildx prune) or "--keep-storage" (builder prune)\n' >&2
+    printf '       for bounded build-cache pruning. No unbounded fallback is allowed.\n' >&2
+    return 1
+  fi
+  printf '%s\n' "$cmd"
+}
+
 prune_dangling_and_cache() {
+  if [[ "$GLOBAL_PRUNE" != true ]]; then
+    return 0
+  fi
+
+  printf '  WARNING: --global-prune removes dangling images and build cache from the\n'
+  printf '           ENTIRE Docker daemon, including resources from OTHER projects.\n'
+
   if [[ "$DRY_RUN" == true ]]; then
     printf '  [dry-run] would run: docker image prune -f\n'
-    printf '  [dry-run] would run: docker builder prune -f\n'
+    # Inventory of dangling images for dry-run visibility.
+    local dangling
+    if dangling="$(docker images --filter 'dangling=true' \
+        --format '{{.ID}}\t{{.Repository}}:{{.Tag}}\t{{.Size}}' 2>/dev/null)"; then
+      local dcount=0 line
+      while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        if [[ $dcount -eq 0 ]]; then
+          printf '  [dry-run] dangling image candidates (may belong to other projects):\n'
+        fi
+        printf '    %s\n' "$line"
+        dcount=$((dcount + 1))
+      done <<< "$dangling"
+      printf '  [dry-run] dangling image candidate count: %d\n' "$dcount"
+    else
+      printf '  [dry-run] could not enumerate dangling images (docker images failed).\n'
+    fi
+    # Build-cache summary (inventory/estimate; Docker has no exact dry-run for prune).
+    local cache_cmd
+    if ! cache_cmd="$(select_cache_prune_cmd)"; then
+      return 1
+    fi
+    printf '  [dry-run] would run: %s\n' "$cache_cmd"
+    printf '  [dry-run] note: Docker has no exact dry-run for builder prune; cache info is an inventory.\n'
+    if docker buildx du >/dev/null 2>&1; then
+      docker buildx du 2>/dev/null | sed 's/^/    /' || true
+    elif docker system df 2>/dev/null | grep -i build >/dev/null; then
+      docker system df 2>/dev/null | grep -i build | sed 's/^/    /' || true
+    fi
   else
     docker image prune -f
-    docker builder prune -f
+    local cache_cmd
+    if ! cache_cmd="$(select_cache_prune_cmd)"; then
+      return 1
+    fi
+    # shellcheck disable=SC2086
+    eval "$cache_cmd"
   fi
 }
 
 prune_worktrees() {
   if [[ "$DRY_RUN" == true ]]; then
-    printf '  [dry-run] would run: git worktree prune\n'
+    printf '  [dry-run] stale git worktree preview:\n'
+    git worktree prune --dry-run --verbose 2>/dev/null | sed 's/^/    /' || \
+      printf '    (no stale worktree metadata or git unavailable)\n'
   else
     git worktree prune
     printf '  Pruned stale git worktrees.\n'
@@ -151,8 +281,15 @@ main() {
     return 0
   fi
 
+  docker_preflight || return $?
+
   printf '=== Agent environment disk cleanup ===\n'
   [[ "$DRY_RUN" == true ]] && printf '(dry-run mode — no changes will be made)\n'
+  if [[ "$GLOBAL_PRUNE" == true ]]; then
+    printf '(--global-prune enabled — includes daemon-wide Docker cleanup)\n'
+  else
+    printf '(scoped to LearnLoop agent resources only)\n'
+  fi
 
   printf '\n--- Unused agent volumes ---\n'
   prune_agent_volumes
@@ -160,8 +297,10 @@ main() {
   printf '\n--- Old agent tools images (keeping %s most recent) ---\n' "$KEEP_IMAGES"
   prune_old_images
 
-  printf '\n--- Dangling images and build cache ---\n'
-  prune_dangling_and_cache
+  if [[ "$GLOBAL_PRUNE" == true ]]; then
+    printf '\n--- Daemon-wide dangling images and build cache (--global-prune) ---\n'
+    prune_dangling_and_cache || return $?
+  fi
 
   printf '\n--- Stale git worktrees ---\n'
   prune_worktrees

--- a/scripts/agent-env.test.sh
+++ b/scripts/agent-env.test.sh
@@ -319,6 +319,435 @@ test_cleanup_keep_images_logic() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# Deterministic stub-based regression tests for scripts/agent-env-cleanup.sh.
+# These run the cleanup script with fake `docker`/`git` on PATH so they never
+# touch the developer's real Docker daemon or git worktree metadata.
+# ---------------------------------------------------------------------------
+
+# Create a temp bin dir containing fake `docker` and `git`, set up env, and
+# export globals: STUB_BIN_DIR, STUB_MUTATIONS. Caller is in repo root.
+setup_stub_env() {
+  STUB_BIN_DIR="$(mktemp -d)"
+  STUB_MUTATIONS="$(mktemp)"
+  : > "$STUB_MUTATIONS"
+
+  cat > "$STUB_BIN_DIR/docker" <<'DOCKER_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+MUT="${STUB_MUTATIONS:-/dev/null}"
+case "${1:-}" in
+  info)
+    [[ "${STUB_DOCKER_INFO:-0}" == "1" ]] && exit 1
+    exit 0
+    ;;
+  volume)
+    case "${2:-}" in
+      ls) printf '%s\n' "${STUB_VOLUMES:-}" | sed '/^$/d' ;;
+      rm) printf 'docker volume rm %s\n' "${3:-}" >> "$MUT" ;;
+    esac
+    ;;
+  ps)
+    name=""
+    for a in "$@"; do case "$a" in volume=*) name="${a#volume=}" ;; esac; done
+    for v in ${STUB_INUSE_VOLUMES:-}; do
+      [[ "$v" == "$name" ]] && { printf 'some-container\n'; exit 0; }
+    done
+    ;;
+  images)
+    dangling=false
+    for a in "$@"; do case "$a" in dangling=true) dangling=true ;; esac; done
+    if [[ "$dangling" == true ]]; then
+      printf '%s\n' "${STUB_DANGLING:-}" | sed '/^$/d'
+    else
+      printf '%s\n' "${STUB_IMAGES:-}" | sed '/^$/d'
+    fi
+    ;;
+  rmi) printf 'docker rmi %s\n' "${2:-}" >> "$MUT" ;;
+  image)
+    printf 'docker image prune %s\n' "${2:-}" >> "$MUT"
+    ;;
+  buildx)
+    case "${2:-}" in
+      version) [[ "${STUB_BUILDX:-0}" == "0" ]] && exit 0 || exit 1 ;;
+      prune)
+        if [[ "${3:-}" == "--help" ]]; then
+          [[ "${STUB_BUILDX:-0}" == "0" ]] && printf -- '--reserved-space\n'
+          exit 0
+        fi
+        printf 'docker buildx prune %s\n' "${*:3}" >> "$MUT"
+        ;;
+      du) printf 'RECLAIMABLE 1.0GB\n' ;;
+    esac
+    ;;
+  builder)
+    case "${2:-}" in
+      prune)
+        if [[ "${3:-}" == "--help" ]]; then
+          [[ "${STUB_BUILDER_KEEPSTORAGE:-0}" == "0" ]] && printf -- '--keep-storage\n'
+          exit 0
+        fi
+        printf 'docker builder prune %s\n' "${*:3}" >> "$MUT"
+        ;;
+    esac
+    ;;
+esac
+exit 0
+DOCKER_EOF
+  chmod +x "$STUB_BIN_DIR/docker"
+
+  cat > "$STUB_BIN_DIR/git" <<'GIT_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+MUT="${STUB_MUTATIONS:-/dev/null}"
+case "${1:-}" in
+  worktree)
+    case "${2:-}" in
+      prune)
+        if [[ "${3:-}" == "--dry-run" ]]; then
+          printf 'would prune: /tmp/stale-worktree\n'
+        else
+          printf 'git worktree prune\n' >> "$MUT"
+        fi
+        ;;
+    esac
+    ;;
+esac
+exit 0
+GIT_EOF
+  chmod +x "$STUB_BIN_DIR/git"
+
+  export PATH="$STUB_BIN_DIR:$PATH"
+  export STUB_MUTATIONS STUB_DOCKER_INFO=0 STUB_VOLUMES="" STUB_INUSE_VOLUMES=""
+  export STUB_IMAGES="" STUB_DANGLING="" STUB_BUILDX=0 STUB_BUILDER_KEEPSTORAGE=0
+}
+
+teardown_stub_env() {
+  [ -n "${STUB_BIN_DIR:-}" ] && rm -rf "$STUB_BIN_DIR"
+  [ -n "${STUB_MUTATIONS:-}" ] && rm -f "$STUB_MUTATIONS"
+  unset STUB_BIN_DIR STUB_MUTATIONS STUB_DOCKER_INFO STUB_VOLUMES \
+    STUB_INUSE_VOLUMES STUB_IMAGES STUB_DANGLING STUB_BUILDX STUB_BUILDER_KEEPSTORAGE
+}
+
+# Run the cleanup script under the stubbed PATH. Args passed through.
+run_cleanup_stubbed() {
+  STUB_MUTATIONS="$STUB_MUTATIONS" \
+    env PATH="$STUB_BIN_DIR:$PATH" \
+    bash "$script_dir/agent-env-cleanup.sh" "$@"
+}
+
+mutations_log() { cat "$STUB_MUTATIONS" 2>/dev/null || true; }
+mutations_count() { wc -l < "$STUB_MUTATIONS" 2>/dev/null | tr -d ' ' || printf '0'; }
+
+test_cleanup_default_never_prunes() {
+  printf '%s\n' "test_cleanup_default_never_prunes"
+  setup_stub_env
+  STUB_VOLUMES="learnloop-agent-abc
+learnloop-agent-def" STUB_IMAGES="2026-07-01 00:00:00 +0000	learnloop-agent-tools:old
+2026-07-10 00:00:00 +0000	learnloop-agent-tools:new" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'image prune\|buildx prune\|builder prune'; then
+    fail "default run must not invoke any daemon-wide prune"
+  else
+    pass "default run never invokes daemon-wide prune"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_global_prune_invokes_commands() {
+  printf '%s\n' "test_cleanup_global_prune_invokes_commands"
+  setup_stub_env
+  STUB_BUILDX=0 STUB_IMAGES="2026-07-01 00:00:00 +0000	learnloop-agent-tools:old
+2026-07-10 00:00:00 +0000	learnloop-agent-tools:new" \
+    run_cleanup_stubbed --global-prune >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker image prune'; then
+    pass "--global-prune invokes docker image prune"
+  else
+    fail "--global-prune invokes docker image prune"
+  fi
+  if printf '%s' "$log" | grep -q 'buildx prune.*--reserved-space 10GB'; then
+    pass "--global-prune uses buildx prune with --reserved-space 10GB"
+  else
+    fail "--global-prune uses buildx prune with --reserved-space 10GB"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_dry_run_global_no_mutations() {
+  printf '%s\n' "test_cleanup_dry_run_global_no_mutations"
+  setup_stub_env
+  export STUB_BUILDX=0 STUB_VOLUMES="learnloop-agent-abc"
+  export STUB_DANGLING="deadbeef	other-project:latest	100MB"
+  export STUB_IMAGES="2026-07-01 00:00:00 +0000	learnloop-agent-tools:old
+2026-07-05 00:00:00 +0000	learnloop-agent-tools:mid
+2026-07-10 00:00:00 +0000	learnloop-agent-tools:new"
+  local out rc
+  out="$(run_cleanup_stubbed --dry-run --global-prune 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail "dry-run --global-prune should exit zero (rc=$rc)"
+  else
+    pass "dry-run --global-prune exits zero"
+  fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "dry-run --global-prune must not mutate (log: $(mutations_log))"
+  else
+    pass "dry-run --global-prune makes no mutations"
+  fi
+  if printf '%s' "$out" | grep -q 'other-project:latest'; then
+    pass "dry-run --global-prune lists dangling image candidates"
+  else
+    fail "dry-run --global-prune lists dangling image candidates"
+  fi
+  if printf '%s' "$out" | grep -q 'reserved-space 10GB'; then
+    pass "dry-run --global-prune shows selected guarded command"
+  else
+    fail "dry-run --global-prune shows selected guarded command"
+  fi
+  if printf '%s' "$out" | grep -q 'WARNING'; then
+    pass "dry-run --global-prune prints cross-project warning"
+  else
+    fail "dry-run --global-prune prints cross-project warning"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_buildx_capability_selection() {
+  printf '%s\n' "test_cleanup_buildx_capability_selection"
+  setup_stub_env
+  # Modern buildx with --reserved-space.
+  STUB_BUILDX=0 run_cleanup_stubbed --global-prune >/dev/null 2>&1
+  if mutations_log | grep -q 'buildx prune.*--reserved-space 10GB'; then
+    pass "modern buildx selects --reserved-space 10GB"
+  else
+    fail "modern buildx selects --reserved-space 10GB"
+  fi
+  teardown_stub_env
+
+  setup_stub_env
+  # No buildx, but legacy builder has --keep-storage.
+  STUB_BUILDX=1 STUB_BUILDER_KEEPSTORAGE=0 run_cleanup_stubbed --global-prune >/dev/null 2>&1
+  if mutations_log | grep -q 'builder prune.*--keep-storage 10GB'; then
+    pass "legacy builder selects --keep-storage 10GB"
+  else
+    fail "legacy builder selects --keep-storage 10GB"
+  fi
+  teardown_stub_env
+
+  setup_stub_env
+  # Neither capacity flag available: must fail without pruning cache.
+  local rc=0
+  STUB_BUILDX=1 STUB_BUILDER_KEEPSTORAGE=1 run_cleanup_stubbed --global-prune >/dev/null 2>&1 && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    pass "unsupported CLI fails non-zero without pruning cache"
+  else
+    fail "unsupported CLI fails non-zero without pruning cache (rc=$rc)"
+  fi
+  if mutations_log | grep -q 'buildx prune\|builder prune'; then
+    fail "unsupported CLI must not run any cache prune"
+  else
+    pass "unsupported CLI runs no cache prune"
+  fi
+  # image prune runs before cache selection per script order; ensure it did run
+  # but cache prune did not.
+  if mutations_log | grep -q 'docker image prune'; then
+    pass "unsupported CLI still attempted image prune before cache selection"
+  else
+    fail "unsupported CLI still attempted image prune before cache selection"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_default_dry_run_scoped_nonmutating() {
+  printf '%s\n' "test_cleanup_default_dry_run_scoped_nonmutating"
+  setup_stub_env
+  export STUB_VOLUMES="learnloop-agent-abc
+learnloop-agent-def"
+  export STUB_IMAGES="2026-07-01 00:00:00 +0000	learnloop-agent-tools:old
+2026-07-05 00:00:00 +0000	learnloop-agent-tools:mid
+2026-07-10 00:00:00 +0000	learnloop-agent-tools:new"
+  local out rc
+  out="$(run_cleanup_stubbed --dry-run 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then fail "default dry-run exits zero (rc=$rc)"; else pass "default dry-run exits zero"; fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "default dry-run must not mutate (log: $(mutations_log))"
+  else
+    pass "default dry-run makes no mutations"
+  fi
+  if printf '%s' "$out" | grep -q 'learnloop-agent-abc'; then
+    pass "default dry-run lists scoped volume candidates"
+  else
+    fail "default dry-run lists scoped volume candidates"
+  fi
+  if printf '%s' "$out" | grep -q 'learnloop-agent-tools:old'; then
+    pass "default dry-run lists scoped image candidates"
+  else
+    fail "default dry-run lists scoped image candidates"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_help_without_docker() {
+  printf '%s\n' "test_cleanup_help_without_docker"
+  setup_stub_env
+  STUB_DOCKER_INFO=1
+  local out rc
+  out="$(run_cleanup_stubbed --help 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -eq 0 ]; then pass "--help exits zero without Docker"; else fail "--help exits zero without Docker (rc=$rc)"; fi
+  if printf '%s' "$out" | grep -q 'global-prune'; then
+    pass "--help documents --global-prune"
+  else
+    fail "--help documents --global-prune"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_docker_unavailable_nonzero() {
+  printf '%s\n' "test_cleanup_docker_unavailable_nonzero"
+  setup_stub_env
+  STUB_DOCKER_INFO=1
+  local out rc
+  out="$(run_cleanup_stubbed --dry-run 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "Docker unavailable exits non-zero"; else fail "Docker unavailable exits non-zero (rc=$rc)"; fi
+  if printf '%s' "$out" | grep -qi 'Docker daemon is not available'; then
+    pass "Docker unavailable prints clear error"
+  else
+    fail "Docker unavailable prints clear error"
+  fi
+  # Must not claim zero resources were found.
+  if printf '%s' "$out" | grep -q 'No unused agent volumes found'; then
+    fail "Docker unavailable must not print misleading zero-resource success"
+  else
+    pass "Docker unavailable does not print misleading zero-resource success"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_volume_prefix_strict() {
+  printf '%s\n' "test_cleanup_volume_prefix_strict"
+  setup_stub_env
+  # Substring trap: "backup-learnloop-agent-data" must NEVER be selected.
+  STUB_VOLUMES="learnloop-agent-keep
+backup-learnloop-agent-data
+learnloop-agent-drop" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker volume rm backup-learnloop-agent-data'; then
+    fail "substring volume must never be removed"
+  else
+    pass "substring volume is never removed"
+  fi
+  if printf '%s' "$log" | grep -q 'docker volume rm learnloop-agent-keep'; then
+    pass "true-prefix volume learnloop-agent-keep is removed"
+  else
+    fail "true-prefix volume learnloop-agent-keep is removed"
+  fi
+  if printf '%s' "$log" | grep -q 'docker volume rm learnloop-agent-drop'; then
+    pass "true-prefix volume learnloop-agent-drop is removed"
+  else
+    fail "true-prefix volume learnloop-agent-drop is removed"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_volume_inuse_protected() {
+  printf '%s\n' "test_cleanup_volume_inuse_protected"
+  setup_stub_env
+  STUB_VOLUMES="learnloop-agent-free
+learnloop-agent-used" \
+    STUB_INUSE_VOLUMES="learnloop-agent-used" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker volume rm learnloop-agent-used'; then
+    fail "in-use volume must be protected"
+  else
+    pass "in-use volume is protected"
+  fi
+  if printf '%s' "$log" | grep -q 'docker volume rm learnloop-agent-free'; then
+    pass "free volume is removed"
+  else
+    fail "free volume is removed"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_dry_run_worktree_preview() {
+  printf '%s\n' "test_cleanup_dry_run_worktree_preview"
+  setup_stub_env
+  local out rc
+  out="$(run_cleanup_stubbed --dry-run 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -eq 0 ]; then pass "dry-run worktree preview exits zero"; else fail "dry-run worktree preview exits zero (rc=$rc)"; fi
+  if printf '%s' "$out" | grep -q 'would prune'; then
+    pass "dry-run uses git worktree prune --dry-run --verbose output"
+  else
+    fail "dry-run uses git worktree prune --dry-run --verbose output"
+  fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "dry-run must not mutate worktree metadata"
+  else
+    pass "dry-run does not mutate worktree metadata"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_normal_mode_worktree_prune() {
+  printf '%s\n' "test_cleanup_normal_mode_worktree_prune"
+  setup_stub_env
+  run_cleanup_stubbed >/dev/null 2>&1
+  if mutations_log | grep -q 'git worktree prune'; then
+    pass "normal mode runs git worktree prune"
+  else
+    fail "normal mode runs git worktree prune"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_help_global_prune_documented() {
+  printf '%s\n' "test_cleanup_help_global_prune_documented"
+  local out
+  out="$(bash "$script_dir/agent-env-cleanup.sh" --help 2>&1)" || true
+  if printf '%s' "$out" | grep -qi 'global-prune'; then
+    pass "help text mentions --global-prune"
+  else
+    fail "help text mentions --global-prune"
+  fi
+}
+
+test_cleanup_keep_images_stubbed() {
+  printf '%s\n' "test_cleanup_keep_images_stubbed"
+  setup_stub_env
+  STUB_IMAGES="2026-07-01 00:00:00 +0000	learnloop-agent-tools:a
+2026-07-02 00:00:00 +0000	learnloop-agent-tools:b
+2026-07-03 00:00:00 +0000	learnloop-agent-tools:c
+2026-07-04 00:00:00 +0000	learnloop-agent-tools:d" \
+    run_cleanup_stubbed --keep-images 2 >/dev/null 2>&1
+  local log removed
+  log="$(mutations_log)"
+  removed="$(printf '%s\n' "$log" | grep -c 'docker rmi' || true)"
+  # 4 images, keep 2 newest (c,d), remove a,b -> 2 rmi calls.
+  if [ "$removed" -eq 2 ]; then
+    pass "keep-images=2 removes 2 of 4 agent tools images"
+  else
+    fail "keep-images=2 removes 2 of 4 agent tools images (got $removed)"
+  fi
+  if printf '%s' "$log" | grep -q 'docker rmi learnloop-agent-tools:a'; then
+    pass "oldest image a is removed"
+  else
+    fail "oldest image a is removed"
+  fi
+  if ! printf '%s' "$log" | grep -q 'docker rmi learnloop-agent-tools:d'; then
+    pass "newest image d is kept"
+  else
+    fail "newest image d is kept"
+  fi
+  teardown_stub_env
+}
+
 main() {
   printf 'Running agent-env.sh regression tests in %s\n' "$repo_root"
   reset_repo_root
@@ -334,6 +763,19 @@ main() {
   test_cleanup_dry_run_no_changes
   test_cleanup_dry_run_help_text
   test_cleanup_keep_images_logic
+  test_cleanup_default_never_prunes
+  test_cleanup_global_prune_invokes_commands
+  test_cleanup_dry_run_global_no_mutations
+  test_cleanup_buildx_capability_selection
+  test_cleanup_default_dry_run_scoped_nonmutating
+  test_cleanup_help_without_docker
+  test_cleanup_docker_unavailable_nonzero
+  test_cleanup_volume_prefix_strict
+  test_cleanup_volume_inuse_protected
+  test_cleanup_dry_run_worktree_preview
+  test_cleanup_normal_mode_worktree_prune
+  test_cleanup_help_global_prune_documented
+  test_cleanup_keep_images_stubbed
 
   printf '\nResults: %d passed, %d failed\n' "$passed" "$failed"
   if [ "$failed" -gt 0 ]; then


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Default cleanup is now scoped to LearnLoop agent resources only: unused `learnloop-agent-*` volumes, old `learnloop-agent-tools:*` images, and stale git worktree metadata.
- Daemon-wide `docker image prune` and shared build-cache pruning move behind an explicit `--global-prune` flag using a fixed 30-day/10-GB policy, selected by Docker/buildx CLI capability (not OS name).
- Added Docker preflight (aborts non-zero before any cleanup if daemon unavailable), strict `learnloop-agent-` prefix check for volume deletion, reliable Docker failure propagation, and a fully non-mutating dry-run with scoped/global inventory.
- Added deterministic stub-based regression tests using fake `docker`/`git` on PATH so tests never touch the real Docker daemon or git worktree metadata.
- Updated `DEVELOPMENT.md` disk-cleanup section to document safe defaults vs opt-in cross-project pruning.

## Linked Issue

Closes #494

## Issue Alignment

This PR implements the issue by:

- Changing default cleanup scope to LearnLoop agent resources only; daemon-wide pruning is opt-in via `--global-prune`.
- Adding `--global-prune` parsing, help text, state, prominent cross-project warning, and conditional execution.
- Adding a Docker preflight (`docker info`) after help/arg handling and before any removal; failures abort non-zero.
- Enforcing a strict `learnloop-agent-` prefix check in shell (Docker `--filter name=` is a substring match).
- Preserving existing `--keep-images N` behavior for `learnloop-agent-tools:*` images.
- Implementing capability-based cache-prune selection: prefers `docker buildx prune -f --filter until=720h --reserved-space 10GB`, falls back to `docker builder prune -f --filter until=720h --keep-storage 10GB`, fails safely if neither capacity flag is supported (no unbounded fallback).
- Restructuring volume/image discovery to capture Docker command output and propagate failures to the main shell exit status.
- Implementing non-mutating dry-run inventories for scoped volumes/images, opt-in global dangling-image candidates, build-cache summary, and native `git worktree prune --dry-run --verbose`.
- Keeping the implementation Bash 3.2-compatible (no `mapfile`/`readarray`/associative arrays).
- Updating `DEVELOPMENT.md` to distinguish safe default cleanup from optional cross-project Docker pruning.

Scope covered:

- `--global-prune` option, Docker preflight, strict volume prefix, capability-based cache-prune selection, failure propagation, dry-run inventory, documentation, and stub-based regression tests.

Out of scope / intentionally not included:

- Dedicated LearnLoop BuildKit/buildx builder (explicit follow-up).
- Configurable cache age/storage flags (fixed 30-day/10-GB policy per issue).
- General-purpose Docker disk-management tool.
- Changes to `scripts/agent-env.sh`, `Dockerfile.agent`, or agent Compose topology.

## Implementation Notes

- `select_cache_prune_cmd` probes CLI capability via `--help` output parsing rather than OS name, so it works on macOS Docker 29.5.2 and Linux Docker 29.6.1.
- `supports_flag` greps the subcommand `--help` for the exact flag token to avoid false positives from unrelated help text.
- Volume discovery captures `docker volume ls` output into a variable and iterates via a here-string, so failures propagate instead of being swallowed by process substitution.
- `--help` returns before the Docker preflight, so it works without a running daemon.

## Tests

Commands run:

- `bash -n scripts/agent-env-cleanup.sh scripts/agent-env.test.sh` — passed (syntax OK)
- `bash scripts/agent-env.test.sh` — passed (80 passed, 0 failed)
- `./scripts/agent-env-cleanup.sh --help` — passed (exits 0, documents `--global-prune`)
- `./scripts/agent-env-cleanup.sh --dry-run` — passed (scoped, non-mutating, lists volume candidates)
- `./scripts/agent-env-cleanup.sh --dry-run --global-prune` — passed (shows WARNING, dangling candidates, selected `docker buildx prune -f --filter 'until=720h' --reserved-space 10GB`)
- `DOCKER_HOST=unix:///tmp/learnloop-nonexistent-docker.sock ./scripts/agent-env-cleanup.sh --dry-run` — passed (exits 1, prints daemon-unavailable error, no misleading zero-resource success)
- `DOCKER_HOST=unix:///tmp/learnloop-nonexistent-docker.sock ./scripts/agent-env-cleanup.sh --help` — passed (exits 0 without Docker)
- `git diff --check` — passed (no whitespace errors)
- `docker buildx version` / `docker buildx prune --help` — confirmed `--reserved-space` supported on this host; `docker builder prune --help` confirmed `--keep-storage` available as fallback

Automated tests added or updated:

- `test_cleanup_default_never_prunes` — default run never invokes `docker image prune`, `buildx prune`, or `builder prune`.
- `test_cleanup_global_prune_invokes_commands` — `--global-prune` invokes `docker image prune` and `buildx prune ... --reserved-space 10GB`.
- `test_cleanup_dry_run_global_no_mutations` — `--dry-run --global-prune` exits 0, makes no mutations, lists dangling candidates, shows guarded command, prints WARNING.
- `test_cleanup_buildx_capability_selection` — modern buildx selects `--reserved-space`; legacy builder selects `--keep-storage`; unsupported CLI fails non-zero without cache prune.
- `test_cleanup_default_dry_run_scoped_nonmutating` — default dry-run exits 0, no mutations, lists scoped volume and image candidates.
- `test_cleanup_help_without_docker` — `--help` exits 0 and documents `--global-prune` when Docker is unavailable.
- `test_cleanup_docker_unavailable_nonzero` — Docker preflight exits non-zero, prints clear error, no misleading zero-resource success.
- `test_cleanup_volume_prefix_strict` — substring volume `backup-learnloop-agent-data` never removed; true-prefix volumes removed.
- `test_cleanup_volume_inuse_protected` — in-use volume protected; free volume removed.
- `test_cleanup_dry_run_worktree_preview` — dry-run uses `git worktree prune --dry-run --verbose` output and makes no mutations.
- `test_cleanup_normal_mode_worktree_prune` — normal mode runs `git worktree prune`.
- `test_cleanup_help_global_prune_documented` — help text mentions `--global-prune`.
- `test_cleanup_keep_images_stubbed` — `--keep-images 2` removes 2 of 4 agent tools images, oldest removed, newest kept.

Manual verification:

- Verified `--help`, default `--dry-run`, and `--dry-run --global-prune` output against a running Docker daemon; no actual Docker resource or git worktree metadata changed during dry-run.
- Verified the nonexistent-socket command exits non-zero.
- Did not run non-dry-run `--global-prune` on the shared developer daemon (per issue guidance); mutating command construction validated through stubs.

## Deviations From Issue Plan

None.

## Follow-Up Work

Potential future isolation through a dedicated LearnLoop BuildKit/buildx builder is intentionally excluded per the issue Follow-Up Work section.