### PR TITLE
fix(agent): propagate Docker discovery failures before cleanup mutations

### DIFF
--- a/scripts/agent-env-cleanup.sh
+++ b/scripts/agent-env-cleanup.sh
@@ -96,25 +96,33 @@ docker_preflight() {
 }
 
 # Check if a Docker volume is in use by any container (running or stopped).
-# Returns 0 (true) if in use, 1 (false) if not. Safe under set -e.
+# Returns 0 (in use), 1 (not in use), or 2 (docker ps -a failed). Callers must
+# distinguish a genuine "not in use" result (1) from a discovery failure (2)
+# so a failed lookup aborts planning instead of being treated as unused and
+# silently deleted. Safe under set -e: callers capture status explicitly.
 volume_in_use() {
-  local names
-  names="$(docker ps -a --filter "volume=$1" --format '{{.Names}}')" || return 0
+  local names rc
+  names="$(docker ps -a --filter "volume=$1" --format '{{.Names}}' 2>&1)" || {
+    rc=$?
+    printf 'Error: docker ps -a failed for volume %s: %s\n' "$1" "$names" >&2
+    return 2
+  }
   [[ -n "$names" ]]
 }
 
-# Emit unused agent volumes with a strict prefix check. Docker's volume name
-# filter is a substring match, so we re-validate each name in shell to avoid
-# deleting unrelated volumes whose names merely contain the prefix text.
-# Failures from docker volume ls propagate via the captured exit status.
-list_unused_agent_volumes() {
-  local raw rc
+# Discover unused agent volumes with a strict prefix check. Docker's volume
+# name filter is a substring match, so we re-validate each name in shell to
+# avoid deleting unrelated volumes whose names merely contain the prefix
+# text. Output and status are captured by the caller BEFORE any mutation:
+# the result is consumed through `output="$(plan_unused_agent_volumes)" || …`,
+# never through process substitution, which would hide the exit status.
+plan_unused_agent_volumes() {
+  local raw rc vol vrc
   raw="$(docker volume ls --filter "name=${VOLUME_PREFIX}" --format '{{.Name}}' 2>&1)" || {
     rc=$?
     printf 'Error: docker volume ls failed: %s\n' "$raw" >&2
     return "$rc"
   }
-  local vol
   while IFS= read -r vol; do
     [[ -z "$vol" ]] && continue
     # Strict prefix check; Docker's --filter is a substring match.
@@ -122,16 +130,21 @@ list_unused_agent_volumes() {
       "${VOLUME_PREFIX}"*) ;;
       *) continue ;;
     esac
-    if volume_in_use "$vol"; then
-      continue
-    fi
+    volume_in_use "$vol" && vrc=0 || vrc=$?
+    case $vrc in
+      0) continue ;;       # in use
+      1) ;;                # not in use, keep as candidate
+      *) return "$vrc" ;;  # discovery failure, abort planning
+    esac
     printf '%s\n' "$vol"
   done <<< "$raw"
 }
 
-# List learnloop-agent-tools images, newest first by creation time.
-# Failures from docker images propagate via the captured exit status.
-list_agent_tools_images() {
+# Discover learnloop-agent-tools images, newest first by creation time.
+# Output and status are captured by the caller BEFORE any mutation. Never
+# consume this through process substitution; the exit status would not
+# propagate.
+plan_agent_tools_images() {
   local raw rc
   raw="$(docker images --filter "reference=${IMAGE_REF}:*" \
     --format '{{.CreatedAt}}\t{{.Repository}}:{{.Tag}}' 2>&1)" || {
@@ -142,6 +155,8 @@ list_agent_tools_images() {
   printf '%s' "$raw" | sort -t$'\t' -k1,1 -r | cut -f2
 }
 
+# Remove planned volumes. Args: <newline-separated volume list>.
+# A zero-length list prints the empty-resource success message.
 prune_agent_volumes() {
   local vol count=0
   while IFS= read -r vol; do
@@ -153,19 +168,20 @@ prune_agent_volumes() {
       printf '  Removed volume: %s\n' "$vol"
     fi
     count=$((count + 1))
-  done < <(list_unused_agent_volumes)
+  done <<< "$1"
   if [[ $count -eq 0 ]]; then
     printf '  No unused agent volumes found.\n'
   fi
 }
 
+# Remove old planned images. Args: <newline-separated image list>.
 prune_old_images() {
-  local images=() i line
+  local images=() i line total
   while IFS= read -r line; do
     [[ -n "$line" ]] && images+=("$line")
-  done < <(list_agent_tools_images)
+  done <<< "$1"
 
-  local total=${#images[@]}
+  total=${#images[@]}
   if [[ $total -le $KEEP_IMAGES ]]; then
     printf '  Keeping all %d agent tools images (keep-images=%d).\n' "$total" "$KEEP_IMAGES"
     return 0
@@ -213,10 +229,11 @@ select_cache_prune_cmd() {
   printf '%s\n' "$cmd"
 }
 
+# Daemon-wide dangling-image and build-cache pruning. Args: <chosen cache cmd>.
+# The cache command was validated during planning; passing it in guarantees a
+# discovery-time capability failure aborts before any mutation.
 prune_dangling_and_cache() {
-  if [[ "$GLOBAL_PRUNE" != true ]]; then
-    return 0
-  fi
+  local cache_cmd="$1"
 
   printf '  WARNING: --global-prune removes dangling images and build cache from the\n'
   printf '           ENTIRE Docker daemon, including resources from OTHER projects.\n'
@@ -240,11 +257,6 @@ prune_dangling_and_cache() {
     else
       printf '  [dry-run] could not enumerate dangling images (docker images failed).\n'
     fi
-    # Build-cache summary (inventory/estimate; Docker has no exact dry-run for prune).
-    local cache_cmd
-    if ! cache_cmd="$(select_cache_prune_cmd)"; then
-      return 1
-    fi
     printf '  [dry-run] would run: %s\n' "$cache_cmd"
     printf '  [dry-run] note: Docker has no exact dry-run for builder prune; cache info is an inventory.\n'
     if docker buildx du >/dev/null 2>&1; then
@@ -254,10 +266,6 @@ prune_dangling_and_cache() {
     fi
   else
     docker image prune -f
-    local cache_cmd
-    if ! cache_cmd="$(select_cache_prune_cmd)"; then
-      return 1
-    fi
     # shellcheck disable=SC2086
     eval "$cache_cmd"
   fi
@@ -283,6 +291,29 @@ main() {
 
   docker_preflight || return $?
 
+  # --- Discovery / planning phase -----------------------------------------
+  # Gather all scoped candidates and validate optional --global-prune
+  # capability BEFORE any Docker or Git mutation. A failure here aborts with
+  # zero mutations and no misleading success output. Outputs are captured with
+  # `output="$(producer)" || return $?` because Bash does not propagate the
+  # exit status of process substitution (`< <(...)`) to the outer loop.
+  local planned_volumes planned_images cache_cmd=""
+  if ! planned_volumes="$(plan_unused_agent_volumes)"; then
+    printf 'Error: volume discovery failed; aborting before any cleanup.\n' >&2
+    return 1
+  fi
+  if ! planned_images="$(plan_agent_tools_images)"; then
+    printf 'Error: image discovery failed; aborting before any cleanup.\n' >&2
+    return 1
+  fi
+  if [[ "$GLOBAL_PRUNE" == true ]]; then
+    if ! cache_cmd="$(select_cache_prune_cmd)"; then
+      return 1
+    fi
+  fi
+
+  # --- Mutation phase -----------------------------------------------------
+  # All discovery/planning succeeded; it is now safe to remove resources.
   printf '=== Agent environment disk cleanup ===\n'
   [[ "$DRY_RUN" == true ]] && printf '(dry-run mode — no changes will be made)\n'
   if [[ "$GLOBAL_PRUNE" == true ]]; then
@@ -292,14 +323,14 @@ main() {
   fi
 
   printf '\n--- Unused agent volumes ---\n'
-  prune_agent_volumes
+  prune_agent_volumes "$planned_volumes"
 
   printf '\n--- Old agent tools images (keeping %s most recent) ---\n' "$KEEP_IMAGES"
-  prune_old_images
+  prune_old_images "$planned_images"
 
   if [[ "$GLOBAL_PRUNE" == true ]]; then
     printf '\n--- Daemon-wide dangling images and build cache (--global-prune) ---\n'
-    prune_dangling_and_cache || return $?
+    prune_dangling_and_cache "$cache_cmd" || return $?
   fi
 
   printf '\n--- Stale git worktrees ---\n'

--- a/scripts/agent-env.test.sh
+++ b/scripts/agent-env.test.sh
@@ -343,11 +343,15 @@ case "${1:-}" in
     ;;
   volume)
     case "${2:-}" in
-      ls) printf '%s\n' "${STUB_VOLUMES:-}" | sed '/^$/d' ;;
+      ls)
+        [[ "${STUB_VOLUME_LS_FAIL:-0}" == "1" ]] && { printf 'volume ls boom\n' >&2; exit 1; }
+        printf '%s\n' "${STUB_VOLUMES:-}" | sed '/^$/d'
+        ;;
       rm) printf 'docker volume rm %s\n' "${3:-}" >> "$MUT" ;;
     esac
     ;;
   ps)
+    [[ "${STUB_PS_FAIL:-0}" == "1" ]] && { printf 'ps boom\n' >&2; exit 1; }
     name=""
     for a in "$@"; do case "$a" in volume=*) name="${a#volume=}" ;; esac; done
     for v in ${STUB_INUSE_VOLUMES:-}; do
@@ -355,6 +359,7 @@ case "${1:-}" in
     done
     ;;
   images)
+    [[ "${STUB_IMAGES_FAIL:-0}" == "1" ]] && { printf 'images boom\n' >&2; exit 1; }
     dangling=false
     for a in "$@"; do case "$a" in dangling=true) dangling=true ;; esac; done
     if [[ "$dangling" == true ]]; then
@@ -420,13 +425,15 @@ GIT_EOF
   export PATH="$STUB_BIN_DIR:$PATH"
   export STUB_MUTATIONS STUB_DOCKER_INFO=0 STUB_VOLUMES="" STUB_INUSE_VOLUMES=""
   export STUB_IMAGES="" STUB_DANGLING="" STUB_BUILDX=0 STUB_BUILDER_KEEPSTORAGE=0
+  export STUB_VOLUME_LS_FAIL=0 STUB_PS_FAIL=0 STUB_IMAGES_FAIL=0
 }
 
 teardown_stub_env() {
   [ -n "${STUB_BIN_DIR:-}" ] && rm -rf "$STUB_BIN_DIR"
   [ -n "${STUB_MUTATIONS:-}" ] && rm -f "$STUB_MUTATIONS"
   unset STUB_BIN_DIR STUB_MUTATIONS STUB_DOCKER_INFO STUB_VOLUMES \
-    STUB_INUSE_VOLUMES STUB_IMAGES STUB_DANGLING STUB_BUILDX STUB_BUILDER_KEEPSTORAGE
+    STUB_INUSE_VOLUMES STUB_IMAGES STUB_DANGLING STUB_BUILDX STUB_BUILDER_KEEPSTORAGE \
+    STUB_VOLUME_LS_FAIL STUB_PS_FAIL STUB_IMAGES_FAIL
 }
 
 # Run the cleanup script under the stubbed PATH. Args passed through.
@@ -538,7 +545,8 @@ test_cleanup_buildx_capability_selection() {
   teardown_stub_env
 
   setup_stub_env
-  # Neither capacity flag available: must fail without pruning cache.
+  # Neither capacity flag available: must fail during planning before any
+  # global or scoped mutation, including docker image prune.
   local rc=0
   STUB_BUILDX=1 STUB_BUILDER_KEEPSTORAGE=1 run_cleanup_stubbed --global-prune >/dev/null 2>&1 && rc=$? || rc=$?
   if [ "$rc" -ne 0 ]; then
@@ -551,12 +559,12 @@ test_cleanup_buildx_capability_selection() {
   else
     pass "unsupported CLI runs no cache prune"
   fi
-  # image prune runs before cache selection per script order; ensure it did run
-  # but cache prune did not.
+  # With two-phase planning, capability selection happens BEFORE mutation, so
+  # docker image prune must NOT run when global cache capability is unsupported.
   if mutations_log | grep -q 'docker image prune'; then
-    pass "unsupported CLI still attempted image prune before cache selection"
+    fail "unsupported CLI must not run docker image prune before failing (planning aborts first)"
   else
-    fail "unsupported CLI still attempted image prune before cache selection"
+    pass "unsupported CLI runs no docker image prune (planning aborts before mutation)"
   fi
   teardown_stub_env
 }
@@ -748,6 +756,143 @@ test_cleanup_keep_images_stubbed() {
   teardown_stub_env
 }
 
+# Regression tests for post-preflight discovery failures. Each must exit
+# non-zero, perform zero Docker/Git mutations, and print no misleading
+# empty-resource or completion message. These would pass on the new
+# two-phase implementation and fail on the PR #495 process-substitution code.
+
+test_cleanup_volume_ls_failure_aborts() {
+  printf '%s\n' "test_cleanup_volume_ls_failure_aborts"
+  setup_stub_env
+  STUB_VOLUME_LS_FAIL=1
+  STUB_VOLUMES="learnloop-agent-abc"
+  local out rc
+  out="$(run_cleanup_stubbed 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "volume ls failure exits non-zero"; else fail "volume ls failure exits non-zero (rc=$rc)"; fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "volume ls failure must perform zero mutations (log: $(mutations_log))"
+  else
+    pass "volume ls failure performs zero mutations"
+  fi
+  if printf '%s' "$out" | grep -q 'No unused agent volumes found'; then
+    fail "volume ls failure must not print misleading empty-resource success"
+  else
+    pass "volume ls failure prints no misleading empty-resource success"
+  fi
+  if printf '%s' "$out" | grep -q '=== Done ==='; then
+    fail "volume ls failure must not print completion marker"
+  else
+    pass "volume ls failure prints no completion marker"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_images_failure_aborts_after_volume_discovery() {
+  printf '%s\n' "test_cleanup_images_failure_aborts_after_volume_discovery"
+  setup_stub_env
+  # Removable volume candidates are present and discoverable, but image
+  # discovery fails. No volumes may be removed and no later cleanup may run.
+  STUB_VOLUMES="learnloop-agent-abc"
+  STUB_IMAGES_FAIL=1
+  local out rc
+  out="$(run_cleanup_stubbed 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "images failure exits non-zero"; else fail "images failure exits non-zero (rc=$rc)"; fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "images failure must perform zero mutations (log: $(mutations_log))"
+  else
+    pass "images failure performs zero mutations"
+  fi
+  if printf '%s' "$out" | grep -q 'docker volume rm learnloop-agent-abc'; then
+    fail "images failure must not remove discovered volumes"
+  else
+    pass "images failure does not remove discovered volumes"
+  fi
+  if printf '%s' "$out" | grep -q '=== Done ==='; then
+    fail "images failure must not print completion marker"
+  else
+    pass "images failure prints no completion marker"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_ps_failure_aborts() {
+  printf '%s\n' "test_cleanup_ps_failure_aborts"
+  setup_stub_env
+  # volume_in_use calls docker ps -a; a failure there must abort planning
+  # rather than being treated as "in use" and continuing.
+  STUB_VOLUMES="learnloop-agent-abc"
+  STUB_PS_FAIL=1
+  local out rc
+  out="$(run_cleanup_stubbed 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "ps failure exits non-zero"; else fail "ps failure exits non-zero (rc=$rc)"; fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "ps failure must perform zero mutations (log: $(mutations_log))"
+  else
+    pass "ps failure performs zero mutations"
+  fi
+  if printf '%s' "$out" | grep -q 'docker volume rm learnloop-agent-abc'; then
+    fail "ps failure must not remove volumes"
+  else
+    pass "ps failure does not remove volumes"
+  fi
+  if printf '%s' "$out" | grep -q '=== Done ==='; then
+    fail "ps failure must not print completion marker"
+  else
+    pass "ps failure prints no completion marker"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_empty_discovery_success() {
+  printf '%s\n' "test_cleanup_empty_discovery_success"
+  setup_stub_env
+  # Successful empty discovery still prints the correct empty-resource message.
+  STUB_VOLUMES="" STUB_IMAGES=""
+  local out rc
+  out="$(run_cleanup_stubbed 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -eq 0 ]; then pass "empty discovery exits zero"; else fail "empty discovery exits zero (rc=$rc)"; fi
+  if printf '%s' "$out" | grep -q 'No unused agent volumes found'; then
+    pass "empty discovery prints empty-resource message"
+  else
+    fail "empty discovery prints empty-resource message"
+  fi
+  if printf '%s' "$out" | grep -q '=== Done ==='; then
+    pass "empty discovery prints completion marker"
+  else
+    fail "empty discovery prints completion marker"
+  fi
+  # Empty discovery removes no Docker resources; git worktree prune is the
+  # only expected mutation in normal mode.
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker volume rm\|docker rmi\|image prune\|buildx prune\|builder prune'; then
+    fail "empty discovery must not remove any Docker resources (log: $log)"
+  else
+    pass "empty discovery removes no Docker resources"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_dry_run_empty_discovery_success() {
+  printf '%s\n' "test_cleanup_dry_run_empty_discovery_success"
+  setup_stub_env
+  STUB_VOLUMES="" STUB_IMAGES=""
+  local out rc
+  out="$(run_cleanup_stubbed --dry-run 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -eq 0 ]; then pass "dry-run empty discovery exits zero"; else fail "dry-run empty discovery exits zero (rc=$rc)"; fi
+  if printf '%s' "$out" | grep -q 'No unused agent volumes found'; then
+    pass "dry-run empty discovery prints empty-resource message"
+  else
+    fail "dry-run empty discovery prints empty-resource message"
+  fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "dry-run empty discovery must not mutate (log: $(mutations_log))"
+  else
+    pass "dry-run empty discovery makes no mutations"
+  fi
+  teardown_stub_env
+}
+
 main() {
   printf 'Running agent-env.sh regression tests in %s\n' "$repo_root"
   reset_repo_root
@@ -776,6 +921,11 @@ main() {
   test_cleanup_normal_mode_worktree_prune
   test_cleanup_help_global_prune_documented
   test_cleanup_keep_images_stubbed
+  test_cleanup_volume_ls_failure_aborts
+  test_cleanup_images_failure_aborts_after_volume_discovery
+  test_cleanup_ps_failure_aborts
+  test_cleanup_empty_discovery_success
+  test_cleanup_dry_run_empty_discovery_success
 
   printf '\nResults: %d passed, %d failed\n' "$passed" "$failed"
   if [ "$failed" -gt 0 ]; then


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- `scripts/agent-env-cleanup.sh` now uses a two-phase discovery/mutation flow: all scoped volume/image candidates and the optional `--global-prune` cache capability are validated BEFORE any Docker or Git mutation.
- Discovery producers are consumed via `output="$(producer)" || return $?` instead of Bash process substitution (`< <(...)`), which does not propagate the producer's exit status to the outer loop.
- `volume_in_use` now returns distinct outcomes (0 in use / 1 not in use / 2 failure) so a `docker ps -a` failure aborts planning instead of being silently treated as "in use" or "unused".
- The fake Docker stub gains independent failure controls (`STUB_VOLUME_LS_FAIL`, `STUB_PS_FAIL`, `STUB_IMAGES_FAIL`) for post-preflight discovery-failure regression tests.

## Linked Issue

Closes #496

## Issue Alignment

This PR implements the issue by:

- Removing process-substitution boundaries that hide fallible producer exit status (`prune_agent_volumes`, `prune_old_images`).
- Introducing `plan_unused_agent_volumes` / `plan_agent_tools_images` whose output and status are captured by the caller before any mutation.
- Making per-volume container-usage lookup distinguish a successful "not in use" result from a `docker ps -a` failure.
- Building a complete cleanup plan (including guarded cache-prune capability selection when `--global-prune` is enabled) before mutation.
- Aborting without running later Docker or Git cleanup phases when planning fails, with zero mutations and no misleading success output.
- Extending deterministic stub tests for post-preflight discovery failures and zero-mutation guarantees.
- Preserving macOS Bash 3.2 and Linux Bash compatibility (no `mapfile`/`readarray`/associative arrays).

Scope covered:

- Remove process-substitution boundaries that hide failures from fallible resource producers.
- Explicitly capture output and exit status of volume and image discovery before iterating.
- Make per-volume container-usage lookup distinguish a successful "not in use" result from a Docker command failure.
- Introduce a planning/discovery phase that gathers all scoped candidates before any removal.
- When `--global-prune` is requested, select/validate the guarded cache-prune command during planning, before any scoped or global mutation.
- Abort without running later Docker or Git cleanup phases when planning fails.
- Extend deterministic stub tests for post-preflight discovery failures and zero-mutation guarantees.
- Preserve macOS Bash 3.2 and Linux Bash compatibility.

Out of scope / intentionally not included:

- Adding stopped-container cleanup (dependent follow-up #497).
- Changing which successfully discovered volumes or images are eligible for cleanup.
- Adding container, network, or volume age policies.
- Implementing transactional rollback after a mutation itself fails.
- Changing the fixed 30-day/10-GB global build-cache policy.
- Refactoring unrelated agent-environment code.

## Implementation Notes

- `volume_in_use` returns 0 (in use), 1 (not in use), or 2 (docker ps -a failed). `plan_unused_agent_volumes` inspects the return code explicitly (`volume_in_use "$vol" && vrc=0 || vrc=$?`) and returns non-zero on a discovery failure.
- `plan_unused_agent_volumes` / `plan_agent_tools_images` replace the old `list_*` producers; callers capture their output and status with `output="$(producer)" || return $?`, never through process substitution.
- `prune_agent_volumes` / `prune_old_images` now take the pre-built candidate list as `$1` and iterate over it with `<<< "$1"` (the list is already in hand, so there is no fallible producer inside the loop).
- `prune_dangling_and_cache` takes the planning-selected cache command as `$1`; the `select_cache_prune_cmd` call was moved out of the mutation phase into the planning phase of `main`.
- `main` is split into a discovery/planning phase and a mutation phase. Any planning failure returns non-zero before the `=== Agent environment disk cleanup ===` banner is printed, so no empty-resource success message or `=== Done ===` marker appears on a failure path.
- `test_cleanup_buildx_capability_selection` was updated: with planning-before-mutation, an unsupported CLI now aborts before `docker image prune` (previously `docker image prune` ran before cache selection). The test now asserts no `docker image prune` mutation occurs on the unsupported-CLI path.
- No Bash 4+ features are used; the implementation is compatible with macOS Bash 3.2.

## Tests

Commands run:

- `bash -n scripts/agent-env-cleanup.sh scripts/agent-env.test.sh` — passed (syntax OK)
- `bash scripts/agent-env.test.sh` — passed (99 passed, 0 failed)
- `./scripts/agent-env-cleanup.sh --dry-run` — passed (rc=0, lists scoped candidates, no mutations)
- `./scripts/agent-env-cleanup.sh --dry-run --global-prune` — passed (rc=0, shows selected guarded command, no mutations)
- `git diff --check` — passed (no whitespace errors)

Automated tests added or updated:

- `test_cleanup_volume_ls_failure_aborts`: `STUB_VOLUME_LS_FAIL=1` → exit non-zero, zero mutations, no `No unused agent volumes found`, no `=== Done ===`.
- `test_cleanup_images_failure_aborts_after_volume_discovery`: removable volume candidates present + `STUB_IMAGES_FAIL=1` → exit non-zero, volumes not removed, zero mutations, no `=== Done ===`.
- `test_cleanup_ps_failure_aborts`: `STUB_PS_FAIL=1` → exit non-zero, zero mutations, volumes not removed, no `=== Done ===`.
- `test_cleanup_empty_discovery_success`: successful empty discovery → exit zero, prints `No unused agent volumes found`, no Docker resource removal, git worktree prune is the only expected mutation.
- `test_cleanup_dry_run_empty_discovery_success`: dry-run empty discovery → exit zero, empty-resource message, no mutations.
- Updated `test_cleanup_buildx_capability_selection`: unsupported CLI now aborts before `docker image prune` (planning-before-mutation).

Manual verification:

- Ran the stub-based regression suite (`bash scripts/agent-env.test.sh`): 99 passed, 0 failed.
- Ran `--dry-run` and `--dry-run --global-prune` against the real Docker daemon on this machine: both exit zero, list scoped candidates, and make no mutations.
- Verified syntax with `bash -n` and whitespace with `git diff --check`.

Stub commands / environment variables used to reproduce each discovery failure:

- `docker volume ls` failure: `STUB_VOLUME_LS_FAIL=1` (fake docker prints `volume ls boom` to stderr and exits 1).
- `docker images` failure: `STUB_IMAGES_FAIL=1` (fake docker prints `images boom` to stderr and exits 1).
- `docker ps -a --filter volume=...` failure: `STUB_PS_FAIL=1` (fake docker prints `ps boom` to stderr and exits 1).
- All failure-path tests assert `mutations_count == 0` and no `=== Done ===` / empty-resource success output.

## Deviations From Issue Plan

None. The implementation follows the chosen two-phase discovery/mutation approach exactly.

## Follow-Up Work

- #497 (Remove stopped containers from inactive LearnLoop agent projects): explicitly depends on this issue and is left for a follow-up PR.
