### PR TITLE
test+docs: add exam grading parity characterization (#506)

### DIFF
--- a/backend/docs/exam_grading_parity.md
+++ b/backend/docs/exam_grading_parity.md
@@ -202,10 +202,10 @@ storage adapter, then runs the result-persistence transaction.
 
 **Worker path:**
 
-- `run_exam_grading_worker` constructs one `build_grading_vlm_client(settings)`
-per claimed task in its `try` block and calls `await vlm_client.aclose()` in
-the matching `finally` block. So VLM client lifecycle is one client per task,
-closed after `process_exam_grading_task` returns or raises.
+- `run_exam_grading_worker` constructs one `VLMClient(...)` per claimed task in
+its `try` block and calls `await vlm_client.aclose()` in the matching `finally`
+block. So VLM client lifecycle is one client per task, closed after
+`process_exam_grading_task` returns or raises.
 - The storage adapter is constructed once at worker startup (or passed in) and
 shared across all tasks. It is not closed per task.
 - `process_exam_grading_task` receives the already-built VLM client and storage

--- a/backend/docs/exam_grading_parity.md
+++ b/backend/docs/exam_grading_parity.md
@@ -1,0 +1,158 @@
+# Exam Grading Parity
+
+This document records the behavior of the two exam-grading execution paths and the
+characterization tests that keep them aligned.
+
+## Paths
+
+| Path | Entry point | When it runs | Transaction boundary |
+|------|-------------|--------------|----------------------|
+| Synchronous | `app.presentation.exams._submit_exam_synchronous` | `POST /api/v1/exams/{id}/submit` for objective-only exams | Single function, writes exam + problems + task inside the call |
+| Worker | `app.infrastructure.worker.exam_grading_worker.process_exam_grading_task` | Celery task (`exam_grading_task`) for exams containing short-answer / essay items | Per-task function; idempotent re-runs are safe |
+
+Both paths use the same item-grading helpers in `app.presentation.exam_grading`:
+
+- `grade_item`
+- `build_tracking_update`
+- `_compute_objective_grade`
+
+## Grading outcomes
+
+A graded item is stored as:
+
+```text
+items[].grading:
+  status                -> graded | pending_review | needs_review
+  method                -> exact_match | llm_judge | self_report | system_error
+  isCorrect             -> bool | None
+  score                 -> 0..1
+  retryCount            -> int
+  selfReportedCorrect   -> bool | None
+```
+
+The worker additionally writes:
+
+```text
+summary:
+  autoGradedCount
+  pendingReviewCount
+  needsReviewCount
+  completedCount
+```
+
+The synchronous path does not populate `summary` for objective-only exams
+because the result is returned immediately; the fields are not required by the
+API contract for that endpoint.
+
+## Tracking updates
+
+Both paths update `problems.tracking` with `build_tracking_update`, which
+increments:
+
+- `exposureCount`
+- `correctCount` if `isCorrect`
+- `failedCount` if not `isCorrect`
+- sets `lastTestedAt` and `lastAttemptCorrect`
+
+There is one intentional divergence:
+
+- The synchronous path does **not** increment `exposureCount` during exam
+  creation; it only increments during the grading transaction.
+- The worker path also does not select problems, so it matches the sync
+  end-state after one grading transaction.
+
+Consequently, a problem that starts with `exposureCount: 0` ends at `1` after
+one synchronous submit or one worker task, not `2`.
+
+## Objective-only parity
+
+For an exam that contains only objective items (`single-choice`, `multiple-choice`,
+`fill-in-the-blank`), the synchronous submit and a single worker run produce the
+same final item-level grading and problem tracking.
+
+This is asserted by
+`tests/integration/test_exam_grading_parity.py::test_parity_objective_only_sync_matches_worker`.
+
+## Short-answer / essay flow
+
+Items with `problemType: short-answer` or `problemType: essay` require a VLM
+judge and are always routed through the worker.
+
+- `grade_item` calls the VLM with a judge prompt.
+- If the VLM returns a parseable verdict, the item is `graded` with
+  `method: llm_judge`.
+- If the VLM fails or returns an unparsable verdict, the worker retries up to
+  `MAX_VLM_RETRIES` (configured per deployment, default `3`).
+- After retries are exhausted the item becomes `pending_review` with
+  `method: system_error`.
+
+See `tests/integration/test_exam_grading_parity.py::test_parity_short_answer_retry_then_success`
+and `test_parity_short_answer_retry_exhaustion_pending_review_then_self_report`.
+
+## Self-report tracking
+
+When an item is `pending_review` or `needs_review`, a learner (or reviewer) can
+submit a self-report via `POST /api/v1/exams/{id}/items/{itemId}/self-report`.
+
+- If `selfReportedCorrect: true`, the item becomes `graded`,
+  `method: self_report`, `isCorrect: true`, `score: 1`.
+- If `selfReportedCorrect: false`, the item becomes `graded`,
+  `method: self_report`, `isCorrect: false`, `score: 0`.
+
+The self-report endpoint updates problem tracking in the same way as an
+auto-graded item.
+
+## Worker idempotency
+
+The worker is designed to be safely re-run on the same exam:
+
+- Already-graded items are skipped.
+- `pending_review` items are re-evaluated if the VLM becomes available.
+- Tracking is only mutated for items that change state, so a no-op re-run does
+  not double-count correct/failed counts.
+
+See `tests/integration/test_exam_grading_parity.py::test_parity_worker_rerun_is_idempotent`.
+
+## Failure / restart behavior
+
+If the worker crashes between items, a re-delivery resumes at the ungraded
+items. Terminal items (`graded`, `pending_review`, `needs_review`) are left
+untouched. This is asserted by
+`test_parity_worker_restart_preserves_terminal_items_and_tracking`.
+
+## What parity does **not** cover
+
+- **Response payloads**: the synchronous submit returns a JSON response; the
+  worker writes to the database and emits nothing to the caller.
+- **Timing / ordering**: the worker is asynchronous and may interleave with
+  other operations.
+- **VLM availability edge cases**: transient VLM failures are retried but not
+  guaranteed to converge if the service is permanently down.
+- **Exam creation side effects**: creation may log analytics or update selection
+  metadata that the worker path does not reproduce.
+
+## Running the parity tests
+
+```bash
+cd backend
+uv run --frozen --active pytest tests/integration/test_exam_grading_parity.py -q
+```
+
+To run the broader exam-grading related suites:
+
+```bash
+uv run --frozen --active pytest \
+  tests/presentation/test_exam_grading.py \
+  tests/worker/test_exam_grading_worker.py \
+  tests/api/test_exams.py \
+  tests/integration/test_exam_workflow.py \
+  tests/integration/test_exam_grading_parity.py \
+  -q
+```
+
+## Human review gate
+
+Changes that alter `app.presentation.exam_grading`,
+`app.presentation.exams._submit_exam_synchronous`, or
+`app.infrastructure.worker.exam_grading_worker` must update this document and
+keep the parity tests green before merge.

--- a/backend/docs/exam_grading_parity.md
+++ b/backend/docs/exam_grading_parity.md
@@ -1,135 +1,231 @@
 # Exam Grading Parity
 
-This document records the behavior of the two exam-grading execution paths and the
-characterization tests that keep them aligned.
+This document records the behavior of the exam-grading execution paths and the
+characterization tests that keep them aligned. It is a characterization artifact
+only; no production behavior or module location was changed.
 
 ## Paths
 
 | Path | Entry point | When it runs | Transaction boundary |
 |------|-------------|--------------|----------------------|
-| Synchronous | `app.presentation.exams._submit_exam_synchronous` | `POST /api/v1/exams/{id}/submit` for objective-only exams | Single function, writes exam + problems + task inside the call |
-| Worker | `app.infrastructure.worker.exam_grading_worker.process_exam_grading_task` | Celery task (`exam_grading_task`) for exams containing short-answer / essay items | Per-task function; idempotent re-runs are safe |
+| Synchronous | `app.presentation.exams._submit_exam_synchronous` | `POST /api/v1/exams/{id}/submit` when no item needs VLM grading | Single `with_transaction` covering exam state, items, summary, and problem tracking |
+| Worker | `app.infrastructure.worker.exam_grading_worker.process_exam_grading_task` | Celery task `exam_grading_task` when at least one item needs VLM grading | Per-item updates outside a transaction; finalization uses `with_transaction` for exam state, tracking, and task completion |
+| Self-report | `app.presentation.exams.self_report_exam_item` | `POST /api/v1/exams/{id}/items/{itemId}/self-report` for a `pending-review` item | Single `with_transaction` covering item grading, summary, and problem tracking |
 
-Both paths use the same item-grading helpers in `app.presentation.exam_grading`:
+All three paths use the same item-grading helpers in `app.presentation.exam_grading`:
 
 - `grade_item`
+- `grade_objective_item`
+- `grade_short_answer_item`
 - `build_tracking_update`
-- `_compute_objective_grade`
 
 ## Grading outcomes
 
-A graded item is stored as:
+A graded item stores:
 
 ```text
 items[].grading:
-  status                -> graded | pending_review | needs_review
-  method                -> exact_match | llm_judge | self_report | system_error
+  status                -> ungraded | correct | incorrect | pending-review
+  method                -> normalized-match | vlm | self-report
   isCorrect             -> bool | None
-  score                 -> 0..1
+  score                 -> 0..1 | None
+  feedback              -> str | None
+  providerModel         -> str | None
+  rawProviderResponse   -> Any | None
+  gradedAt              -> datetime | None
   retryCount            -> int
   selfReportedCorrect   -> bool | None
 ```
 
-The worker additionally writes:
+Terminal item statuses (`CORRECT`, `INCORRECT`, `PENDING_REVIEW`) are never
+re-graded by the worker (`TERMINAL_GRADING_STATUSES` in
+`app.presentation.exam_helpers`).
+
+The exam summary is produced by `build_exam_summary` using `compute_summary`:
 
 ```text
 summary:
-  autoGradedCount
-  pendingReviewCount
-  needsReviewCount
-  completedCount
+  totalProblems
+  answeredProblems
+  gradedProblems
+  pendingProblems
+  correctProblems
+  failedProblems
+  score
 ```
 
-The synchronous path does not populate `summary` for objective-only exams
-because the result is returned immediately; the fields are not required by the
-API contract for that endpoint.
+Both the synchronous path and the worker path store this summary. The
+synchronous path computes it once after all items are graded; the worker
+recomputes it after every item and stores the final value at finalization.
 
 ## Tracking updates
 
-Both paths update `problems.tracking` with `build_tracking_update`, which
+All paths update `problems.tracking` with `build_tracking_update`, which
 increments:
 
 - `exposureCount`
-- `correctCount` if `isCorrect`
-- `failedCount` if not `isCorrect`
-- sets `lastTestedAt` and `lastAttemptCorrect`
+- `correctCount` if the item is correct
+- `failedCount` if the item is incorrect
 
-There is one intentional divergence:
+and sets:
+
+- `lastTestedAt`
+- `lastAttemptCorrect`
+
+There is one deliberate divergence:
 
 - The synchronous path does **not** increment `exposureCount` during exam
-  creation; it only increments during the grading transaction.
-- The worker path also does not select problems, so it matches the sync
-  end-state after one grading transaction.
+creation. It increments only inside the submit transaction.
+- The worker path operates on an already-created exam, so it also increments
+tracking exactly once per graded item.
 
-Consequently, a problem that starts with `exposureCount: 0` ends at `1` after
-one synchronous submit or one worker task, not `2`.
+Consequently, a problem that starts with `exposureCount: 0` ends at `1` after one
+synchronous submit or one worker task, not `2`.
 
 ## Objective-only parity
 
-For an exam that contains only objective items (`single-choice`, `multiple-choice`,
-`fill-in-the-blank`), the synchronous submit and a single worker run produce the
-same final item-level grading and problem tracking.
+For an exam that contains only objective items (`single-choice`,
+`multi-choice`, `fill-in-the-blank`), the synchronous submit and a single worker
+run produce the same final item-level grading, summary, and problem tracking.
 
 This is asserted by
 `tests/integration/test_exam_grading_parity.py::test_parity_objective_only_sync_matches_worker`.
 
 ## Short-answer / essay flow
 
-Items with `problemType: short-answer` or `problemType: essay` require a VLM
-judge and are always routed through the worker.
+Items with `problemType: short-answer` require a VLM judge and are always routed
+through the worker.
 
-- `grade_item` calls the VLM with a judge prompt.
-- If the VLM returns a parseable verdict, the item is `graded` with
-  `method: llm_judge`.
-- If the VLM fails or returns an unparsable verdict, the worker retries up to
-  `MAX_VLM_RETRIES` (configured per deployment, default `3`).
-- After retries are exhausted the item becomes `pending_review` with
-  `method: system_error`.
+- `grade_item` calls `grade_short_answer_item`, which calls the VLM with a judge
+prompt.
+- If the VLM returns a parseable verdict, the item becomes `correct` or
+`incorrect` with `method: vlm`.
+- If the VLM raises a retryable `VLMError`, `grade_short_answer_item` performs
+exactly **one** retry (hardcoded limit in `backend/app/presentation/exam_grading.py`).
+- After the retry is exhausted, or on a non-retryable or unexpected error, the
+item becomes `pending-review` with `method: vlm` and the error stored in
+`feedback` / `rawProviderResponse`.
 
-See `tests/integration/test_exam_grading_parity.py::test_parity_short_answer_retry_then_success`
-and `test_parity_short_answer_retry_exhaustion_pending_review_then_self_report`.
+See
+`tests/integration/test_exam_grading_parity.py::test_parity_short_answer_vlm_retry_then_success`
+and
+`test_parity_short_answer_retry_exhaustion_then_self_report_updates_tracking_once`.
 
-## Self-report tracking
+## Self-report behavior
 
-When an item is `pending_review` or `needs_review`, a learner (or reviewer) can
-submit a self-report via `POST /api/v1/exams/{id}/items/{itemId}/self-report`.
+When an item is `pending-review`, a learner can submit a self-report via
+`POST /api/v1/exams/{id}/items/{itemId}/self-report`.
 
-- If `selfReportedCorrect: true`, the item becomes `graded`,
-  `method: self_report`, `isCorrect: true`, `score: 1`.
-- If `selfReportedCorrect: false`, the item becomes `graded`,
-  `method: self_report`, `isCorrect: false`, `score: 0`.
+- If `isCorrect: true`, the item becomes `correct`, `method: self-report`,
+`score: 1`.
+- If `isCorrect: false`, the item becomes `incorrect`, `method: self-report`,
+`score: 0`.
 
-The self-report endpoint updates problem tracking in the same way as an
-auto-graded item.
+The self-report endpoint rejects items whose status is not `pending-review`.
+It updates the exam summary and the problem tracking exactly once in the same
+transaction.
 
 ## Worker idempotency
 
 The worker is designed to be safely re-run on the same exam:
 
-- Already-graded items are skipped.
-- `pending_review` items are re-evaluated if the VLM becomes available.
-- Tracking is only mutated for items that change state, so a no-op re-run does
-  not double-count correct/failed counts.
+- Already-terminal items are skipped.
+- Each non-terminal item is graded and persisted exactly once per successful run.
+- `_finalize_exam` only updates tracking for items whose status is not
+`pending-review`, so a second run cannot double-count correct/failed counts.
 
-See `tests/integration/test_exam_grading_parity.py::test_parity_worker_rerun_is_idempotent`.
+See
+`tests/integration/test_exam_grading_parity.py::test_parity_worker_idempotent_rerun_does_not_double_apply_tracking`.
 
 ## Failure / restart behavior
 
-If the worker crashes between items, a re-delivery resumes at the ungraded
-items. Terminal items (`graded`, `pending_review`, `needs_review`) are left
-untouched. This is asserted by
+If the worker loses ownership or crashes between items, a later task claim
+resumes at the first non-terminal item. Terminal items are left untouched.
+This is asserted by
 `test_parity_worker_restart_preserves_terminal_items_and_tracking`.
 
-## What parity does **not** cover
+Ownership is guarded by a per-task `claimToken` and `leaseUntil` timestamp:
 
-- **Response payloads**: the synchronous submit returns a JSON response; the
-  worker writes to the database and emits nothing to the caller.
-- **Timing / ordering**: the worker is asynchronous and may interleave with
-  other operations.
-- **VLM availability edge cases**: transient VLM failures are retried but not
-  guaranteed to converge if the service is permanently down.
-- **Exam creation side effects**: creation may log analytics or update selection
-  metadata that the worker path does not reproduce.
+- `_claim_task` atomically claims a pending task or reclaims a stale-leased task.
+- `_refresh_lease` keeps the lease alive while grading runs.
+- `_verify_ownership` is checked before every item persistence and before
+finalization.
+- `_release_task` returns the task to `pending` if processing fails.
+
+## Transaction rollback / all-or-nothing behavior
+
+The synchronous path and the self-report path both wrap exam/item/summary and
+problem-tracking writes in `session.with_transaction`. The worker's
+`_finalize_exam` also uses `session.with_transaction` when a real Mongo adapter
+is available.
+
+**Why a dedicated rollback characterization test is not included:**
+
+The existing integration test harness (`tests/integration/conftest.py`) uses
+`FakeDatabase` and `FakeMongoAdapter`, which are in-memory fakes without
+multi-document transaction support. `FakeSession.with_transaction` simply runs
+the callback with a dummy session and never aborts. Exercising a real
+`with_transaction` abort requires a real MongoDB replica set, a test-specific
+adapter, and a deterministic way to trigger a failure inside the callback
+without adding production seams solely for testability.
+
+The strongest available evidence is therefore:
+
+1. The production code uses `session.with_transaction` in the three mutating
+paths listed above.
+2. The worker's per-item grading loop is intentionally **outside** a
+transaction: each item is persisted as soon as it is graded so that a crash
+can resume from the last completed item rather than losing all progress.
+3. The worker's finalization step groups the exam-state transition,
+problem-tracking updates, and task completion into one transaction when the
+adapter supports sessions.
+
+A real-Mongo rollback test would require a new test harness that is not part of
+the current fake-based integration seam. That work is out of scope for this
+characterization issue.
+
+## VLM and S3/storage lifecycle ownership
+
+### Current ownership
+
+**Synchronous path:**
+
+- `get_grading_vlm_client` (in `app.presentation.deps`) is a FastAPI dependency
+that constructs a grading VLM client per request and closes it with
+`aclose()` in a `finally` block after the endpoint returns.
+- `get_s3_storage` constructs an `S3StorageAdapter` per request. The adapter is a
+thin wrapper around `boto3.client("s3", ...)`; the boto3 client is created
+lazily on first use and is not explicitly closed per request. It lives for the
+request duration and is garbage collected afterward.
+- The sync endpoint calls `grade_item` with the request-scoped VLM client and
+storage adapter, then runs the result-persistence transaction.
+
+**Worker path:**
+
+- `run_exam_grading_worker` constructs one `build_grading_vlm_client(settings)`
+per claimed task in its `try` block and calls `await vlm_client.aclose()` in
+the matching `finally` block. So VLM client lifecycle is one client per task,
+closed after `process_exam_grading_task` returns or raises.
+- The storage adapter is constructed once at worker startup (or passed in) and
+shared across all tasks. It is not closed per task.
+- `process_exam_grading_task` receives the already-built VLM client and storage
+adapter as arguments; it does not construct or close them itself.
+
+### Candidate later boundary
+
+A possible later refactor is to extract pure grading rules (score computation,
+answer normalization, summary computation, tracking deltas) into
+`app/domain/exam` while keeping concrete VLM and S3 coordination outside the
+domain layer. That boundary is **not approved here**.
+
+- Current ownership: orchestration lives in `app.presentation.exams` and
+`app.infrastructure.worker.exam_grading_worker`; shared grading logic lives in
+`app.presentation.exam_grading`; domain models live in `app.domain.models`.
+- Candidate ownership: pure, I/O-free grading rules under `app/domain/exam`;
+VLM client construction/close and S3 adapter lifecycle remain in presentation
+and infrastructure code.
+- This document recommends that shape, but implementing it requires a new
+council/human review and its own issue/rollback plan per R-001.
 
 ## Running the parity tests
 
@@ -150,9 +246,32 @@ uv run --frozen --active pytest \
   -q
 ```
 
-## Human review gate
+## What parity does **not** cover
+
+- **Response payloads:** the synchronous submit returns a JSON response; the
+worker writes to the database and emits nothing to the caller.
+- **Timing / ordering:** the worker is asynchronous and may interleave with
+other operations.
+- **VLM availability edge cases:** transient VLM failures are retried once but
+not guaranteed to converge if the service is permanently down.
+- **Real-Mongo rollback aborts:** the current fake test seam cannot reproduce a
+`with_transaction` abort; only the code path is documented above.
+- **Exam creation side effects:** creation may log analytics or update selection
+metadata that the worker path does not reproduce.
+
+## Human / council review gate
 
 Changes that alter `app.presentation.exam_grading`,
-`app.presentation.exams._submit_exam_synchronous`, or
-`app.infrastructure.worker.exam_grading_worker` must update this document and
-keep the parity tests green before merge.
+`app.presentation.exams._submit_exam_synchronous`,
+`app.presentation.exams.self_report_exam_item`, or
+`app.infrastructure.worker.exam_grading_worker` must:
+
+1. Keep `backend/docs/exam_grading_parity.md` accurate and up to date.
+2. Keep the parity tests in
+`backend/tests/integration/test_exam_grading_parity.py` green.
+
+Any move of grading rules into `app/domain/exam`, any service-layer
+extraction, any retry/transaction/ownership redesign, or any change to the VLM
+or S3 lifecycle is out of scope for this issue. Such work requires a new
+council/human decision under R-001 and its own follow-up issue with a rollback
+plan.

--- a/backend/tests/integration/test_exam_grading_parity.py
+++ b/backend/tests/integration/test_exam_grading_parity.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from bson import ObjectId
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from app.domain.models import ExamState, GradingStatus
+from app.infrastructure.storage.mongo import EXAM_GRADING_TASKS_COLLECTION
+from app.infrastructure.worker.exam_grading_worker import process_exam_grading_task
+from app.presentation.deps import get_app_settings
+
+from .conftest import FakeGradingResult, FakeMongoAdapter, FakeVLMClient
+
+
+# ---------------------------------------------------------------------------
+# Shared corpus helpers
+# ---------------------------------------------------------------------------
+
+def _make_problem(
+    user_id: ObjectId,
+    *,
+    text: str,
+    problem_type: str,
+    correct_answer: str,
+    subject: str = "math",
+    tracking: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "text": text,
+        "problemType": problem_type,
+        "subject": subject,
+        "graphDsl": None,
+        "correctAnswer": {
+            "display": correct_answer,
+            "normalizedText": correct_answer.lower(),
+            "normalizedSet": [],
+            "format": "single",
+        },
+        "tags": ["parity"],
+        "sourceImage": {
+            "bucket": "learnloop-media",
+            "objectKey": f"users/{user_id}/images/{ObjectId()}.png",
+            "contentType": "image/png",
+            "sizeBytes": 4,
+            "sha256": None,
+            "uploadedAt": now,
+        },
+        "origin": {},
+        "tracking": tracking
+        or {
+            "exposureCount": 0,
+            "correctCount": 0,
+            "failedCount": 0,
+            "lastTestedAt": None,
+            "lastAttemptCorrect": None,
+        },
+        "isDeleted": False,
+        "deletedAt": None,
+        "isDisabled": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def _make_item(
+    problem: dict[str, Any],
+    *,
+    order: int,
+    answer: str | None,
+    status: GradingStatus = GradingStatus.UNGRADED,
+    method: str | None = None,
+    is_correct: bool | None = None,
+    score: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "itemId": str(ObjectId()),
+        "order": order,
+        "problemId": problem["_id"],
+        "problemSnapshot": {
+            "text": problem["text"],
+            "problemType": problem["problemType"],
+            "subject": problem["subject"],
+            "graphDsl": None,
+            "correctAnswer": deepcopy(problem["correctAnswer"]),
+            "sourceImage": deepcopy(problem.get("sourceImage")),
+        },
+        "answer": {"raw": answer, "savedAt": datetime.now(UTC)},
+        "grading": {
+            "status": status.value,
+            "method": method,
+            "isCorrect": is_correct,
+            "score": score,
+            "feedback": None,
+            "providerModel": None,
+            "rawProviderResponse": None,
+            "gradedAt": None,
+            "retryCount": 0,
+            "selfReportedCorrect": None,
+        },
+    }
+
+
+def _make_grading_exam(user_id: ObjectId, items: list[dict[str, Any]]) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "state": ExamState.GRADING.value,
+        "configSnapshot": {
+            "maxProblemCount": len(items),
+            "selectionPolicy": {
+                "cooldownDays": 7,
+                "lastWrongWeight": 1.0,
+                "failureRateWeight": 1.0,
+                "recencyWeight": 1.0,
+                "minProblemAgeDays": 0,
+            },
+            "generatedAt": now,
+        },
+        "items": items,
+        "summary": {
+            "totalProblems": len(items),
+            "answeredProblems": len(items),
+            "gradedProblems": 0,
+            "pendingProblems": 0,
+            "correctProblems": 0,
+            "failedProblems": 0,
+            "score": None,
+        },
+        "createdAt": now,
+        "startedAt": now,
+        "submittedAt": None,
+        "updatedAt": now,
+    }
+
+
+def _make_task(
+    exam_id: ObjectId,
+    user_id: ObjectId,
+    *,
+    claim_token: str | None = None,
+    status: str = "pending",
+) -> dict[str, Any]:
+    now = datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "examId": exam_id,
+        "userId": user_id,
+        "status": status,
+        "claimToken": claim_token,
+        "leaseUntil": None,
+        "error": None,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+async def _run_worker(
+    app: FastAPI,
+    exam_id: ObjectId,
+    user_id: ObjectId,
+) -> None:
+    """Claim the durable task for ``exam_id`` and process it through the worker."""
+    database = app.state.fake_database
+    storage = app.state.fake_storage
+    vlm: FakeVLMClient = app.state.fake_grading_vlm
+    settings = app.dependency_overrides[get_app_settings]()
+    tasks_col = database[EXAM_GRADING_TASKS_COLLECTION]
+
+    task = await tasks_col.find_one({"examId": exam_id})
+    assert task is not None, "expected a durable exam grading task"
+    task = deepcopy(task)
+    task["claimToken"] = "parity-test-token"
+    task["status"] = "processing"
+    await tasks_col.update_one(
+        {"_id": task["_id"]},
+        {"$set": {"status": "processing", "claimToken": "parity-test-token"}},
+    )
+    await process_exam_grading_task(
+        task,
+        database,
+        vlm,
+        storage,
+        settings,
+        tasks_col,
+        adapter=FakeMongoAdapter(),
+    )
+
+
+def _final_grading_snapshot(exam: dict[str, Any]) -> dict[str, Any]:
+    """Return a stable, comparable view of item gradings and summary.
+
+    Problem identifiers and item order are replaced with ``problemType`` so that
+    two independent problem documents producing the same grading behavior compare
+    equal. Order is an exam-selection concern, not a grading outcome.
+    """
+    return {
+        "state": exam["state"],
+        "summary": exam["summary"],
+        "items": sorted(
+            [
+                {
+                    "problemType": item["problemSnapshot"]["problemType"],
+                    "status": item["grading"]["status"],
+                    "method": item["grading"]["method"],
+                    "isCorrect": item["grading"]["isCorrect"],
+                    "score": item["grading"]["score"],
+                    "retryCount": item["grading"]["retryCount"],
+                    "selfReportedCorrect": item["grading"]["selfReportedCorrect"],
+                }
+                for item in exam["items"]
+            ],
+            key=lambda it: it["problemType"],
+        ),
+    }
+
+
+def _tracking_snapshot(problem: dict[str, Any]) -> dict[str, Any]:
+    tracking = problem.get("tracking", {})
+    return {
+        "exposureCount": tracking.get("exposureCount"),
+        "correctCount": tracking.get("correctCount"),
+        "failedCount": tracking.get("failedCount"),
+        "lastAttemptCorrect": tracking.get("lastAttemptCorrect"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Characterization tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_parity_objective_only_sync_matches_worker(
+    exams_app: FastAPI,
+    exams_client: AsyncClient,
+) -> None:
+    """The same objective-only exam produces identical final state via synchronous
+    submit and via the durable worker path.
+
+    Two independent problem sets are used so the sync-path tracking updates do not
+    leak into the worker-path baseline.
+    """
+    database = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    sync_a = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    sync_b = _make_problem(
+        user_id,
+        text="Capital of France?",
+        problem_type="single-choice",
+        correct_answer="Paris",
+        tracking={"exposureCount": 2, "correctCount": 1, "failedCount": 1, "lastTestedAt": None, "lastAttemptCorrect": False},
+    )
+    database["problems"].seed(sync_a, sync_b)
+
+    # Sync path: create exam, answer both items, submit.
+    create_response = await exams_client.post("/api/v1/exams", json={"maxProblemCount": 2})
+    assert create_response.status_code == 201
+    sync_exam_id = create_response.json()["exam"]["id"]
+    sync_items = create_response.json()["exam"]["items"]
+    sync_by_pid = {item["problemId"]: item["itemId"] for item in sync_items}
+
+    await exams_client.patch(
+        f"/api/v1/exams/{sync_exam_id}/items/{sync_by_pid[str(sync_a['_id'])]}/answer",
+        json={"answer": "4"},
+    )
+    await exams_client.patch(
+        f"/api/v1/exams/{sync_exam_id}/items/{sync_by_pid[str(sync_b['_id'])]}/answer",
+        json={"answer": "Paris"},
+    )
+
+    submit_response = await exams_client.post(f"/api/v1/exams/{sync_exam_id}/submit")
+    assert submit_response.status_code == 200
+    assert submit_response.json()["exam"]["state"] == "submitted"
+
+    # Worker path: independent problem documents with the same initial tracking.
+    worker_a = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    worker_b = _make_problem(
+        user_id,
+        text="Capital of France?",
+        problem_type="single-choice",
+        correct_answer="Paris",
+        tracking={"exposureCount": 2, "correctCount": 1, "failedCount": 1, "lastTestedAt": None, "lastAttemptCorrect": False},
+    )
+    database["problems"].seed(worker_a, worker_b)
+
+    worker_items = [
+        _make_item(worker_a, order=0, answer="4"),
+        _make_item(worker_b, order=1, answer="Paris"),
+    ]
+    worker_exam = _make_grading_exam(user_id, worker_items)
+    worker_exam_id = worker_exam["_id"]
+    database["exams"].seed(worker_exam)
+    database[EXAM_GRADING_TASKS_COLLECTION].seed(_make_task(worker_exam_id, user_id))
+
+    await _run_worker(exams_app, worker_exam_id, user_id)
+
+    sync_exam = await database["exams"].find_one({"_id": ObjectId(sync_exam_id)})
+    worker_exam_doc = await database["exams"].find_one({"_id": worker_exam_id})
+
+    assert _final_grading_snapshot(sync_exam) == _final_grading_snapshot(worker_exam_doc)
+
+    # Sync-path tracking: only the grading transaction increments it.
+    sync_a_doc = await database["problems"].find_one({"_id": sync_a["_id"]})
+    sync_b_doc = await database["problems"].find_one({"_id": sync_b["_id"]})
+    assert _tracking_snapshot(sync_a_doc) == {"exposureCount": 1, "correctCount": 1, "failedCount": 0, "lastAttemptCorrect": True}
+    assert _tracking_snapshot(sync_b_doc) == {"exposureCount": 3, "correctCount": 2, "failedCount": 1, "lastAttemptCorrect": True}
+
+    # Worker-path tracking matches the sync-path end state.
+    worker_a_doc = await database["problems"].find_one({"_id": worker_a["_id"]})
+    worker_b_doc = await database["problems"].find_one({"_id": worker_b["_id"]})
+    assert _tracking_snapshot(worker_a_doc) == _tracking_snapshot(sync_a_doc)
+    assert _tracking_snapshot(worker_b_doc) == _tracking_snapshot(sync_b_doc)
+
+
+@pytest.mark.asyncio
+async def test_parity_mixed_exam_worker_produces_expected_final_state(
+    exams_app: FastAPI,
+    exams_client: AsyncClient,
+) -> None:
+    """A mixed objective + short-answer exam is always routed through the worker.
+    The final state matches the deterministic outcome expected from the unit-level
+    grading helpers.
+    """
+    database = exams_app.state.fake_database
+    storage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+
+    obj = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    short = _make_problem(user_id, text="Explain gravity", problem_type="short-answer", correct_answer="Mass attracts mass")
+    database["problems"].seed(obj, short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+    vlm.responses = [FakeGradingResult(is_correct=True, feedback="good")]
+
+    create_response = await exams_client.post("/api/v1/exams", json={"maxProblemCount": 2})
+    assert create_response.status_code == 201
+    exam_id = create_response.json()["exam"]["id"]
+    items = create_response.json()["exam"]["items"]
+    by_pid = {item["problemId"]: item["itemId"] for item in items}
+
+    await exams_client.patch(
+        f"/api/v1/exams/{exam_id}/items/{by_pid[str(obj['_id'])]}/answer",
+        json={"answer": "4"},
+    )
+    await exams_client.patch(
+        f"/api/v1/exams/{exam_id}/items/{by_pid[str(short['_id'])]}/answer",
+        json={"answer": "my answer"},
+    )
+
+    submit_response = await exams_client.post(f"/api/v1/exams/{exam_id}/submit")
+    assert submit_response.status_code == 200
+    assert submit_response.json()["exam"]["state"] == "grading"
+
+    await _run_worker(exams_app, ObjectId(exam_id), user_id)
+
+    exam_doc = await database["exams"].find_one({"_id": ObjectId(exam_id)})
+    assert exam_doc["state"] == ExamState.SUBMITTED.value
+    assert exam_doc["summary"] == {
+        "totalProblems": 2,
+        "answeredProblems": 2,
+        "gradedProblems": 2,
+        "pendingProblems": 0,
+        "correctProblems": 2,
+        "failedProblems": 0,
+        "score": 1.0,
+    }
+
+    short_doc = await database["problems"].find_one({"_id": short["_id"]})
+    assert short_doc["tracking"]["exposureCount"] == 1
+    assert short_doc["tracking"]["correctCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_parity_short_answer_vlm_retry_then_success(
+    exams_app: FastAPI,
+    exams_client: AsyncClient,
+) -> None:
+    """A retryable VLM failure followed by success ends with the same grading as an
+    immediate success and updates tracking exactly once.
+    """
+    from app.infrastructure.vlm.client import VLMError
+
+    database = exams_app.state.fake_database
+    storage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+
+    short = _make_problem(user_id, text="Explain gravity", problem_type="short-answer", correct_answer="Mass attracts mass")
+    database["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+    vlm.responses = [
+        VLMError("temporary", code="vlm-timeout", retryable=True),
+        FakeGradingResult(is_correct=True, feedback="good"),
+    ]
+
+    create_response = await exams_client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    assert create_response.status_code == 201
+    exam_id = create_response.json()["exam"]["id"]
+    item_id = create_response.json()["exam"]["items"][0]["itemId"]
+
+    await exams_client.patch(
+        f"/api/v1/exams/{exam_id}/items/{item_id}/answer",
+        json={"answer": "my answer"},
+    )
+    await exams_client.post(f"/api/v1/exams/{exam_id}/submit")
+
+    await _run_worker(exams_app, ObjectId(exam_id), user_id)
+
+    exam_doc = await database["exams"].find_one({"_id": ObjectId(exam_id)})
+    item = exam_doc["items"][0]
+    assert item["grading"]["status"] == "correct"
+    assert item["grading"]["method"] == "vlm"
+    assert item["grading"]["retryCount"] == 1
+
+    short_doc = await database["problems"].find_one({"_id": short["_id"]})
+    assert short_doc["tracking"]["exposureCount"] == 1
+    assert short_doc["tracking"]["correctCount"] == 1
+
+
+@pytest.mark.asyncio
+async def test_parity_short_answer_retry_exhaustion_then_self_report_updates_tracking_once(
+    exams_app: FastAPI,
+    exams_client: AsyncClient,
+) -> None:
+    """Retry-exhausted short-answer items become pending-review. Self-report then
+    updates the item, summary, and tracking exactly once, regardless of prior retries.
+    """
+    from app.infrastructure.vlm.client import VLMError
+
+    database = exams_app.state.fake_database
+    storage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+
+    short = _make_problem(user_id, text="Explain gravity", problem_type="short-answer", correct_answer="Mass attracts mass")
+    database["problems"].seed(short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+    vlm.responses = [
+        VLMError("temporary", code="vlm-timeout", retryable=True),
+        VLMError("still broken", code="vlm-network-error", retryable=True),
+    ]
+
+    create_response = await exams_client.post("/api/v1/exams", json={"maxProblemCount": 1})
+    assert create_response.status_code == 201
+    exam_id = create_response.json()["exam"]["id"]
+    item_id = create_response.json()["exam"]["items"][0]["itemId"]
+
+    await exams_client.patch(
+        f"/api/v1/exams/{exam_id}/items/{item_id}/answer",
+        json={"answer": "my answer"},
+    )
+    await exams_client.post(f"/api/v1/exams/{exam_id}/submit")
+    await _run_worker(exams_app, ObjectId(exam_id), user_id)
+
+    before_tracking_doc = await database["problems"].find_one({"_id": short["_id"]})
+    assert before_tracking_doc["tracking"]["exposureCount"] == 0
+
+    self_report_response = await exams_client.post(
+        f"/api/v1/exams/{exam_id}/items/{item_id}/self-report",
+        json={"isCorrect": True},
+    )
+    assert self_report_response.status_code == 200
+
+    exam_doc = await database["exams"].find_one({"_id": ObjectId(exam_id)})
+    item = next(it for it in exam_doc["items"] if it["itemId"] == item_id)
+    assert item["grading"]["status"] == "correct"
+    assert item["grading"]["method"] == "self-report"
+    assert item["grading"]["selfReportedCorrect"] is True
+    assert exam_doc["summary"] == {
+        "totalProblems": 1,
+        "answeredProblems": 1,
+        "gradedProblems": 1,
+        "pendingProblems": 0,
+        "correctProblems": 1,
+        "failedProblems": 0,
+        "score": 1.0,
+    }
+
+    after_tracking_doc = await database["problems"].find_one({"_id": short["_id"]})
+    assert after_tracking_doc["tracking"]["exposureCount"] == 1
+    assert after_tracking_doc["tracking"]["correctCount"] == 1
+    assert after_tracking_doc["tracking"]["lastAttemptCorrect"] is True
+
+
+@pytest.mark.asyncio
+async def test_parity_worker_restart_preserves_terminal_items_and_tracking(
+    exams_app: FastAPI,
+    exams_client: AsyncClient,
+) -> None:
+    """After a restart, terminal items are not re-graded and their tracking is not
+    double-counted when the worker finalizes.
+    """
+    database = exams_app.state.fake_database
+    storage = exams_app.state.fake_storage
+    vlm: FakeVLMClient = exams_app.state.fake_grading_vlm
+    user_id = exams_app.state.primary_user["_id"]
+
+    obj = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    short = _make_problem(user_id, text="Explain gravity", problem_type="short-answer", correct_answer="Mass attracts mass")
+    database["problems"].seed(obj, short)
+    storage.seed(short["sourceImage"]["bucket"], short["sourceImage"]["objectKey"], b"img")
+
+    # Seed a grading exam where the objective is already terminal.
+    obj_item = _make_item(obj, order=0, answer="4", status=GradingStatus.CORRECT, method="normalized-match", is_correct=True, score=1.0)
+    short_item = _make_item(short, order=1, answer="my answer")
+    exam = _make_grading_exam(user_id, [obj_item, short_item])
+    exam_id = exam["_id"]
+    database["exams"].seed(exam)
+    database[EXAM_GRADING_TASKS_COLLECTION].seed(_make_task(exam_id, user_id))
+
+    vlm.responses = [FakeGradingResult(is_correct=False, feedback="no")]
+
+    await _run_worker(exams_app, exam_id, user_id)
+
+    exam_doc = await database["exams"].find_one({"_id": exam_id})
+    assert exam_doc["state"] == ExamState.SUBMITTED.value
+    assert exam_doc["summary"]["gradedProblems"] == 2
+    assert exam_doc["summary"]["score"] == 0.5
+
+    # Objective tracked exactly once despite being present before the restart.
+    obj_doc = await database["problems"].find_one({"_id": obj["_id"]})
+    assert obj_doc["tracking"]["exposureCount"] == 1
+    assert obj_doc["tracking"]["correctCount"] == 1
+    assert len(vlm.calls) == 1  # only the short-answer was graded
+
+
+@pytest.mark.asyncio
+async def test_parity_worker_idempotent_rerun_does_not_double_apply_tracking(
+    exams_app: FastAPI,
+    exams_client: AsyncClient,
+) -> None:
+    """If the exam is already submitted, a rerun of the worker only marks the task
+    completed and leaves tracking unchanged.
+    """
+    database = exams_app.state.fake_database
+    user_id = exams_app.state.primary_user["_id"]
+
+    obj = _make_problem(user_id, text="2+2?", problem_type="fill-in-the-blank", correct_answer="4")
+    database["problems"].seed(obj)
+
+    obj_item = _make_item(obj, order=0, answer="4", status=GradingStatus.CORRECT, method="normalized-match", is_correct=True, score=1.0)
+    exam = _make_grading_exam(user_id, [obj_item])
+    exam["state"] = ExamState.SUBMITTED.value
+    exam["submittedAt"] = datetime.now(UTC)
+    exam_id = exam["_id"]
+    database["exams"].seed(exam)
+    await database["problems"].update_one(
+        {"_id": obj["_id"]},
+        {"$set": {"tracking": {"exposureCount": 1, "correctCount": 1, "failedCount": 0, "lastTestedAt": datetime.now(UTC), "lastAttemptCorrect": True}}},
+    )
+    database[EXAM_GRADING_TASKS_COLLECTION].seed(_make_task(exam_id, user_id))
+
+    await _run_worker(exams_app, exam_id, user_id)
+
+    obj_doc = await database["problems"].find_one({"_id": obj["_id"]})
+    assert obj_doc["tracking"]["exposureCount"] == 1
+    assert obj_doc["tracking"]["correctCount"] == 1
+
+    task = await database[EXAM_GRADING_TASKS_COLLECTION].find_one({"examId": exam_id})
+    assert task["status"] == "completed"


### PR DESCRIPTION
Model-Signature: ollama-cloud/kimi-k2.7-code

## Summary

- Adds six executable characterization tests for sync vs. async worker exam grading parity in `backend/tests/integration/test_exam_grading_parity.py`.
- Adds `backend/docs/exam_grading_parity.md` documenting observed parity, deliberate divergences, retry/self-report behavior, transaction rollback evidence, VLM/S3 lifecycle ownership, and the unapproved candidate `app/domain/exam` boundary.
- No production code is changed.

## Linked Issue

Closes #506

## Issue Alignment

This PR implements the issue by:

- Characterizing sync and worker paths for objective-only and mixed exams.
- Covering short-answer VLM retry-then-success, retry exhaustion → pending-review → self-report, worker restart, and idempotent rerun.
- Documenting transaction rollback/all-or-nothing behavior: explains why a dedicated real-Mongo rollback test is infeasible with the current `FakeDatabase`/`FakeMongoAdapter` seam, and records the strongest available evidence (`with_transaction` usage, per-item grading intentionally outside transaction, finalization grouped in transaction).
- Documenting VLM and S3/storage lifecycle ownership for both sync and worker paths.
- Distinguishing observed ownership from the unapproved candidate `app/domain/exam` boundary and stating that any implementation requires a new council/human decision per R-001.

Scope covered:

- `backend/tests/integration/test_exam_grading_parity.py`
- `backend/docs/exam_grading_parity.md`

Out of scope / intentionally not included:

- No production code changes.
- No new real-Mongo transaction rollback test (documented as infeasible with current fake seam).

## Implementation Notes

- Tests use the existing integration fixtures (`exams_app`, `exams_client`, `FakeVLMClient`, `FakeMongoAdapter`).
- Snapshots compare shared outcome fields and deliberately ignore path-specific differences such as `status`/`startedAt` on the `GradingTask`, `workerId`, and `leaseExpiresAt`.
- The parity doc was rewritten to use correct enum values (`correct | incorrect | pending-review`), method strings (`normalized-match | vlm | self-report`), actual summary fields, retry limit `1`, and accurate helper/test references.

## Tests

Commands run:

- `cd backend && uv run --frozen --active pytest tests/integration/test_exam_grading_parity.py -q` — 6 passed.
- `cd backend && uv run --frozen --active pytest tests/presentation/test_exam_grading.py tests/worker/test_exam_grading_worker.py tests/api/test_exams.py tests/integration/test_exam_workflow.py tests/integration/test_exam_grading_parity.py -q` — 78 passed.
- `cd backend && uv run --frozen --active pytest tests/ -q` — 966 passed, 1 skipped.

Automated tests added or updated:

- `backend/tests/integration/test_exam_grading_parity.py` (new file, 6 tests).

Manual verification:

- `git diff --name-only` confirms only `backend/docs/exam_grading_parity.md` and `backend/tests/integration/test_exam_grading_parity.py` are added/modified; no production code touched.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
