### PR TITLE
Move graph DSL sanitizer policy into the whiteboard domain

### DIFF
--- a/backend/app/domain/whiteboard/__init__.py
+++ b/backend/app/domain/whiteboard/__init__.py
@@ -1,0 +1,5 @@
+"""Whiteboard domain package."""
+
+from .graph_dsl import sanitize_whiteboard_dsl
+
+__all__ = ["sanitize_whiteboard_dsl"]

--- a/backend/app/domain/whiteboard/graph_dsl.py
+++ b/backend/app/domain/whiteboard/graph_dsl.py
@@ -1,0 +1,264 @@
+"""Graph/whiteboard DSL sanitizer policy.
+
+This module owns the complete existing sanitizer policy that was previously
+embedded in the VLM coaching client. It exposes a single public function,
+``sanitize_whiteboard_dsl``, which validates and cleans a raw whiteboard DSL
+string so it can safely be executed as JSXGraph DSL inside the browser sandbox.
+"""
+
+from __future__ import annotations
+
+import re
+
+_ALLOWED_DSL_ELEMENT_TYPES = {
+    "point",
+    "segment",
+    "line",
+    "arrow",
+    "circle",
+    "angle",
+    "polygon",
+    "text",
+    "glider",
+    "intersection",
+    "midpoint",
+    "perpendicular",
+}
+
+_ALLOWED_DSL_OPTION_KEYS = {
+    "anchorX",
+    "anchorY",
+    "color",
+    "dash",
+    "face",
+    "fillColor",
+    "fillOpacity",
+    "fixed",
+    "fontSize",
+    "highlight",
+    "label",
+    "name",
+    "opacity",
+    "radius",
+    "showInfobox",
+    "size",
+    "strokeColor",
+    "strokeOpacity",
+    "strokeWidth",
+    "visible",
+    "withLabel",
+}
+
+_BLOCKED_DSL_TOKENS = {
+    "constructor",
+    "document",
+    "eval",
+    "fetch",
+    "for",
+    "function",
+    "globalThis",
+    "if",
+    "import",
+    "localStorage",
+    "new",
+    "prototype",
+    "return",
+    "sessionStorage",
+    "setInterval",
+    "setTimeout",
+    "this",
+    "while",
+    "window",
+    "XMLHttpRequest",
+    "__proto__",
+}
+
+_MAX_DSL_LENGTH = 16384
+
+
+def _strip_quoted_strings(value: str) -> str:
+    return re.sub(r"""'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"""", "", value)
+
+
+def _split_top_level(value: str, delimiter: str) -> list[str] | None:
+    parts: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(value):
+        if quote:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+
+        if char in {"'", '"'}:
+            quote = char
+        elif char in {"[", "{", "("}:
+            depth += 1
+        elif char in {"]", "}", ")"}:
+            depth -= 1
+            if depth < 0:
+                return None
+        elif char == delimiter and depth == 0:
+            parts.append(value[start:index].strip())
+            start = index + 1
+
+    if quote or depth != 0:
+        return None
+
+    last = value[start:].strip()
+    if last:
+        parts.append(last)
+    return parts
+
+
+def _is_js_string_literal(value: str) -> bool:
+    return bool(re.fullmatch(r"""'(?:\\.|[^'\\])*'|\"(?:\\.|[^\"\\])*\"""", value))
+
+
+def _validate_dsl_object(value: str, declared_names: set[str]) -> bool:
+    if not value.startswith("{") or not value.endswith("}"):
+        return False
+    inner = value[1:-1].strip()
+    if not inner:
+        return True
+    entries = _split_top_level(inner, ",")
+    if entries is None:
+        return False
+    for entry in entries:
+        pair = _split_top_level(entry, ":")
+        if pair is None or len(pair) != 2:
+            return False
+        key = pair[0].strip().strip('""')
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) or key not in _ALLOWED_DSL_OPTION_KEYS:
+            return False
+        if not _validate_dsl_value(pair[1], declared_names):
+            return False
+    return True
+
+
+def _validate_dsl_value(value: str, declared_names: set[str]) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return False
+    if re.fullmatch(r"-?\d+(?:\.\d+)?", stripped):
+        return True
+    if _is_js_string_literal(stripped):
+        return True
+    if stripped in {"true", "false", "null"}:
+        return True
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", stripped):
+        return stripped in declared_names
+    if stripped.startswith("[") and stripped.endswith("]"):
+        inner = stripped[1:-1].strip()
+        if not inner:
+            return True
+        items = _split_top_level(inner, ",")
+        return items is not None and all(_validate_dsl_value(item, declared_names) for item in items)
+    if stripped.startswith("{") and stripped.endswith("}"):
+        return _validate_dsl_object(stripped, declared_names)
+    return False
+
+
+def _validate_dsl_create_call(call: str, declared_names: set[str]) -> bool:
+    if not call.startswith("board.create(") or not call.endswith(")"):
+        return False
+    args = _split_top_level(call[len("board.create(") : -1], ",")
+    if args is None or len(args) < 2 or len(args) > 3:
+        return False
+    element_type_arg = args[0].strip()
+    if not _is_js_string_literal(element_type_arg):
+        return False
+    element_type = element_type_arg[1:-1]
+    if element_type not in _ALLOWED_DSL_ELEMENT_TYPES:
+        return False
+    if not _validate_dsl_value(args[1], declared_names):
+        return False
+    if len(args) == 3 and not _validate_dsl_object(args[2].strip(), declared_names):
+        return False
+    return True
+
+
+def _is_allowed_graph_dsl(dsl: str) -> bool:
+    if len(dsl) > _MAX_DSL_LENGTH:
+        return False
+    unquoted = _strip_quoted_strings(dsl)
+    if re.search(r"=>|`|//|/\*|\*/|\+\+|--", unquoted):
+        return False
+    for token in _BLOCKED_DSL_TOKENS:
+        if re.search(rf"\b{re.escape(token)}\b", unquoted, re.IGNORECASE):
+            return False
+
+    statements = _split_top_level(dsl, ";")
+    if statements is None:
+        return False
+
+    declared_names: set[str] = set()
+    for statement in [part for part in statements if part]:
+        bbox_match = re.fullmatch(r"board\.setBoundingBox\((.*)\)", statement)
+        if bbox_match:
+            value = bbox_match.group(1).strip()
+            parts = (
+                _split_top_level(value[1:-1], ",")
+                if value.startswith("[") and value.endswith("]")
+                else None
+            )
+            if parts is None or len(parts) != 4 or not all(re.fullmatch(r"-?\d+(?:\.\d+)?", part.strip()) for part in parts):
+                return False
+            continue
+
+        declaration_match = re.fullmatch(
+            r"var\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(board\.create\(.*\))",
+            statement,
+        )
+        if declaration_match:
+            name = declaration_match.group(1)
+            if name in declared_names:
+                return False
+            if not _validate_dsl_create_call(declaration_match.group(2), declared_names):
+                return False
+            declared_names.add(name)
+            continue
+
+        if statement.startswith("board.create("):
+            if not _validate_dsl_create_call(statement, declared_names):
+                return False
+            continue
+
+        return False
+
+    return True
+
+
+def sanitize_whiteboard_dsl(dsl: str | None) -> str | None:
+    """Return cleaned DSL or None if the input is unsafe, empty, or malformed.
+
+    The policy strips markdown code fences, removes ``JXG.JSXGraph.initBoard``
+    boilerplate, then validates the remaining DSL against the allowed grammar,
+    element types, option keys, and blocked-token list.
+    """
+    if dsl is None:
+        return None
+
+    stripped = dsl.strip()
+    if not stripped:
+        return None
+
+    # Remove markdown code fences: ```js ... ``` or ``` ... ```
+    fence_match = re.match(r"^```(?:\w*)\n?(.*?)\n?```$", stripped, re.DOTALL)
+    if fence_match:
+        stripped = fence_match.group(1).strip()
+
+    # Strip initBoard calls — board already exists in the sandbox
+    stripped = re.sub(r"var\s+\w+\s*=\s*JXG\.JSXGraph\.initBoard\([^)]*\)\s*;?", "", stripped)
+    stripped = stripped.strip()
+
+    if stripped and not _is_allowed_graph_dsl(stripped):
+        return None
+
+    return stripped if stripped else None

--- a/backend/app/domain/whiteboard/graph_dsl.py
+++ b/backend/app/domain/whiteboard/graph_dsl.py
@@ -134,7 +134,7 @@ def _validate_dsl_object(value: str, declared_names: set[str]) -> bool:
         pair = _split_top_level(entry, ":")
         if pair is None or len(pair) != 2:
             return False
-        key = pair[0].strip().strip('""')
+        key = pair[0].strip().strip("'\"")
         if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) or key not in _ALLOWED_DSL_OPTION_KEYS:
             return False
         if not _validate_dsl_value(pair[1], declared_names):

--- a/backend/app/infrastructure/vlm/solution_coaching_client.py
+++ b/backend/app/infrastructure/vlm/solution_coaching_client.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
-import re
 from typing import Any, Callable, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
+from app.domain.whiteboard import sanitize_whiteboard_dsl
 from app.infrastructure.config.settings import Settings, get_settings
 from app.infrastructure.vlm.base_client import (
     FAILURE_CODE_INVALID_RESPONSE,
@@ -31,70 +31,6 @@ from app.infrastructure.vlm.solution_coaching_prompts import (
     build_coaching_user_prompt,
     build_solution_user_prompt,
 )
-
-_ALLOWED_DSL_ELEMENT_TYPES = {
-    "point",
-    "segment",
-    "line",
-    "arrow",
-    "circle",
-    "angle",
-    "polygon",
-    "text",
-    "glider",
-    "intersection",
-    "midpoint",
-    "perpendicular",
-}
-
-_ALLOWED_DSL_OPTION_KEYS = {
-    "anchorX",
-    "anchorY",
-    "color",
-    "dash",
-    "face",
-    "fillColor",
-    "fillOpacity",
-    "fixed",
-    "fontSize",
-    "highlight",
-    "label",
-    "name",
-    "opacity",
-    "radius",
-    "showInfobox",
-    "size",
-    "strokeColor",
-    "strokeOpacity",
-    "strokeWidth",
-    "visible",
-    "withLabel",
-}
-
-_BLOCKED_DSL_TOKENS = {
-    "constructor",
-    "document",
-    "eval",
-    "fetch",
-    "for",
-    "function",
-    "globalThis",
-    "if",
-    "import",
-    "localStorage",
-    "new",
-    "prototype",
-    "return",
-    "sessionStorage",
-    "setInterval",
-    "setTimeout",
-    "this",
-    "while",
-    "window",
-    "XMLHttpRequest",
-    "__proto__",
-}
-
 
 class SolutionCoachingVLMError(BaseVLMError):
     pass
@@ -371,189 +307,6 @@ class SolutionVLMClient(_BaseSolutionCoachingVLMClient):
             ) from exc
 
 
-def _strip_quoted_strings(value: str) -> str:
-    return re.sub(r"""'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*" """.strip(), "", value)
-
-
-def _split_top_level(value: str, delimiter: str) -> list[str] | None:
-    parts: list[str] = []
-    start = 0
-    depth = 0
-    quote: str | None = None
-    escaped = False
-    for index, char in enumerate(value):
-        if quote:
-            if escaped:
-                escaped = False
-            elif char == "\\":
-                escaped = True
-            elif char == quote:
-                quote = None
-            continue
-
-        if char in {"'", '"'}:
-            quote = char
-        elif char in {"[", "{", "("}:
-            depth += 1
-        elif char in {"]", "}", ")"}:
-            depth -= 1
-            if depth < 0:
-                return None
-        elif char == delimiter and depth == 0:
-            parts.append(value[start:index].strip())
-            start = index + 1
-
-    if quote or depth != 0:
-        return None
-
-    last = value[start:].strip()
-    if last:
-        parts.append(last)
-    return parts
-
-
-def _is_js_string_literal(value: str) -> bool:
-    return bool(re.fullmatch(r"""'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*" """.strip(), value))
-
-
-def _validate_dsl_object(value: str, declared_names: set[str]) -> bool:
-    if not value.startswith("{") or not value.endswith("}"):
-        return False
-    inner = value[1:-1].strip()
-    if not inner:
-        return True
-    entries = _split_top_level(inner, ",")
-    if entries is None:
-        return False
-    for entry in entries:
-        pair = _split_top_level(entry, ":")
-        if pair is None or len(pair) != 2:
-            return False
-        key = pair[0].strip().strip("'\"")
-        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) or key not in _ALLOWED_DSL_OPTION_KEYS:
-            return False
-        if not _validate_dsl_value(pair[1], declared_names):
-            return False
-    return True
-
-
-def _validate_dsl_value(value: str, declared_names: set[str]) -> bool:
-    stripped = value.strip()
-    if not stripped:
-        return False
-    if re.fullmatch(r"-?\d+(?:\.\d+)?", stripped):
-        return True
-    if _is_js_string_literal(stripped):
-        return True
-    if stripped in {"true", "false", "null"}:
-        return True
-    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", stripped):
-        return stripped in declared_names
-    if stripped.startswith("[") and stripped.endswith("]"):
-        inner = stripped[1:-1].strip()
-        if not inner:
-            return True
-        items = _split_top_level(inner, ",")
-        return items is not None and all(_validate_dsl_value(item, declared_names) for item in items)
-    if stripped.startswith("{") and stripped.endswith("}"):
-        return _validate_dsl_object(stripped, declared_names)
-    return False
-
-
-def _validate_dsl_create_call(call: str, declared_names: set[str]) -> bool:
-    if not call.startswith("board.create(") or not call.endswith(")"):
-        return False
-    args = _split_top_level(call[len("board.create(") : -1], ",")
-    if args is None or len(args) < 2 or len(args) > 3:
-        return False
-    element_type_arg = args[0].strip()
-    if not _is_js_string_literal(element_type_arg):
-        return False
-    element_type = element_type_arg[1:-1]
-    if element_type not in _ALLOWED_DSL_ELEMENT_TYPES:
-        return False
-    if not _validate_dsl_value(args[1], declared_names):
-        return False
-    if len(args) == 3 and not _validate_dsl_object(args[2].strip(), declared_names):
-        return False
-    return True
-
-
-_MAX_DSL_LENGTH = 16384
-
-
-def _is_allowed_graph_dsl(dsl: str) -> bool:
-    if len(dsl) > _MAX_DSL_LENGTH:
-        return False
-    unquoted = _strip_quoted_strings(dsl)
-    if re.search(r"=>|`|//|/\*|\*/|\+\+|--", unquoted):
-        return False
-    for token in _BLOCKED_DSL_TOKENS:
-        if re.search(rf"\b{re.escape(token)}\b", unquoted, re.IGNORECASE):
-            return False
-
-    statements = _split_top_level(dsl, ";")
-    if statements is None:
-        return False
-
-    declared_names: set[str] = set()
-    for statement in [part for part in statements if part]:
-        bbox_match = re.fullmatch(r"board\.setBoundingBox\((.*)\)", statement)
-        if bbox_match:
-            value = bbox_match.group(1).strip()
-            parts = (
-                _split_top_level(value[1:-1], ",")
-                if value.startswith("[") and value.endswith("]")
-                else None
-            )
-            if parts is None or len(parts) != 4 or not all(re.fullmatch(r"-?\d+(?:\.\d+)?", part.strip()) for part in parts):
-                return False
-            continue
-
-        declaration_match = re.fullmatch(
-            r"var\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(board\.create\(.*\))",
-            statement,
-        )
-        if declaration_match:
-            name = declaration_match.group(1)
-            if name in declared_names:
-                return False
-            if not _validate_dsl_create_call(declaration_match.group(2), declared_names):
-                return False
-            declared_names.add(name)
-            continue
-
-        if statement.startswith("board.create("):
-            if not _validate_dsl_create_call(statement, declared_names):
-                return False
-            continue
-
-        return False
-
-    return True
-
-
-def _sanitize_whiteboard_dsl(dsl: str | None) -> str | None:
-    if dsl is None:
-        return None
-
-    stripped = dsl.strip()
-    if not stripped:
-        return None
-
-    # Remove markdown code fences: ```js ... ``` or ``` ... ```
-    fence_match = re.match(r"^```(?:\w*)\n?(.*?)\n?```$", stripped, re.DOTALL)
-    if fence_match:
-        stripped = fence_match.group(1).strip()
-
-    # Strip initBoard calls — board already exists in the sandbox
-    stripped = re.sub(r"var\s+\w+\s*=\s*JXG\.JSXGraph\.initBoard\([^)]*\)\s*;?", "", stripped)
-    stripped = stripped.strip()
-
-    if stripped and not _is_allowed_graph_dsl(stripped):
-        return None
-
-    return stripped if stripped else None
 
 
 class CoachingVLMClient(_BaseSolutionCoachingVLMClient):
@@ -634,7 +387,7 @@ class CoachingVLMClient(_BaseSolutionCoachingVLMClient):
         return CoachingVLMResult(
             model=self._model,
             text=parsed.text,
-            whiteboard_dsl=_sanitize_whiteboard_dsl(parsed.whiteboard_dsl),
+            whiteboard_dsl=sanitize_whiteboard_dsl(parsed.whiteboard_dsl),
             reasoning_content=parsed.reasoning_content,
             raw_provider_response=raw_provider_response,
         )

--- a/backend/tests/domain/test_graph_dsl_sanitizer.py
+++ b/backend/tests/domain/test_graph_dsl_sanitizer.py
@@ -1,8 +1,8 @@
 import pytest
 
-from app.infrastructure.vlm.solution_coaching_client import (
+from app.domain.whiteboard.graph_dsl import (
+    sanitize_whiteboard_dsl,
     _is_allowed_graph_dsl,
-    _sanitize_whiteboard_dsl,
     _split_top_level,
     _strip_quoted_strings,
     _validate_dsl_create_call,
@@ -180,41 +180,41 @@ class TestIsAllowedGraphDsl:
 
 class TestSanitizeWhiteboardDsl:
     def test_returns_none_for_none(self) -> None:
-        assert _sanitize_whiteboard_dsl(None) is None
+        assert sanitize_whiteboard_dsl(None) is None
 
     def test_returns_none_for_empty_string(self) -> None:
-        assert _sanitize_whiteboard_dsl("") is None
+        assert sanitize_whiteboard_dsl("") is None
 
     def test_returns_none_for_whitespace_only(self) -> None:
-        assert _sanitize_whiteboard_dsl("   \n\t  ") is None
+        assert sanitize_whiteboard_dsl("   \n\t  ") is None
 
     def test_strips_markdown_code_fence(self) -> None:
         raw = "```js\nvar p = board.create('point', [0, 0]);\n```"
-        assert _sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
+        assert sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
 
     def test_strips_plain_code_fence(self) -> None:
         raw = "```\nvar p = board.create('point', [0, 0]);\n```"
-        assert _sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
+        assert sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
 
     def test_strips_initboard_call(self) -> None:
         raw = "var board = JXG.JSXGraph.initBoard('box', {boundingbox: [-5, 5, 5, -5]}); var p = board.create('point', [0, 0]);"
-        assert _sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
+        assert sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
 
     def test_returns_none_for_disallowed_dsl(self) -> None:
-        assert _sanitize_whiteboard_dsl("fetch('/api/private');") is None
+        assert sanitize_whiteboard_dsl("fetch('/api/private');") is None
 
     def test_returns_sanitized_dsl_for_allowed_input(self) -> None:
         raw = "var p = board.create('point', [0, 0]);"
-        assert _sanitize_whiteboard_dsl(raw) == raw
+        assert sanitize_whiteboard_dsl(raw) == raw
 
     def test_strips_initboard_without_semicolon(self) -> None:
         raw = "var board = JXG.JSXGraph.initBoard('box', {boundingbox: [-5, 5, 5, -5]}) var p = board.create('point', [0, 0]);"
-        assert _sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
+        assert sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
 
     def test_returns_none_after_initboard_strips_to_empty(self) -> None:
         raw = "var board = JXG.JSXGraph.initBoard('box', {boundingbox: [-5, 5, 5, -5]});"
-        assert _sanitize_whiteboard_dsl(raw) is None
+        assert sanitize_whiteboard_dsl(raw) is None
 
     def test_strips_initboard_with_extra_whitespace(self) -> None:
         raw = "var  board  =  JXG.JSXGraph.initBoard(  'box'  )  ;  var p = board.create('point', [0, 0]);"
-        assert _sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"
+        assert sanitize_whiteboard_dsl(raw) == "var p = board.create('point', [0, 0]);"

--- a/backend/tests/domain/test_graph_dsl_sanitizer.py
+++ b/backend/tests/domain/test_graph_dsl_sanitizer.py
@@ -170,6 +170,10 @@ class TestIsAllowedGraphDsl:
     def test_rejects_invalid_bounding_box(self) -> None:
         assert _is_allowed_graph_dsl("board.setBoundingBox([0, 0])") is False
 
+    def test_allows_single_quoted_option_key(self) -> None:
+        dsl = "var p = board.create('point', [0, 0], {'name': 'P'});"
+        assert _is_allowed_graph_dsl(dsl) is True
+
     def test_rejects_duplicate_declaration(self) -> None:
         dsl = "var A = board.create('point', [0, 0]); var A = board.create('point', [1, 1]);"
         assert _is_allowed_graph_dsl(dsl) is False


### PR DESCRIPTION
Model-Signature: ollama-cloud/kimi-k2.7-code\n\n## Summary\n\nMove the entire existing graph/whiteboard DSL sanitizer policy from the VLM transport client into a dedicated whiteboard domain module, exposing exactly one public API. The VLM coaching client now delegates to that API, and direct sanitizer tests target the domain module instead of private transport helpers. All characterized and browser-visible behavior is preserved exactly.\n\n## Linked Issue\n\nCloses #505\n\n## Issue Alignment\n\nThis PR implements the issue by:\n\n- Creating backend/app/domain/whiteboard/__init__.py and backend/app/domain/whiteboard/graph_dsl.py.\n- Moving the complete existing policy (allowed element types, allowed option keys, blocked tokens, max-length, grammar validation, fence stripping, initBoard stripping, and unsafe fallback) verbatim behind one public function sanitize_whiteboard_dsl.\n- Updating CoachingVLMClient.send_message to call sanitize_whiteboard_dsl from the domain module instead of the private _sanitize_whiteboard_dsl.\n- Removing all constants and private helpers that are now owned by the domain module from solution_coaching_client.py, including the obsolete import re.\n- Updating backend/tests/domain/test_graph_dsl_sanitizer.py to import from app.domain.whiteboard.graph_dsl instead of app.infrastructure.vlm.solution_coaching_client.\n- Running a deterministic before/after corpus comparison to prove identical outputs for allowed, rejected, fenced, wrapped, oversized (max-length boundary), malformed, empty, and null inputs.\n\nScope covered:\n\n- Whiteboard domain package/module creation.\n- Sanitizer policy relocation behind a single public API.\n- VLM client delegation to the new API.\n- Test import migration to the public domain API.\n- Before/after corpus comparison covering existing security cases.\n\nOut of scope / intentionally not included:\n\n- No grammar, allowed element type, option key, blocked-token, or 16,384-character-limit changes.\n- No code-fence or initBoard-wrapper stripping changes.\n- No unsafe/empty/malformed fallback behavior changes.\n- No frontend GraphSandbox, sandbox attributes, or browser validation changes.\n- No VLM prompt, parsing, response-model, or unrelated client refactoring.\n- No cross-language corpus generator, shared security framework, or JS sanitizer.\n\n## Implementation Notes\n\n- The policy is copied verbatim; every constant, regex, helper, and branch order is identical to the original implementation.\n- The public API is app.domain.whiteboard.graph_dsl.sanitize_whiteboard_dsl (also re-exported from app.domain.whiteboard).\n- Grammar internals remain private to the domain module.\n- The VLM client keeps only the call site change: whiteboard_dsl=sanitize_whiteboard_dsl(parsed.whiteboard_dsl).\n\n## Tests\n\nCommands run:\n\n- uv run --directory backend pytest tests/domain/test_graph_dsl_sanitizer.py tests/infrastructure/test_solution_coaching_client.py -q -- passed (103 tests).\n- ./scripts/agent-env.sh test backend -- passed (959 passed, 1 skipped).\n- rg search for private sanitizer names across backend/app and backend/tests excluding the new domain module and its test -- no hits, confirming no duplicate policy remains in transport or other tests.\n- git diff --check -- passed.\n\nAutomated tests added or updated:\n\n- backend/tests/domain/test_graph_dsl_sanitizer.py (updated): imports from the new public domain module and continues to cover every existing case (string stripping, top-level splitting, create-call validation, allowed/rejected DSL, max-length boundary, markdown fences, initBoard stripping, empty/null inputs).\n- backend/tests/infrastructure/test_solution_coaching_client.py (existing): still exercises the VLM client's use of the sanitizer through CoachingVLMClient end-to-end; passed unchanged.\n\nManual verification:\n\n- Before/after corpus comparison using the same representative inputs (allowed multi-statement DSL, every unsafe case from existing tests, fenced/wrapped DSL, initBoard-only input, empty/whitespace/null, and max-length boundary string) produced identical JSON outputs.\n- Confirmed no remaining imports of private sanitizer helpers from solution_coaching_client.py anywhere in backend/app or backend/tests (except the legitimate VLM client usage of the public API).\n\n## Deviations From Issue Plan\n\nNone.\n\n## Follow-Up Work\n\nPer the issue, a formal cross-language contract/corpus and any grammar or policy change remain separately gated and are not part of this PR.\n