### PR TITLE
Centralize presentation mapping for problem-selection config

### DIFF
--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -9,9 +9,10 @@ from bson import ObjectId
 from fastapi import APIRouter, Query
 
 from app.domain.models import ExamState, GradingStatus, ProblemType, SelectionPolicyConfig
-from app.domain.selection import ProblemSelectionConfig, select_problems
+from app.domain.selection import select_problems
 from app.domain.state import transition_exam_state
 from app.presentation.exam_grading import build_tracking_update, grade_item
+from app.presentation.selection_config import problem_selection_config
 from app.presentation.exam_helpers import (
     build_exam_summary,
     exam_requires_vlm_grading,
@@ -60,7 +61,7 @@ async def create_exam(
         "userId": current_user["_id"],
         "state": {"$in": [ExamState.IN_PROGRESS.value, ExamState.GRADING.value]},
     }
-    selection_config = ProblemSelectionConfig(
+    selection_config = problem_selection_config(
         cooldown_days=settings.problem_selection_cooldown_days,
         last_wrong_weight=settings.problem_selection_last_wrong_weight,
         failure_rate_weight=settings.problem_selection_failure_rate_weight,

--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -9,9 +9,10 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
-from app.domain.selection import ProblemSelectionConfig, compute_score_breakdown, ensure_utc
+from app.domain.selection import compute_score_breakdown, ensure_utc
 from app.presentation.deps import CurrentUserDependency, DatabaseDependency, SettingsDependency
 from app.presentation.exam_helpers import problem_document_to_model
+from app.presentation.selection_config import problem_selection_config
 
 router = APIRouter(prefix="/home", tags=["home"])
 
@@ -67,8 +68,8 @@ class HomeSummaryResponse(BaseModel):
     scoreDistribution: ScoreDistribution
 
 
-def _selection_config_from_settings(settings: Any) -> ProblemSelectionConfig:
-    return ProblemSelectionConfig(
+def _selection_config_from_settings(settings: Any):
+    return problem_selection_config(
         cooldown_days=settings.problem_selection_cooldown_days,
         last_wrong_weight=settings.problem_selection_last_wrong_weight,
         failure_rate_weight=settings.problem_selection_failure_rate_weight,

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -11,11 +11,11 @@ from pydantic import BaseModel
 from app.domain.models import GradingStatus, GradingMethod, ProblemType
 from app.domain.normalization import compare_answers, normalize_answer
 from app.domain.practice_selection import (
-    PracticeSelectionConfig,
     get_eligible_practice_problems,
     select_practice_problem,
 )
 from app.infrastructure.config.settings import get_settings
+from app.presentation.selection_config import practice_selection_config
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import S3StorageAdapter
 from app.infrastructure.vlm.client import VLMClient, VLMError
@@ -100,7 +100,7 @@ async def get_practice_stats(
     ).to_list(length=None)
 
     problem_models = [problem_document_to_model(p) for p in problem_documents]
-    config = PracticeSelectionConfig(
+    config = practice_selection_config(
         cooldown_days=settings.problem_selection_cooldown_days,
         min_problem_age_days=settings.problem_selection_min_age_days,
     )
@@ -130,7 +130,7 @@ async def get_next_practice_problem(
     if not eligible_documents:
         return PracticeNextResponse(status="no_problems")
 
-    config = PracticeSelectionConfig(
+    config = practice_selection_config(
         cooldown_days=settings.problem_selection_cooldown_days,
         last_wrong_weight=settings.problem_selection_last_wrong_weight,
         failure_rate_weight=settings.problem_selection_failure_rate_weight,

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -12,9 +12,10 @@ from pydantic import BaseModel, Field
 
 from app.domain.models import ProblemType
 from app.domain.normalization import normalize_answer
-from app.domain.practice_selection import PracticeSelectionConfig, compute_problem_weight_breakdown
+from app.domain.practice_selection import compute_problem_weight_breakdown
 from app.infrastructure.auth.password import verify_password
 from app.infrastructure.config.settings import Settings, get_settings
+from app.presentation.selection_config import practice_selection_config
 from app.observability import log_teacher_password_event
 from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
@@ -117,8 +118,8 @@ async def _solution_state_problem_ids(
     ]
 
 
-def _practice_selection_config(settings: Settings) -> PracticeSelectionConfig:
-    return PracticeSelectionConfig(
+def _practice_selection_config(settings: Settings):
+    return practice_selection_config(
         cooldown_days=settings.problem_selection_cooldown_days,
         last_wrong_weight=settings.problem_selection_last_wrong_weight,
         failure_rate_weight=settings.problem_selection_failure_rate_weight,

--- a/backend/app/presentation/selection_config.py
+++ b/backend/app/presentation/selection_config.py
@@ -1,0 +1,50 @@
+from app.domain.practice_selection import PracticeSelectionConfig
+from app.domain.selection import ProblemSelectionConfig
+
+__all__ = ["problem_selection_config", "practice_selection_config"]
+
+
+def problem_selection_config(
+    *,
+    cooldown_days: int = 7,
+    last_wrong_weight: float = 1.0,
+    failure_rate_weight: float = 1.0,
+    recency_weight: float = 1.0,
+    min_problem_age_days: int = 3,
+) -> ProblemSelectionConfig:
+    """Build a presentation-agnostic ``ProblemSelectionConfig`` from primitives.
+
+    Default values mirror the domain defaults and must not change without a
+    corresponding settings/API review.
+    """
+    return ProblemSelectionConfig(
+        cooldown_days=cooldown_days,
+        last_wrong_weight=last_wrong_weight,
+        failure_rate_weight=failure_rate_weight,
+        recency_weight=recency_weight,
+        min_problem_age_days=min_problem_age_days,
+    )
+
+
+def practice_selection_config(
+    *,
+    cooldown_days: int = 7,
+    last_wrong_weight: float | None = None,
+    failure_rate_weight: float | None = None,
+    recency_weight: float | None = None,
+    min_problem_age_days: int | None = None,
+) -> PracticeSelectionConfig:
+    """Build a ``PracticeSelectionConfig`` from primitives.
+
+    Omitted weight values retain the domain defaults. This keeps the existing
+    partial/default construction path used by ``/practice/stats`` intact: that
+    endpoint intentionally supplies only ``cooldown_days`` and
+    ``min_problem_age_days``.
+    """
+    return PracticeSelectionConfig(
+        cooldown_days=cooldown_days,
+        last_wrong_weight=last_wrong_weight if last_wrong_weight is not None else 1.0,
+        failure_rate_weight=failure_rate_weight if failure_rate_weight is not None else 1.0,
+        recency_weight=recency_weight if recency_weight is not None else 1.0,
+        min_problem_age_days=min_problem_age_days if min_problem_age_days is not None else 3,
+    )

--- a/backend/tests/presentation/test_selection_config.py
+++ b/backend/tests/presentation/test_selection_config.py
@@ -1,0 +1,92 @@
+from app.domain.practice_selection import PracticeSelectionConfig
+from app.domain.selection import ProblemSelectionConfig
+from app.presentation.selection_config import (
+    practice_selection_config,
+    problem_selection_config,
+)
+
+
+def test_problem_selection_config_defaults_match_domain() -> None:
+    mapped = problem_selection_config()
+    domain_default = ProblemSelectionConfig()
+
+    assert mapped == domain_default
+    assert isinstance(mapped, ProblemSelectionConfig)
+
+
+def test_problem_selection_config_all_primitives() -> None:
+    mapped = problem_selection_config(
+        cooldown_days=5,
+        last_wrong_weight=1.5,
+        failure_rate_weight=2.0,
+        recency_weight=2.5,
+        min_problem_age_days=0,
+    )
+
+    assert mapped.cooldown_days == 5
+    assert mapped.last_wrong_weight == 1.5
+    assert mapped.failure_rate_weight == 2.0
+    assert mapped.recency_weight == 2.5
+    assert mapped.min_problem_age_days == 0
+
+
+def test_practice_selection_config_defaults_match_domain() -> None:
+    mapped = practice_selection_config()
+    domain_default = PracticeSelectionConfig()
+
+    assert mapped == domain_default
+    assert isinstance(mapped, PracticeSelectionConfig)
+
+
+def test_practice_selection_config_all_primitives() -> None:
+    mapped = practice_selection_config(
+        cooldown_days=5,
+        last_wrong_weight=1.5,
+        failure_rate_weight=2.0,
+        recency_weight=2.5,
+        min_problem_age_days=0,
+    )
+
+    assert mapped.cooldown_days == 5
+    assert mapped.last_wrong_weight == 1.5
+    assert mapped.failure_rate_weight == 2.0
+    assert mapped.recency_weight == 2.5
+    assert mapped.min_problem_age_days == 0
+
+
+def test_practice_selection_config_partial_preserves_defaults() -> None:
+    """Omitted weights fall back to domain defaults; only cooldown/min_age are supplied."""
+    mapped = practice_selection_config(
+        cooldown_days=14,
+        min_problem_age_days=1,
+    )
+
+    assert mapped.cooldown_days == 14
+    assert mapped.min_problem_age_days == 1
+    assert mapped.last_wrong_weight == 1.0
+    assert mapped.failure_rate_weight == 1.0
+    assert mapped.recency_weight == 1.0
+    assert mapped == PracticeSelectionConfig(
+        cooldown_days=14,
+        min_problem_age_days=1,
+    )
+
+
+def test_problem_selection_config_and_practice_selection_config_to_shared_values() -> None:
+    """For identical primitive inputs the shared selection math receives identical values."""
+    problem_config = problem_selection_config(
+        cooldown_days=7,
+        last_wrong_weight=1.5,
+        failure_rate_weight=2.0,
+        recency_weight=2.5,
+        min_problem_age_days=3,
+    )
+    practice_config = practice_selection_config(
+        cooldown_days=7,
+        last_wrong_weight=1.5,
+        failure_rate_weight=2.0,
+        recency_weight=2.5,
+        min_problem_age_days=3,
+    )
+
+    assert problem_config == practice_config.to_shared_config()


### PR DESCRIPTION
Model-Signature: ollama-cloud/kimi-k2.7-code

## Summary

Add a presentation-owned primitive-to-domain mapper for problem-selection configuration and migrate all current presentation callers to use it. No defaults, values, types, or persisted/API casing changed.

## Linked Issue

Closes #500

## Issue Alignment

This PR implements the issue by:

- Adding `backend/app/presentation/selection_config.py` with two public mapper functions:
  - `problem_selection_config(...)` returns `ProblemSelectionConfig`.
  - `practice_selection_config(...)` returns `PracticeSelectionConfig`, with omitted weight arguments defaulting to domain defaults so the existing partial/default practice path is preserved.
- Migrating inline `ProblemSelectionConfig`/`PracticeSelectionConfig` construction in `home.py`, `problems.py`, `practice.py`, and `exams.py` to call the new mappers.
- Keeping both domain config types unchanged and independent of infrastructure `Settings`.
- Adding focused mapper tests in `backend/tests/presentation/test_selection_config.py`.

Scope covered:

- Presentation-owned selection config mapping seam.
- Migration of all current callers.
- Focused regression coverage.

Out of scope / intentionally not included:

- Merging `ProblemSelectionConfig` and `PracticeSelectionConfig`.
- Moving config construction into domain or infrastructure.
- Changing defaults, scoring, eligibility, sampling, snapshot behavior, or API casing.
- Refactoring adjacent settings/presentation code.

## Implementation Notes

- The mapper accepts primitive values rather than `Settings`, preserving domain independence from infrastructure config.
- `practice_selection_config` intentionally mirrors the existing default behavior: omitted weight fields fall back to `1.0`, exactly as the domain dataclass defaults. This lets `practice.py` continue its partial construction for `/practice/stats` without drifting.
- Imports of `ProblemSelectionConfig` and `PracticeSelectionConfig` were removed from the migrated modules where no longer needed; the only remaining direct dataclass construction sites are now in `selection_config.py` and the domain tests.

## Tests

Commands run:

- `./scripts/agent-env.sh test backend` — **951 passed, 1 skipped** (full backend suite in isolated agent environment).
- `uv run --directory backend pytest tests/presentation/test_selection_config.py tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/api/test_exams.py tests/api/test_problems.py tests/api/test_practice.py tests/api/test_home.py` — initially blocked by missing host venv dependencies; superseded by the agent-environment run above which includes all these modules.
- `rg -n "ProblemSelectionConfig\(|PracticeSelectionConfig\(" backend/app/presentation --glob "*.py"` — confirms only `selection_config.py` constructs the dataclasses directly.
- `git diff --check` — passed.

Automated tests added or updated:

- `backend/tests/presentation/test_selection_config.py`
  - Default mapping parity with domain defaults for both config types.
  - Complete primitive mapping for both config types.
  - Partial practice config preserves default weights.
  - Shared selection math receives identical values from both mappers.

Manual verification:

- Reviewed the diff to confirm `Settings` is not imported into domain code and the two config types are not merged.
- Confirmed no inline field-by-field construction remains in the migrated presentation modules.

## Deviations From Issue Plan

None.

## Follow-Up Work

None within this PR. The behavior-neutral practice API seam (#504) and graph DSL policy relocation (#505) must wait until all Batch 1 tasks are complete, per the issue's follow-up notes.
