### PR TITLE
Prevent TypeScript config sibling emission and verify config loaders

### DIFF
--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "composite": true,
+    "noEmit": true,
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",


### PR DESCRIPTION
Model-Signature: ollama-cloud/kimi-k2.7-code

## Summary

Add  to  so that  does not produce JavaScript or declaration siblings for  and . Build, unit tests, Vite, and Playwright continue to load the TypeScript source configs.

## Linked Issue

Closes #503

## Issue Alignment

This PR implements the issue by:

- Adding  to  without changing , , or other compiler options.
- Confirming that the existing  rules (, , ) already cover any generated config siblings.
- Verifying that  succeeds and leaves no , , , or  files.
- Verifying that vite v8.1.4 building client environment for production...
[2Ktransforming...✓ 1 modules transformed. reports  as the loaded config file.
- Verifying that  discovers tests from .
- Verifying that the full frontend unit/component suite passes.

Scope covered:

- One-line compiler-policy change in .
- Evidence that Vite/Vitest and Playwright still load their TypeScript source configs.
- Evidence that no config siblings are emitted.

Out of scope / intentionally not included:

- No changes to Vite aliases, proxy, ports, plugins, environment behavior, or commands.
- No changes to Vitest or Playwright commands, projects, browser behavior, or compose configuration.
- No reorganization of TypeScript configs.
- No new build system or abstractions.
- No tracked generated files are deleted because none are tracked.

## Implementation Notes

-  is referenced by  and included  and . With  but , TypeScript still participates in project references and type-checks the config files but does not emit / artifacts for them.
-  is still produced by the app project (), which is unaffected. The root  already ignores .
- The Vite and Playwright TypeScript configs are loaded via their respective tooling (Vite uses tsx/esbuild; Playwright uses ts-node/tsx path resolution), not by Node.js directly requiring emitted  files.

## Tests

Commands run:

- 
added 306 packages, and audited 307 packages in 2s

134 packages are looking for funding
  run `npm fund` for details

10 vulnerabilities (3 low, 3 moderate, 3 high, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details. — dependencies installed successfully.
- 
> learnloop-frontend@0.1.0 build
> tsc -b && vite build

vite v5.4.21 building for production...
transforming...
✓ 413 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                         0.99 kB │ gzip:   0.57 kB
dist/assets/KaTeX_Size3-Regular-CTq5MqoE.woff           4.42 kB
dist/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2          4.93 kB
dist/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2          5.21 kB
dist/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2          5.47 kB
dist/assets/KaTeX_Size4-Regular-BF-4gkZK.woff           5.98 kB
dist/assets/KaTeX_Size2-Regular-oD1tc_U0.woff           6.19 kB
dist/assets/KaTeX_Size1-Regular-C195tn64.woff           6.50 kB
dist/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2    6.91 kB
dist/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2       6.91 kB
dist/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf            7.59 kB
dist/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff     7.66 kB
dist/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff        7.72 kB
dist/assets/KaTeX_Script-Regular-D3wIWfF6.woff2         9.64 kB
dist/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2     10.34 kB
dist/assets/KaTeX_Size4-Regular-DWFBv043.ttf           10.36 kB
dist/assets/KaTeX_Script-Regular-D5yQViql.woff         10.59 kB
dist/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2       11.32 kB
dist/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2          11.35 kB
dist/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf           11.51 kB
dist/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2      12.03 kB
dist/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2        12.22 kB
dist/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf           12.23 kB
dist/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff      12.32 kB
dist/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf     12.34 kB
dist/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf        12.37 kB
dist/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff        13.21 kB
dist/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff           13.30 kB
dist/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2    13.57 kB
dist/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff       14.11 kB
dist/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff         14.41 kB
dist/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff     16.03 kB
dist/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2       16.40 kB
dist/assets/KaTeX_Math-Italic-t53AETM-.woff2           16.44 kB
dist/assets/KaTeX_Script-Regular-C5JkGWo-.ttf          16.65 kB
dist/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2       16.78 kB
dist/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2           16.99 kB
dist/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff        18.67 kB
dist/assets/KaTeX_Math-Italic-DA0__PXp.woff            18.75 kB
dist/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff        19.41 kB
dist/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf       19.44 kB
dist/assets/KaTeX_Fraktur-Regular-CB_wures.ttf         19.57 kB
dist/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf            19.58 kB
dist/assets/KaTeX_Main-Italic-BMLOBm91.woff            19.68 kB
dist/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf        22.36 kB
dist/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf          24.50 kB
dist/assets/KaTeX_Main-Bold-Cx986IdX.woff2             25.32 kB
dist/assets/KaTeX_Main-Regular-B22Nviop.woff2          26.27 kB
dist/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf      27.56 kB
dist/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2           28.08 kB
dist/assets/KaTeX_Main-Bold-Jm3AIy58.woff              29.91 kB
dist/assets/KaTeX_Main-Regular-Dr94JaBh.woff           30.77 kB
dist/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf         31.20 kB
dist/assets/KaTeX_Math-Italic-flOr_0UB.ttf             31.31 kB
dist/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf         32.97 kB
dist/assets/KaTeX_AMS-Regular-DMm9YOAa.woff            33.52 kB
dist/assets/KaTeX_Main-Italic-3WenGoN9.ttf             33.58 kB
dist/assets/KaTeX_Main-Bold-waoOVXN0.ttf               51.34 kB
dist/assets/KaTeX_Main-Regular-ypZvNtVU.ttf            53.58 kB
dist/assets/KaTeX_AMS-Regular-DRggAlZN.ttf             63.63 kB
dist/assets/index-5shhyeZ2.css                         38.35 kB │ gzip:  10.42 kB
dist/assets/index-C7DicmVz.js                         851.30 kB │ gzip: 245.94 kB
✓ built in 1.17s () — **passed**. Build completed successfully.
- 
> learnloop-frontend@0.1.0 test
> vitest --run


 RUN  v2.1.9 /home/rlan/projects/LearnLoop/frontend

 ✓ src/components/BulkReviewStep.helpers.test.ts (22 tests) 4ms
 ✓ src/api/client.test.ts (10 tests) 8ms
 ✓ src/pages/ProblemsPage.folderHelpers.test.ts (17 tests) 6ms
 ✓ src/api/bulkIngestion.test.ts (15 tests) 10ms
 ✓ src/utils/boxGeometry.test.ts (8 tests) 4ms
 ✓ src/utils/format.test.ts (9 tests) 19ms
 ✓ src/components/AnswerInput.test.tsx (10 tests) 5ms
 ✓ src/contexts/ThemeContext.test.tsx (10 tests) 82ms
 ✓ src/components/BoxEditor.test.tsx (9 tests) 98ms
 ✓ src/components/TeacherPasswordModal.test.tsx (9 tests) 78ms
 ✓ src/components/LatexText.test.tsx (20 tests) 106ms
 ✓ src/components/BulkSubmitStep.test.tsx (21 tests) 125ms
 ✓ src/components/MarkdownText.test.tsx (10 tests) 83ms
 ✓ src/components/GraphSandbox.test.tsx (18 tests) 275ms
 ✓ src/components/BulkUploadStep.test.tsx (3 tests) 30ms
 ✓ src/pages/IngestPage.test.tsx (4 tests) 48ms
 ✓ src/hooks/useTagSuggestions.test.tsx (1 test) 64ms
 ✓ src/pages/RegisterPage.test.tsx (4 tests) 279ms
 ✓ src/pages/LoginPage.test.tsx (5 tests) 279ms
 ✓ src/App.test.tsx (11 tests) 165ms
 ✓ src/pages/TagsPage.test.tsx (7 tests) 341ms
 ✓ src/pages/PracticePage.test.tsx (15 tests) 330ms
 ✓ src/pages/ActivePracticePage.test.tsx (17 tests) 447ms
 ✓ src/components/BulkIngestionWizard.test.tsx (38 tests) 555ms
 ✓ src/pages/ActiveExamPage.test.tsx (18 tests) 538ms
 ✓ src/pages/ExamsPage.test.tsx (16 tests) 638ms
 ✓ src/pages/SettingsPage.test.tsx (17 tests) 809ms
 ✓ src/pages/CoachingPage.test.tsx (20 tests) 622ms
 ✓ src/components/TagInput.test.tsx (33 tests) 998ms
 ✓ src/components/BulkReviewStep.test.tsx (29 tests) 1066ms
   ✓ BulkReviewStep > saves the latest draft value typed while a save is in flight 542ms
 ✓ src/pages/HomePage.test.tsx (26 tests) 1063ms
 ✓ src/pages/ProblemDetailPage.test.tsx (36 tests) 1039ms
 ✓ src/pages/ExamDetailPage.test.tsx (23 tests) 4585ms
   ✓ ExamDetailPage > transitions from grading checklist to results view when exam becomes submitted 2011ms
   ✓ ExamDetailPage > preserves submitted results view with self-report and reveal controls after grading completes 2012ms
 ✓ src/pages/ProblemsPage.test.tsx (32 tests) 9325ms
   ✓ ProblemsPage > resets pagination and selection mode when sort changes 647ms
   ✓ ProblemsPage > bulk moves selected problems to a folder, clears selection, and refetches data 640ms
   ✓ ProblemsPage > bulk move to Unfiled sends folderId null 634ms
   ✓ ProblemsPage > shows concise error feedback for folder and bulk move failures 651ms
   ✓ ProblemsPage > long press enters selection mode and selects the pressed problem 618ms
   ✓ ProblemsPage > in selection mode, card click toggles selection without navigating 626ms
   ✓ ProblemsPage > Select all selects only current-page problems 627ms
   ✓ ProblemsPage > Deselect all removes only current-page problems from selection 648ms
   ✓ ProblemsPage > Clear selection clears selected IDs but keeps selection mode active 638ms
   ✓ ProblemsPage > Quit selection clears selected IDs and hides checkboxes 635ms
   ✓ ProblemsPage > filter changes exit selection mode and clear selection 633ms
   ✓ ProblemsPage > Move selected button is disabled when no problems are selected 632ms
   ✓ ProblemsPage > changing solution state resets requests to page 1 and exits selection mode 636ms

 Test Files  34 passed (34)
      Tests  543 passed (543)
   Start at  00:16:23
   Duration  10.43s (transform 3.08s, setup 2.03s, collect 11.59s, tests 24.12s, environment 10.58s, prepare 2.12s) — **passed**: 34 test files, 543 tests passed.
-  — output shows , confirming Vite loads the TypeScript source.
- Listing tests:
  active-exam-print.spec.ts:22:3 › Active Exam print preview › renders all exam content in the print preview for a one-problem exam
  active-exam-print.spec.ts:44:3 › Active Exam print preview › print preview hides controls and app shell under print media
  bulk-ingestion.spec.ts:219:3 › Bulk ingestion E2E › happy path uploads multiple images and submits all items
  bulk-ingestion.spec.ts:239:3 › Bulk ingestion E2E › single image with a single box submits one problem
  bulk-ingestion.spec.ts:257:3 › Bulk ingestion E2E › keeps review editors focused while autosaving
  bulk-ingestion.spec.ts:297:3 › Bulk ingestion E2E › recovers from detection failure after retry
  bulk-ingestion.spec.ts:335:3 › Bulk ingestion E2E › handles extraction failure by deleting the failed item and submitting the rest
  bulk-ingestion.spec.ts:391:3 › Bulk ingestion E2E › resumes review after reload and retries a failed extraction
  graph-sandbox-security.spec.ts:8:3 › GraphSandbox Security › should block outbound fetch requests from within the iframe
  graph-sandbox-security.spec.ts:66:3 › GraphSandbox Security › should block access to parent document from within the iframe
  practice.spec.ts:31:3 › Practice E2E › loads the protected practice page for an authenticated user
  practice.spec.ts:41:3 › Practice E2E › shows practice history and expands attempts
  practice.spec.ts:54:3 › Practice E2E › starts a practice session and submits an answer
  practice.spec.ts:70:3 › Practice E2E › shows an empty-state message when no problems exist
  teacher-password.spec.ts:31:3 › Teacher Password E2E › reveals a protected problem answer with the teacher password
  teacher-password.spec.ts:48:3 › Teacher Password E2E › keeps the answer protected after an incorrect teacher password
  teacher-password.spec.ts:64:3 › Teacher Password E2E › changes the teacher password from settings
  theme.spec.ts:36:3 › Theme E2E › defaults to light theme for new authenticated user
  theme.spec.ts:50:3 › Theme E2E › toggles from light to dark and updates localStorage
  theme.spec.ts:74:3 › Theme E2E › toggles from dark to light and updates localStorage
  theme.spec.ts:103:3 › Theme E2E › persists dark theme after page reload
  theme.spec.ts:122:3 › Theme E2E › persists light theme after page reload
  theme.spec.ts:145:3 › Theme E2E › theme toggle button remains usable in both themes
  theme.spec.ts:170:3 › Theme E2E › app shell remains readable in both light and dark themes
  theme.spec.ts:198:3 › Home Page Theme › home page renders in light theme
  theme.spec.ts:211:3 › Home Page Theme › home page renders in dark theme
  theme.spec.ts:224:3 › Home Page Theme › home page dark theme paints a non-white full-page background
  theme.spec.ts:252:3 › Home Page Theme › home page dark theme has no white pixel below the fold
  theme.spec.ts:273:3 › Problems Page Theme › problems page renders in light theme
  theme.spec.ts:292:3 › Problems Page Theme › problems page renders in dark theme
  theme.spec.ts:311:3 › Problems Page Theme › problems page dark theme paints a themed background on main content area
  theme.spec.ts:335:3 › Problems Page Theme › problems page dark theme background matches Ingest page surface-muted
  theme.spec.ts:358:3 › Problem Detail Page Theme › problem detail page renders in light theme
  theme.spec.ts:377:3 › Problem Detail Page Theme › problem detail page renders in dark theme
  theme.spec.ts:396:3 › Problem Detail Page Theme › problem detail page dark theme paints a non-white full-page background
  theme.spec.ts:419:3 › Tags Page Theme › tags page renders in light theme
  theme.spec.ts:437:3 › Tags Page Theme › tags page renders in dark theme
  theme.spec.ts:455:3 › Tags Page Theme › tags page dark theme paints a full-page themed background
  theme.spec.ts:479:3 › Settings Page Theme › settings page renders in light theme
  theme.spec.ts:497:3 › Settings Page Theme › settings page renders in dark theme
  theme.spec.ts:515:3 › Settings Page Theme › settings page dark theme paints a non-white full-page background
  theme.spec.ts:538:3 › Practice Page Theme › practice page renders in light theme
  theme.spec.ts:556:3 › Practice Page Theme › practice page renders in dark theme
  theme.spec.ts:574:3 › Practice Page Theme › practice page dark theme paints a full-page themed background
  theme.spec.ts:598:3 › Active Practice Page Theme › active practice page renders in light theme
  theme.spec.ts:619:3 › Active Practice Page Theme › active practice page renders in dark theme
  theme.spec.ts:640:3 › Active Practice Page Theme › active practice page dark theme paints a non-white full-page background
  theme.spec.ts:668:3 › Exam Detail Page Theme › exam detail page renders in light theme
  theme.spec.ts:683:3 › Exam Detail Page Theme › exam detail page renders in dark theme
  theme.spec.ts:696:3 › Exam Detail Page Theme › exam detail page dark theme paints a non-white full-page background
  theme.spec.ts:719:3 › Active Exam Page Theme › active exam page renders in light theme
  theme.spec.ts:733:3 › Active Exam Page Theme › active exam page renders in dark theme
  theme.spec.ts:747:3 › Active Exam Page Theme › active exam page dark theme paints a non-white full-page background
  theme.spec.ts:770:3 › Exams Page Theme › exams page renders in light theme
  theme.spec.ts:788:3 › Exams Page Theme › exams page renders in dark theme
  theme.spec.ts:806:3 › Exams Page Theme › exams page dark theme paints a full-page themed background
  theme.spec.ts:837:3 › Coaching Page Theme › coaching page renders in light theme
  theme.spec.ts:857:3 › Coaching Page Theme › coaching page renders in dark theme
  theme.spec.ts:877:3 › Coaching Page Theme › coaching page dark theme paints a non-white full-page background
Total: 59 tests in 6 files — **passed**: listed 59 tests in 6 files, confirming Playwright loads .
- frontend/playwright.config.ts
frontend/vite.config.ts — confirms only  configs are tracked.
- Post-build artifact inventory in  — confirms no , , , or  siblings were emitted.

Automated tests added or updated:

- No new test files. The issue asked for verification through existing build/loader commands; this PR records the deterministic command output above. A fully automated regression guard would require either (a) a Node script in the existing test harness that asserts file non-existence after , or (b) a GitHub Actions step. The existing CI already exercises  and would fail if emitted siblings became tracked or broke the build. The one-line  change is the regression guard itself.

Manual verification:

- Confirmed pre-change baseline emitted siblings (, , , ) when  was absent.
- Confirmed post-change  leaves no such siblings.
- Inspected  after verification — only the intended  change is staged.

## Deviations From Issue Plan

None.

## Follow-Up Work

None within this PR. Remaining Batch 1 tasks #504 and #505 and later behavior-neutral seams remain separately gated.
