### PR TITLE
feat(agent): remove stopped containers from inactive agent projects

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -205,14 +205,17 @@ The agent environment:
 
 Over time, agent sessions accumulate Docker volumes, old `learnloop-agent-tools:*` images, dangling layers, and build cache. Use `scripts/agent-env-cleanup.sh` to reclaim disk space.
 
-By default the script is **scoped to LearnLoop agent resources only**: it removes unused `learnloop-agent-*` volumes, old `learnloop-agent-tools:*` images, and stale git worktree metadata in this repository. It does not touch dangling images or build cache from other projects.
+By default the script is **scoped to LearnLoop agent resources only**: it removes stopped containers from fully inactive `learnloop-agent-*` Compose projects, unused `learnloop-agent-*` volumes, old `learnloop-agent-tools:*` images, and stale git worktree metadata in this repository. It does not touch dangling images or build cache from other projects.
+
+> CAUTION: Default cleanup removes stopped containers from fully inactive LearnLoop agent Compose projects. A project is eligible only if **every** container in it is in `exited`, `created`, or `dead` state. If any container is running, paused, restarting, or removing, the entire project is skipped. Removal uses non-forced `docker container rm` (no `-f`, `--force`, `-v`, or `--volumes`), so it does not directly delete volumes — but removing stopped containers makes their referenced named volumes eligible for removal by the existing unused-volume phase in a subsequent cleanup run. Non-zero container exit codes are shown in the output before removal so debugging context is visible.
 
 ```bash
 # Preview what would be cleaned up without removing anything
 ./scripts/agent-env-cleanup.sh --dry-run
 
 # Remove unused agent volumes, old tools images (keeping 2 most recent),
-# and stale git worktree metadata
+# and stale git worktree metadata. Also removes stopped containers from
+# fully inactive learnloop-agent-* Compose projects before volume cleanup.
 ./scripts/agent-env-cleanup.sh
 
 # Keep a different number of recent tools images
@@ -231,10 +234,12 @@ Daemon-wide Docker cleanup (dangling images and shared build-cache pruning) is o
 
 The script:
 
+- Removes stopped containers from fully inactive `learnloop-agent-*` Compose projects whose `com.docker.compose.project` label **strictly starts with** `learnloop-agent-`. A project is eligible only if every member is in `exited`, `created`, or `dead` state; any active member causes the entire project to be skipped. Removal uses non-forced `docker container rm` without volume flags. The normal `learnloop` project, unlabeled containers, and substring false positives are never selected. Container removal runs before volume cleanup so newly unreferenced named volumes become eligible in subsequent runs.
 - Removes unused volumes whose names **strictly start with** `learnloop-agent-` and are not referenced by any container (running or stopped). A name that merely contains the substring (e.g. `backup-learnloop-agent-data`) is never removed.
 - Keeps the N most recent `learnloop-agent-tools:*` images (default 2) and removes the rest.
 - Prunes stale git worktrees via `git worktree prune` (dry-run uses `git worktree prune --dry-run --verbose`).
 - Requires Docker to be reachable; aborts non-zero before any cleanup if the daemon is unavailable.
+- Discovers all container, volume, and image candidates before any mutation. A discovery failure aborts with zero mutations and no misleading success output. A removal failure (e.g. a container started between planning and removal) stops all subsequent cleanup phases.
 - With `--global-prune`, additionally runs `docker image prune -f` and a guarded build-cache prune that keeps a 10 GB reservation and prunes cache older than 30 days. It selects the prune command by Docker/buildx CLI capability (preferring `docker buildx prune -f --filter 'until=720h' --reserved-space 10GB`, falling back to `docker builder prune -f --filter 'until=720h' --keep-storage 10GB`) and fails rather than running an unbounded prune if neither capacity flag is supported.
 - `--help` works without a Docker daemon.
 

--- a/scripts/agent-env-cleanup.sh
+++ b/scripts/agent-env-cleanup.sh
@@ -3,6 +3,7 @@
 # Disk cleanup for agent environment artifacts left by scripts/agent-env.sh.
 #
 # By default this script is SCOPED to LearnLoop agent resources only:
+# stopped containers from fully inactive learnloop-agent-* Compose projects,
 # unused volumes whose names start with "learnloop-agent-", old
 # learnloop-agent-tools images, and stale git worktree metadata in this repo.
 #
@@ -39,6 +40,7 @@ usage() {
 Usage: scripts/agent-env-cleanup.sh [options]
 
 By default only LearnLoop agent resources are cleaned up:
+stopped containers from fully inactive learnloop-agent-* Compose projects,
 unused learnloop-agent-* volumes, old learnloop-agent-tools images,
 and stale git worktree metadata in this repository.
 
@@ -108,6 +110,90 @@ volume_in_use() {
     return 2
   }
   [[ -n "$names" ]]
+}
+
+# Discover stopped containers from fully inactive LearnLoop agent Compose
+# projects. Ownership is determined by the exact `com.docker.compose.project`
+# label (not container name), which must strictly start with `learnloop-agent-`.
+# A project is eligible only if EVERY discovered member is in `exited`,
+# `created`, or `dead` state. If any member is active or has an unknown state,
+# the entire project is skipped. Output: tab-delimited candidate records on
+# stdout (id\tname\tstate\tstatus\tproject\tservice). Skipped projects are
+# reported on stderr. Returns non-zero on discovery failure. Never consume
+# this through process substitution; the exit status would not propagate.
+plan_inactive_agent_containers() {
+  local raw rc
+  raw="$(docker ps -a --filter 'label=com.docker.compose.project' \
+    --format '{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Status}}\t{{.Label "com.docker.compose.project"}}\t{{.Label "com.docker.compose.service"}}' 2>&1)" || {
+    rc=$?
+    printf 'Error: docker ps -a (container discovery) failed: %s\n' "$raw" >&2
+    return "$rc"
+  }
+
+  # Extract unique project labels that strictly start with the agent prefix.
+  local projects proj
+  projects="$(printf '%s\n' "$raw" | awk -F'\t' '$5 != "" {print $5}' | sort -u)"
+
+  local candidates="" active line id name state status project service
+  while IFS= read -r proj; do
+    [[ -z "$proj" ]] && continue
+    # Strict prefix check; Docker's label filter matches label existence, not
+    # value prefix. We validate the value to exclude substring false positives
+    # such as "backup-learnloop-agent-data".
+    case "$proj" in
+      "${VOLUME_PREFIX}"*) ;;
+      *) continue ;;
+    esac
+
+    # Gather all containers for this project and check if all are removable.
+    active=false
+    local proj_records=""
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      IFS=$'\t' read -r id name state status project service <<< "$line"
+      case "$state" in
+        exited|created|dead) proj_records="${proj_records}${line}"$'\n' ;;
+        *) active=true ;;
+      esac
+    done <<< "$(printf '%s\n' "$raw" | awk -F'\t' -v p="$proj" '$5 == p')"
+
+    if [[ "$active" == true ]]; then
+      printf '  Skip: project %s has active or unknown-state members; skipping all containers.\n' "$proj" >&2
+    else
+      candidates="${candidates}${proj_records}"
+    fi
+  done <<< "$projects"
+
+  printf '%s' "$candidates"
+}
+
+# Remove planned containers. Args: <newline-separated tab-delimited records>.
+# Uses only non-forced `docker container rm` without -f, --force, -v, or
+# --volumes. A removal failure (e.g. a container started between planning and
+# removal) propagates non-zero and stops all subsequent cleanup phases.
+prune_agent_containers() {
+  local count=0 line id name state status project service
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    IFS=$'\t' read -r id name state status project service <<< "$line"
+    if [[ "$DRY_RUN" == true ]]; then
+      printf '  [dry-run] would remove container: %s (%s, project=%s, service=%s, state=%s, %s)\n' \
+        "$id" "$name" "$project" "$service" "$state" "$status"
+    else
+      # Show status (includes exit code for exited containers) before removal.
+      printf '  Removing container: %s (%s, project=%s, %s)\n' "$id" "$name" "$project" "$status"
+      if docker container rm "$id" >/dev/null 2>&1; then
+        printf '  Removed container: %s\n' "$id"
+      else
+        printf 'Error: docker container rm %s failed; aborting subsequent cleanup.\n' "$id" >&2
+        return 1
+      fi
+    fi
+    count=$((count + 1))
+  done <<< "$1"
+  if [[ $count -eq 0 ]]; then
+    printf '  No inactive agent containers found.\n'
+  fi
 }
 
 # Discover unused agent volumes with a strict prefix check. Docker's volume
@@ -297,7 +383,11 @@ main() {
   # zero mutations and no misleading success output. Outputs are captured with
   # `output="$(producer)" || return $?` because Bash does not propagate the
   # exit status of process substitution (`< <(...)`) to the outer loop.
-  local planned_volumes planned_images cache_cmd=""
+  local planned_containers planned_volumes planned_images cache_cmd=""
+  if ! planned_containers="$(plan_inactive_agent_containers)"; then
+    printf 'Error: container discovery failed; aborting before any cleanup.\n' >&2
+    return 1
+  fi
   if ! planned_volumes="$(plan_unused_agent_volumes)"; then
     printf 'Error: volume discovery failed; aborting before any cleanup.\n' >&2
     return 1
@@ -314,6 +404,8 @@ main() {
 
   # --- Mutation phase -----------------------------------------------------
   # All discovery/planning succeeded; it is now safe to remove resources.
+  # Container removal runs before volume removal so newly unreferenced named
+  # volumes become eligible for the existing scoped-volume logic in a later run.
   printf '=== Agent environment disk cleanup ===\n'
   [[ "$DRY_RUN" == true ]] && printf '(dry-run mode — no changes will be made)\n'
   if [[ "$GLOBAL_PRUNE" == true ]]; then
@@ -321,6 +413,9 @@ main() {
   else
     printf '(scoped to LearnLoop agent resources only)\n'
   fi
+
+  printf '\n--- Inactive agent containers ---\n'
+  prune_agent_containers "$planned_containers" || return $?
 
   printf '\n--- Unused agent volumes ---\n'
   prune_agent_volumes "$planned_volumes"

--- a/scripts/agent-env.test.sh
+++ b/scripts/agent-env.test.sh
@@ -351,6 +351,19 @@ case "${1:-}" in
     esac
     ;;
   ps)
+    # Detect container discovery (label filter) vs volume-in-use check
+    has_label=false
+    for a in "$@"; do
+      case "$a" in
+        label=com.docker.compose.project) has_label=true ;;
+      esac
+    done
+    if [[ "$has_label" == true ]]; then
+      [[ "${STUB_CONTAINER_LS_FAIL:-0}" == "1" ]] && { printf 'container discovery boom\n' >&2; exit 1; }
+      printf '%s\n' "${STUB_CONTAINERS:-}" | sed '/^$/d'
+      exit 0
+    fi
+    # Volume-in-use check (existing behavior)
     [[ "${STUB_PS_FAIL:-0}" == "1" ]] && { printf 'ps boom\n' >&2; exit 1; }
     name=""
     for a in "$@"; do case "$a" in volume=*) name="${a#volume=}" ;; esac; done
@@ -371,6 +384,16 @@ case "${1:-}" in
   rmi) printf 'docker rmi %s\n' "${2:-}" >> "$MUT" ;;
   image)
     printf 'docker image prune %s\n' "${2:-}" >> "$MUT"
+    ;;
+  container)
+    case "${2:-}" in
+      rm)
+        for rid in ${STUB_CONTAINER_RM_RACE_IDS:-}; do
+          [[ "$rid" == "${3:-}" ]] && { printf 'container rm failed (race): %s\n' "${3:-}" >&2; exit 1; }
+        done
+        printf 'docker container rm %s\n' "${3:-}" >> "$MUT"
+        ;;
+    esac
     ;;
   buildx)
     case "${2:-}" in
@@ -426,6 +449,7 @@ GIT_EOF
   export STUB_MUTATIONS STUB_DOCKER_INFO=0 STUB_VOLUMES="" STUB_INUSE_VOLUMES=""
   export STUB_IMAGES="" STUB_DANGLING="" STUB_BUILDX=0 STUB_BUILDER_KEEPSTORAGE=0
   export STUB_VOLUME_LS_FAIL=0 STUB_PS_FAIL=0 STUB_IMAGES_FAIL=0
+  export STUB_CONTAINERS="" STUB_CONTAINER_LS_FAIL=0 STUB_CONTAINER_RM_RACE_IDS=""
 }
 
 teardown_stub_env() {
@@ -433,7 +457,8 @@ teardown_stub_env() {
   [ -n "${STUB_MUTATIONS:-}" ] && rm -f "$STUB_MUTATIONS"
   unset STUB_BIN_DIR STUB_MUTATIONS STUB_DOCKER_INFO STUB_VOLUMES \
     STUB_INUSE_VOLUMES STUB_IMAGES STUB_DANGLING STUB_BUILDX STUB_BUILDER_KEEPSTORAGE \
-    STUB_VOLUME_LS_FAIL STUB_PS_FAIL STUB_IMAGES_FAIL
+    STUB_VOLUME_LS_FAIL STUB_PS_FAIL STUB_IMAGES_FAIL \
+    STUB_CONTAINERS STUB_CONTAINER_LS_FAIL STUB_CONTAINER_RM_RACE_IDS
 }
 
 # Run the cleanup script under the stubbed PATH. Args passed through.
@@ -893,6 +918,243 @@ test_cleanup_dry_run_empty_discovery_success() {
   teardown_stub_env
 }
 
+# ---------------------------------------------------------------------------
+# Regression tests for inactive-agent-container cleanup (issue #497).
+# ---------------------------------------------------------------------------
+
+test_cleanup_container_inactive_project_removed() {
+  printf '%s\n' "test_cleanup_container_inactive_project_removed"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (0) 2 hours ago	learnloop-agent-proj1	init-deps
+c2	mongodb-1	exited	Exited (0) 1 hour ago	learnloop-agent-proj1	mongodb" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm c1'; then
+    pass "inactive container c1 is removed"
+  else
+    fail "inactive container c1 is removed"
+  fi
+  if printf '%s' "$log" | grep -q 'docker container rm c2'; then
+    pass "inactive container c2 is removed"
+  else
+    fail "inactive container c2 is removed"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_active_project_skipped() {
+  printf '%s\n' "test_cleanup_container_active_project_skipped"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (0) 2 hours ago	learnloop-agent-proj1	init-deps
+c2	tools-run-1	running	Up 5 minutes	learnloop-agent-proj1	tools" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm c1\|docker container rm c2'; then
+    fail "active project must have no containers removed"
+  else
+    pass "active project has no containers removed"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_learnloop_project_excluded() {
+  printf '%s\n' "test_cleanup_container_learnloop_project_excluded"
+  setup_stub_env
+  STUB_CONTAINERS="c1	mongodb-1	exited	Exited (0) 1 hour ago	learnloop	mongodb" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm c1'; then
+    fail "normal learnloop project must never be selected"
+  else
+    pass "normal learnloop project is never selected"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_substring_excluded() {
+  printf '%s\n' "test_cleanup_container_substring_excluded"
+  setup_stub_env
+  STUB_CONTAINERS="c1	some-service	exited	Exited (0) 1 hour ago	backup-learnloop-agent-data	some-service" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm c1'; then
+    fail "substring project label must never be selected"
+  else
+    pass "substring project label is never selected"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_no_label_excluded() {
+  printf '%s\n' "test_cleanup_container_no_label_excluded"
+  setup_stub_env
+  # Container with a learnloop-agent- name but no Compose project label.
+  STUB_CONTAINERS="c1	learnloop-agent-tools-1	exited	Exited (0) 1 hour ago		tools" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm c1'; then
+    fail "container without project label must never be selected"
+  else
+    pass "container without project label is never selected"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_nonzero_exit_removed() {
+  printf '%s\n' "test_cleanup_container_nonzero_exit_removed"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (1) 3 minutes ago	learnloop-agent-proj1	init-deps" \
+    run_cleanup_stubbed 2>/dev/null
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm c1'; then
+    pass "non-zero exit container is still removed"
+  else
+    fail "non-zero exit container is still removed"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_rm_no_force() {
+  printf '%s\n' "test_cleanup_container_rm_no_force"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (0) 2 hours ago	learnloop-agent-proj1	init-deps" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q -- '-f\|--force\|-v\|--volumes'; then
+    fail "container removal must not use force or volume flags (log: $log)"
+  else
+    pass "container removal uses no force or volume flags"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_before_volumes() {
+  printf '%s\n' "test_cleanup_container_before_volumes"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (0) 2 hours ago	learnloop-agent-proj1	init-deps" \
+    STUB_VOLUMES="learnloop-agent-proj1_frontend_deps" \
+    run_cleanup_stubbed 2>/dev/null
+  local log lines
+  log="$(mutations_log)"
+  # Container rm should appear before volume rm in the mutation log.
+  local cidx vidx
+  cidx="$(printf '%s\n' "$log" | grep -n 'docker container rm' | head -1 | cut -d: -f1)"
+  vidx="$(printf '%s\n' "$log" | grep -n 'docker volume rm' | head -1 | cut -d: -f1)"
+  if [ -n "$cidx" ] && [ -n "$vidx" ] && [ "$cidx" -lt "$vidx" ]; then
+    pass "container removal precedes volume removal"
+  else
+    fail "container removal precedes volume removal (cidx=$cidx vidx=$vidx log=$log)"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_dry_run_no_mutations() {
+  printf '%s\n' "test_cleanup_container_dry_run_no_mutations"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (0) 2 hours ago	learnloop-agent-proj1	init-deps
+c2	tools-1	running	Up 5 minutes	learnloop-agent-proj2	tools"
+  local out rc
+  out="$(run_cleanup_stubbed --dry-run 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -eq 0 ]; then pass "dry-run exits zero"; else fail "dry-run exits zero (rc=$rc)"; fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "dry-run must not mutate (log: $(mutations_log))"
+  else
+    pass "dry-run makes no mutations"
+  fi
+  if printf '%s' "$out" | grep -q 'would remove container: c1'; then
+    pass "dry-run lists container candidates"
+  else
+    fail "dry-run lists container candidates"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_discovery_failure_aborts() {
+  printf '%s\n' "test_cleanup_container_discovery_failure_aborts"
+  setup_stub_env
+  STUB_CONTAINER_LS_FAIL=1
+  local out rc
+  out="$(run_cleanup_stubbed 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "container discovery failure exits non-zero"; else fail "container discovery failure exits non-zero (rc=$rc)"; fi
+  if [ "$(mutations_count)" -ne 0 ]; then
+    fail "container discovery failure must perform zero mutations (log: $(mutations_log))"
+  else
+    pass "container discovery failure performs zero mutations"
+  fi
+  if printf '%s' "$out" | grep -q '=== Done ==='; then
+    fail "container discovery failure must not print completion marker"
+  else
+    pass "container discovery failure prints no completion marker"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_rm_race_aborts() {
+  printf '%s\n' "test_cleanup_container_rm_race_aborts"
+  setup_stub_env
+  STUB_CONTAINERS="c1	init-deps-1	exited	Exited (0) 2 hours ago	learnloop-agent-proj1	init-deps
+c2	mongodb-1	exited	Exited (0) 1 hour ago	learnloop-agent-proj1	mongodb"
+  export STUB_CONTAINER_RM_RACE_IDS="c1"
+  local out rc
+  out="$(run_cleanup_stubbed 2>&1)" && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "container rm race failure exits non-zero"; else fail "container rm race failure exits non-zero (rc=$rc)"; fi
+  # Volume, image, global-prune, and git worktree mutations must not run after
+  # a container removal failure.
+  local log
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker volume rm\|docker rmi\|image prune\|buildx prune\|builder prune\|git worktree prune'; then
+    fail "later cleanup must not run after container rm failure (log: $log)"
+  else
+    pass "later cleanup does not run after container rm failure"
+  fi
+  if printf '%s' "$out" | grep -q '=== Done ==='; then
+    fail "container rm race must not print completion marker"
+  else
+    pass "container rm race prints no completion marker"
+  fi
+  teardown_stub_env
+}
+
+test_cleanup_container_all_states_coverage() {
+  printf '%s\n' "test_cleanup_container_all_states_coverage"
+  setup_stub_env
+  # exited, created, and dead are all removable; one of each.
+  STUB_CONTAINERS="c1	svc-exited	exited	Exited (0) 1h ago	learnloop-agent-st	exit-svc
+c2	svc-created	created	Created	learnloop-agent-st	create-svc
+c3	svc-dead	dead	Dead	learnloop-agent-st	dead-svc" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  local log
+  log="$(mutations_log)"
+  local removed
+  removed="$(printf '%s\n' "$log" | grep -c 'docker container rm' || true)"
+  if [ "$removed" -eq 3 ]; then
+    pass "exited, created, and dead containers are all removed"
+  else
+    fail "exited, created, and dead containers are all removed (got $removed)"
+  fi
+  teardown_stub_env
+
+  setup_stub_env
+  # paused, restarting, removing must cause the project to be skipped.
+  STUB_CONTAINERS="c1	svc-paused	paused	Up (Paused)	learnloop-agent-ps	paused-svc
+c2	svc-exited	exited	Exited (0) 1h ago	learnloop-agent-ps	exit-svc" \
+    run_cleanup_stubbed >/dev/null 2>&1
+  log="$(mutations_log)"
+  if printf '%s' "$log" | grep -q 'docker container rm'; then
+    fail "paused member must cause entire project to be skipped"
+  else
+    pass "paused member causes entire project to be skipped"
+  fi
+  teardown_stub_env
+}
+
 main() {
   printf 'Running agent-env.sh regression tests in %s\n' "$repo_root"
   reset_repo_root
@@ -926,6 +1188,18 @@ main() {
   test_cleanup_ps_failure_aborts
   test_cleanup_empty_discovery_success
   test_cleanup_dry_run_empty_discovery_success
+  test_cleanup_container_inactive_project_removed
+  test_cleanup_container_active_project_skipped
+  test_cleanup_container_learnloop_project_excluded
+  test_cleanup_container_substring_excluded
+  test_cleanup_container_no_label_excluded
+  test_cleanup_container_nonzero_exit_removed
+  test_cleanup_container_rm_no_force
+  test_cleanup_container_before_volumes
+  test_cleanup_container_dry_run_no_mutations
+  test_cleanup_container_discovery_failure_aborts
+  test_cleanup_container_rm_race_aborts
+  test_cleanup_container_all_states_coverage
 
   printf '\nResults: %d passed, %d failed\n' "$passed" "$failed"
   if [ "$failed" -gt 0 ]; then


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- `scripts/agent-env-cleanup.sh` now removes stopped containers from fully inactive `learnloop-agent-*` Compose projects before the existing unused-volume cleanup phase.
- Ownership is determined by the exact `com.docker.compose.project` label (not container name); a strict shell prefix check on the label value excludes the normal `learnloop` project, unlabeled containers, and substring false positives.
- A project is eligible only if every discovered member is in `exited`, `created`, or `dead` state. Any active/unknown member causes the entire project to be skipped.
- Removal uses non-forced `docker container rm` without `-f`, `--force`, `-v`, or `--volumes`. Status (including exit code) is shown before removal. A removal failure stops all subsequent phases.

## Linked Issue

Closes #497

## Issue Alignment

This PR implements the issue by:

- Adding `plan_inactive_agent_containers` to the discovery/planning phase: enumerates Compose-managed containers via `com.docker.compose.project` labels, groups by exact project, validates all members are removable, and reports skipped projects on stderr.
- Adding `prune_agent_containers` to the mutation phase: removes candidates with `docker container rm` (non-forced, no volume flags), shows status before removal, and propagates removal failures non-zero.
- Integrating both into the fail-before-mutation model from #496: all container/volume/image discovery and cache-capability validation complete before any Docker or Git mutation. Container removal is the first mutation, before volume removal.
- Extending the fake Docker stub with labeled containers, multiple projects, lifecycle states, discovery failure, and race simulation.
- Updating `DEVELOPMENT.md` and help text to document the new behavior and risks.

Scope covered:

- Discover Compose-managed containers using `com.docker.compose.project` labels.
- Strictly validate the `learnloop-agent-` project-label prefix in shell.
- Group discovered containers by Compose project and determine whether the entire project is inactive.
- Treat only `exited`, `created`, and `dead` as removable states.
- Skip the entire project when any container has another state.
- Remove eligible containers with `docker container rm <id>` before unused agent volume and old agent image cleanup.
- Surface non-zero exit codes prominently while still treating those stopped containers as removable.
- Add dry-run output, deterministic regression tests, and documentation.
- Preserve macOS Bash 3.2 and Linux Bash compatibility.

Out of scope / intentionally not included:

- Removing containers from the ordinary `learnloop` Compose project.
- Stopping or force-removing running, paused, restarting, or removing containers.
- Using `docker container prune`, `docker rm -f`, or `docker rm -v`.
- Directly deleting anonymous or named volumes as part of container removal.
- Removing leftover agent Compose networks (tracked as potential follow-up).
- Adding age-based container retention or a new container-cleanup CLI flag.
- Changing global image/build-cache pruning behavior.
- Refactoring unrelated agent environment code.

## Implementation Notes

- `plan_inactive_agent_containers` uses `docker ps -a --filter 'label=com.docker.compose.project'` to enumerate all Compose-managed containers, then filters by project-label prefix in shell (strict `case` match against `learnloop-agent-*`). The `--filter` matches label existence, not value prefix; the shell check excludes substring false positives like `backup-learnloop-agent-data`.
- Containers are grouped by exact project-label value. A project is eligible only if every member's `.State` is `exited`, `created`, or `dead`. Any `running`, `paused`, `restarting`, `removing`, or unknown state causes the entire project to be skipped and reported on stderr.
- Non-zero exit codes are included in the `{{.Status}}` field (e.g. `Exited (1) 3 minutes ago`) and are displayed before removal so debugging context is visible. Non-zero-exit containers are still treated as removable because running the cleanup script is an explicit request to discard inactive agent environments.
- `prune_agent_containers` uses only `docker container rm "$id"` (no `-f`, `--force`, `-v`, or `--volumes`). If a container started between planning and removal, non-forced `docker container rm` fails, the function returns non-zero, and `main` stops before volumes, images, global prune, and git worktree cleanup.
- Container removal runs before volume removal in the mutation phase. The existing unused-volume discovery still runs during planning (before any mutation), so volumes referenced by stopped containers are marked "in use" at planning time. After container removal, those volumes become unreferenced and are eligible for removal in a subsequent cleanup run — the safe two-pass approach that preserves the #496 all-planning-before-mutation model.
- All discovery (containers, volumes, images, cache capability) still happens before any mutation, preserving the #496 fail-before-mutation guarantee.
- No Bash 4+ features are used; the implementation is compatible with macOS Bash 3.2.

## Tests

Commands run:

- `bash -n scripts/agent-env-cleanup.sh scripts/agent-env.test.sh` — passed (syntax OK)
- `bash scripts/agent-env.test.sh` — passed (119 passed, 0 failed)
- `./scripts/agent-env-cleanup.sh --help` — passed (rc=0, documents container cleanup)
- `./scripts/agent-env-cleanup.sh --dry-run` — passed (rc=0, shows "Inactive agent containers" section with exited init-deps candidates, no mutations)
- `docker ps -a --filter 'label=com.docker.compose.project' --format '{{.ID}}\t{{.Names}}\t{{.State}}\t{{.Label "com.docker.compose.project"}}\t{{.Label "com.docker.compose.service"}}'` — confirmed real Docker returns expected label data; non-agent projects (pytest, permtest, etc.) are correctly excluded by the script.
- `git diff --check` — passed (no whitespace errors)

Automated tests added:

- `test_cleanup_container_inactive_project_removed`: fully inactive project → all containers removed.
- `test_cleanup_container_active_project_skipped`: project with a running member → no containers removed.
- `test_cleanup_container_learnloop_project_excluded`: normal `learnloop` project → not selected.
- `test_cleanup_container_substring_excluded`: `backup-learnloop-agent-data` → not selected.
- `test_cleanup_container_no_label_excluded`: container without project label → not selected.
- `test_cleanup_container_nonzero_exit_removed`: exited with exit code 1 → still removed.
- `test_cleanup_container_rm_no_force`: mutation log contains no `-f`/`--force`/`-v`/`--volumes`.
- `test_cleanup_container_before_volumes`: container rm appears before volume rm in the mutation log.
- `test_cleanup_container_dry_run_no_mutations`: dry-run lists candidates and makes zero mutations.
- `test_cleanup_container_discovery_failure_aborts`: `STUB_CONTAINER_LS_FAIL=1` → exit non-zero, zero mutations, no completion marker.
- `test_cleanup_container_rm_race_aborts`: `STUB_CONTAINER_RM_RACE_IDS="c1"` → exit non-zero, no volume/image/global-prune/git-worktree mutations, no completion marker.
- `test_cleanup_container_all_states_coverage`: exited/created/dead all removed; paused causes entire project to be skipped.

Manual verification:

- Ran the stub-based regression suite (`bash scripts/agent-env.test.sh`): 119 passed, 0 failed.
- Ran `--dry-run` against the real Docker daemon: correctly shows exited `init-deps` containers from `learnloop-agent-*` projects as candidates, excludes non-agent projects (pytest, permtest, uvtest), and makes no mutations.
- Verified `--help` documents container cleanup.
- Verified syntax with `bash -n` and whitespace with `git diff --check`.
- Platform/Docker version checked: Linux, Docker 29.6.1 / buildx 0.35.0.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly. The only clarification: "newly unreferenced named volumes can be handled by the current strict-prefix logic" applies to subsequent cleanup runs (the safe two-pass approach that preserves all-planning-before-mutation from #496), not the same run — volume discovery happens during planning (before any mutation), so volumes referenced by stopped containers are "in use" at planning time and become eligible only after the containers are removed.

## Follow-Up Work

- Potential cleanup of unused `learnloop-agent-*` Compose networks is intentionally excluded and may be tracked separately if needed.
