### PR TITLE
Add a behavior-neutral frontend practice API and query-key seam

### DIFF
--- a/frontend/src/api/practice.test.ts
+++ b/frontend/src/api/practice.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getPracticeHistory,
+  getPracticeStats,
+  startPractice,
+  submitPracticeAttempt,
+  nextPracticeProblem,
+  PRACTICE_HISTORY_KEY,
+  PRACTICE_STATS_KEY,
+} from "./practice";
+import type {
+  PracticeAttemptResult,
+  PracticeHistoryResponse,
+  PracticeNextResponse,
+  PracticeStatsResponse,
+} from "@/types/practice";
+
+describe("practice API module", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exports the exact query keys", () => {
+    expect(PRACTICE_HISTORY_KEY).toEqual(["practice-history"]);
+    expect(PRACTICE_STATS_KEY).toEqual(["practice-stats"]);
+  });
+
+  it("getPracticeHistory GETs /practice/history", async () => {
+    const response: PracticeHistoryResponse = { items: [] };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await getPracticeHistory();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/practice/history", {
+      credentials: "include",
+    });
+    expect(result).toEqual(response);
+  });
+
+  it("getPracticeStats GETs /practice/stats", async () => {
+    const response: PracticeStatsResponse = { practiceableCount: 5 };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await getPracticeStats();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/practice/stats", {
+      credentials: "include",
+    });
+    expect(result).toEqual(response);
+  });
+
+  it("startPractice POSTs an empty object to /practice/next", async () => {
+    const response: PracticeNextResponse = {
+      status: "ok",
+      problem: { id: "p1", text: "Q", type: "short-answer" },
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await startPractice();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/practice/next", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({}),
+    });
+    expect(result).toEqual(response);
+  });
+
+  it("submitPracticeAttempt POSTs problemId and submittedAnswer to /practice/attempts", async () => {
+    const response: PracticeAttemptResult = {
+      gradingStatus: "correct",
+      gradingMethod: "normalized-match",
+    };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await submitPracticeAttempt("p1", "42");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/practice/attempts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ problemId: "p1", submittedAnswer: "42" }),
+    });
+    expect(result).toEqual(response);
+  });
+
+  it("nextPracticeProblem POSTs an empty object to /practice/next", async () => {
+    const response: PracticeNextResponse = { status: "no_eligible" };
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(response),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await nextPracticeProblem();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/practice/next", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({}),
+    });
+    expect(result).toEqual(response);
+  });
+});

--- a/frontend/src/api/practice.ts
+++ b/frontend/src/api/practice.ts
@@ -1,0 +1,36 @@
+import { api } from "./client";
+import type {
+  PracticeAttemptResult,
+  PracticeHistoryResponse,
+  PracticeNextResponse,
+  PracticeStatsResponse,
+} from "@/types/practice";
+
+export const PRACTICE_HISTORY_KEY = ["practice-history"] as const;
+export const PRACTICE_STATS_KEY = ["practice-stats"] as const;
+
+export async function getPracticeHistory(): Promise<PracticeHistoryResponse> {
+  return api.get<PracticeHistoryResponse>("/practice/history");
+}
+
+export async function getPracticeStats(): Promise<PracticeStatsResponse> {
+  return api.get<PracticeStatsResponse>("/practice/stats");
+}
+
+export async function startPractice(): Promise<PracticeNextResponse> {
+  return api.post<PracticeNextResponse>("/practice/next", {});
+}
+
+export async function submitPracticeAttempt(
+  problemId: string,
+  submittedAnswer: string,
+): Promise<PracticeAttemptResult> {
+  return api.post<PracticeAttemptResult>("/practice/attempts", {
+    problemId,
+    submittedAnswer,
+  });
+}
+
+export async function nextPracticeProblem(): Promise<PracticeNextResponse> {
+  return api.post<PracticeNextResponse>("/practice/next", {});
+}

--- a/frontend/src/pages/ActivePracticePage.tsx
+++ b/frontend/src/pages/ActivePracticePage.tsx
@@ -7,6 +7,11 @@ import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { LatexText } from "@/components/LatexText";
 import { AnswerInput, parseOptions } from "@/components/AnswerInput";
+import {
+  nextPracticeProblem,
+  submitPracticeAttempt,
+  PRACTICE_HISTORY_KEY,
+} from "@/api/practice";
 import type { PracticeProblem, PracticeNextResponse, PracticeAttemptResult } from "@/types/practice";
 
 type PracticePhase = "showing" | "grading" | "feedback";
@@ -45,7 +50,7 @@ export function ActivePracticePage() {
 
   const submitMutation = useMutation({
     mutationFn: ({ problemId, submittedAnswer }: { problemId: string; submittedAnswer: string }) =>
-      api.post<PracticeAttemptResult>("/practice/attempts", { problemId, submittedAnswer }),
+      submitPracticeAttempt(problemId, submittedAnswer),
     onSuccess: (result) => {
       setGradingResult(result);
       setPhase("feedback");
@@ -53,7 +58,7 @@ export function ActivePracticePage() {
   });
 
   const nextMutation = useMutation({
-    mutationFn: () => api.post<PracticeNextResponse>("/practice/next", {}),
+    mutationFn: nextPracticeProblem,
     onSuccess: (response) => {
       if (response.status === "ok" && response.problem) {
         setCurrentProblem(response.problem);
@@ -67,7 +72,7 @@ export function ActivePracticePage() {
       } else if (response.status === "no_problems") {
         setStatusMessage("Add some problems first to start practicing.");
       }
-      queryClient.invalidateQueries({ queryKey: ["practice-history"] });
+      queryClient.invalidateQueries({ queryKey: PRACTICE_HISTORY_KEY });
     },
   });
 
@@ -91,7 +96,7 @@ export function ActivePracticePage() {
   };
 
   const handleQuit = () => {
-    queryClient.invalidateQueries({ queryKey: ["practice-history"] });
+    queryClient.invalidateQueries({ queryKey: PRACTICE_HISTORY_KEY });
     navigate("/practice");
   };
 

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -8,6 +8,7 @@ import { MarkdownText } from "@/components/MarkdownText";
 import { LatexText } from "@/components/LatexText";
 import type { CoachingConversation } from "@/types/coaching";
 import type { ProblemDetail, ProblemResponse } from "@/types/problem";
+import { getPracticeHistory, PRACTICE_HISTORY_KEY } from "@/api/practice";
 import type { PracticeHistoryResponse } from "@/types/practice";
 import { WhiteboardPanel } from "./WhiteboardPanel";
 
@@ -62,9 +63,9 @@ export function CoachingPage() {
 
   // 2. Fetch Practice History (if referrer is practice)
   const isFromPractice = fromRoute === "/practice" || fromRoute.startsWith("/practice");
-  const { data: practiceHistory } = useQuery({
-    queryKey: ["practice-history"],
-    queryFn: () => api.get<PracticeHistoryResponse>("/practice/history"),
+  const { data: practiceHistory } = useQuery<PracticeHistoryResponse>({
+    queryKey: PRACTICE_HISTORY_KEY,
+    queryFn: getPracticeHistory,
     enabled: !!problemId && isFromPractice,
   });
 

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -5,11 +5,14 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { api } from "@/api/client";
 import { formatDate } from "@/utils/format";
 import { LatexText } from "@/components/LatexText";
-import type { PracticeHistoryItem, PracticeHistoryResponse, PracticeNextResponse } from "@/types/practice";
-
-interface PracticeStatsResponse {
-  practiceableCount: number;
-}
+import {
+  getPracticeHistory,
+  getPracticeStats,
+  startPractice,
+  PRACTICE_HISTORY_KEY,
+  PRACTICE_STATS_KEY,
+} from "@/api/practice";
+import type { PracticeHistoryItem, PracticeNextResponse } from "@/types/practice";
 
 function getResultStyleClass(result: string) {
   switch (result) {
@@ -290,17 +293,17 @@ export function PracticePage() {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
   const { data, isLoading, error } = useQuery<PracticeHistoryResponse>({
-    queryKey: ["practice-history"],
-    queryFn: () => api.get<PracticeHistoryResponse>("/practice/history"),
+    queryKey: PRACTICE_HISTORY_KEY,
+    queryFn: getPracticeHistory,
   });
 
-  const { data: statsData } = useQuery<PracticeStatsResponse>({
-    queryKey: ["practice-stats"],
-    queryFn: () => api.get<PracticeStatsResponse>("/practice/stats"),
+  const { data: statsData } = useQuery({
+    queryKey: PRACTICE_STATS_KEY,
+    queryFn: getPracticeStats,
   });
 
   const startPracticeMutation = useMutation({
-    mutationFn: () => api.post<PracticeNextResponse>("/practice/next", {}),
+    mutationFn: startPractice,
     onSuccess: (response) => {
       if (response.status === "ok" && response.problem) {
         navigate("/practice/active", { state: { problem: response.problem } });

--- a/frontend/src/pages/PracticePage.tsx
+++ b/frontend/src/pages/PracticePage.tsx
@@ -12,7 +12,7 @@ import {
   PRACTICE_HISTORY_KEY,
   PRACTICE_STATS_KEY,
 } from "@/api/practice";
-import type { PracticeHistoryItem, PracticeNextResponse } from "@/types/practice";
+import type { PracticeHistoryItem, PracticeHistoryResponse, PracticeNextResponse } from "@/types/practice";
 
 function getResultStyleClass(result: string) {
   switch (result) {

--- a/frontend/src/types/practice.ts
+++ b/frontend/src/types/practice.ts
@@ -47,3 +47,7 @@ export interface PracticeNextResponse {
 export interface PracticeHistoryResponse {
   items: PracticeHistoryItem[];
 }
+
+export interface PracticeStatsResponse {
+  practiceableCount: number;
+}


### PR DESCRIPTION
Model-Signature: ollama-cloud/kimi-k2.7-code\n\n## Summary\n\nIntroduce `frontend/src/api/practice.ts` as the single feature-owned seam for current practice transport, export canonical query-key constants, move `PracticeStatsResponse` into `frontend/src/types/practice.ts`, and migrate `PracticePage`, `ActivePracticePage`, and `CoachingPage` to use the seam without changing any URL, method, body, key identity, invalidation, polling, navigation, or UI behavior.\n\n## Linked Issue\n\nCloses #504\n\n## Issue Alignment\n\nThis PR implements the issue by:\n\n- Adding `frontend/src/api/practice.ts` with typed wrappers around `api.get` / `api.post` for:\n  - `GET /practice/history` \u2192 `getPracticeHistory`\n  - `GET /practice/stats` \u2192 `getPracticeStats`\n  - `POST /practice/next` \u2192 `startPractice` and `nextPracticeProblem`\n  - `POST /practice/attempts` \u2192 `submitPracticeAttempt`\n- Exporting readonly query-key constants `PRACTICE_HISTORY_KEY` (exactly `[\"practice-history\"]`) and `PRACTICE_STATS_KEY` (exactly `[\"practice-stats\"]`).\n- Moving `PracticeStatsResponse` from `PracticePage.tsx` into `frontend/src/types/practice.ts` with its single `practiceableCount` field unchanged.\n- Migrating the three named pages to import functions/keys from the new module while keeping React Query orchestration in the pages.\n- Adding `frontend/src/api/practice.test.ts` to pin the exact request contracts and query-key values.\n\nScope covered:\n\n- Practice transport ownership moved to a feature API module.\n- Exact query-key identity preserved and centralized.\n- `PracticeStatsResponse` canonicalized in `types/practice.ts`.\n- Page-level reads, invalidations, mutations, and coaching-origin history load migrated.\n\nOut of scope / intentionally not included:\n\n- No changes to `PracticeHistoryResponse` shape (no `total` / `hasMore`).\n- No URL, method, body, casing, response parsing, or error behavior changes.\n- No query-key identity, invalidation timing, polling cadence, enabled conditions, stale/cache settings, or navigation changes.\n- No migration of solution-status, coaching, problem, exam, or other feature APIs.\n- No hook extraction, state framework, or broad frontend reorganization.\n\n## Implementation Notes\n\n- `PracticePage`: history/stats queries and `startPractice` mutation now use `practice.ts`; the inline `PracticeStatsResponse` interface was removed.\n- `ActivePracticePage`: attempt and next-problem mutations plus history invalidation now use the shared module.\n- `CoachingPage`: conditional practice-history query now uses `getPracticeHistory` and `PRACTICE_HISTORY_KEY`.\n- `api.getSolutionStatus` is intentionally left in `@/api/client` because it is a problem-level concern, not a practice transport function. The pages still import `api` only for that method.\n- The new test file asserts exact URL, method, headers, credentials, JSON body, response type, and key equality to guard against drift.\n\n## Tests\n\nCommands run:\n\n- `cd frontend \u0026\u0026 npm test -- --run src/api/practice.test.ts src/pages/PracticePage.test.tsx src/pages/ActivePracticePage.test.tsx src/pages/CoachingPage.test.tsx` \u2014 passed (58 tests).\n- `cd frontend \u0026\u0026 npm test -- --run` \u2014 passed (35 test files, 549 tests).\n- `cd frontend \u0026\u0026 npx tsc --noEmit` \u2014 passed with no type errors.\n- `! rg -n \"practice-history\" frontend/src/pages --glob \"*.{ts,tsx}\"` \u2014 passed; the only remaining `practice-history` literal is the exported key in `src/api/practice.ts`.\n- `git diff --check` \u2014 passed.\n\nAutomated tests added or updated:\n\n- `frontend/src/api/practice.test.ts` (new):\n  - asserts exact query-key values\n  - asserts `getPracticeHistory` GETs `/api/v1/practice/history`\n  - asserts `getPracticeStats` GETs `/api/v1/practice/stats`\n  - asserts `startPractice` and `nextPracticeProblem` POST `{}` to `/api/v1/practice/next`\n  - asserts `submitPracticeAttempt` POSTs `{ problemId, submittedAnswer }` to `/api/v1/practice/attempts`\n- Existing page tests for `PracticePage`, `ActivePracticePage`, `CoachingPage` remain green and continue to exercise the migrated orchestration.\n\nManual verification:\n\n- Searched `frontend/src/pages` for the literal string `practice-history` and confirmed no duplicate inline keys remain.\n- Verified TypeScript compilation and the full frontend unit/component suite pass.\n- Confirmed the migrated pages still import `api` only for `getSolutionStatus`, which is out of scope for this seam.\n\n## Deviations From Issue Plan\n\nNone.\n\n## Follow-Up Work\n\nNone within this PR. Per the issue, broader R-003 frontend ownership work or any practice response-type correction must wait for human/council reassessment.\n