### PR TITLE
test+docs: characterize real-Mongo ingestion concurrency (#508)

### DIFF
--- a/.refactor-council/ingestion-concurrency-characterization.md
+++ b/.refactor-council/ingestion-concurrency-characterization.md
@@ -1,0 +1,198 @@
+# Ingestion repository concurrency characterization
+
+## Summary
+
+This artifact records a real-Mongo concurrency harness and the observed behavior
+of six bulk-ingestion repository mutation functions under the current
+read-modify-write pattern. No production code was changed.
+
+## Scope
+
+- `backend/tests/integration/test_ingestion_atomicity.py`
+- This document
+
+## Out of scope
+
+- Editing `backend/app/infrastructure/ingestion/repository.py` or any other
+  production module.
+- Implementing positional updates, compare-and-swap, transactions, versioning,
+  or any other atomic strategy.
+- Changing schema, indexes, API behavior, return values, errors, status
+  eligibility, timestamps, or idempotency.
+- `claim_item` (already atomic via `find_one_and_update`).
+- Preview durability, worker redesign, or single-image preview work.
+
+## Current ownership
+
+The repository functions under test live in
+`backend/app/infrastructure/ingestion/repository.py`:
+
+- `save_item_extraction_success`
+- `save_item_extraction_failure`
+- `reset_item_for_retry`
+- `update_item_draft`
+- `mark_item_deleted`
+- `undo_item_deletion`
+
+All six follow the same read-modify-write shape:
+
+1. `_load_batch_for_update` calls `find_one` for the whole batch document.
+2. The function mutates an in-memory copy of the embedded `items` array.
+3. `_persist_batch` calls `update_one` with `$set: {items: [...], updatedAt: ...}`.
+
+This shape is owned by the infrastructure/persistence layer. Any move toward an
+atomic or domain-layer strategy requires a new human/council decision and a
+separate issue with a rollback plan.
+
+## Harness design
+
+`backend/tests/integration/test_ingestion_atomicity.py` connects to the
+isolated agent-environment MongoDB (no host port collisions, one replica set per
+worktree).
+
+Key components:
+
+- `_SynchronizedCollection`: a delegating proxy that forwards every call to the
+  real `ingestion_batches` collection but can insert `asyncio.Event` barriers
+  around `find_one` and `update_one`.
+- `_SynchronizedDatabase`: a delegating database proxy that returns the
+  synchronized collection for `ingestion_batches` and delegates all other
+  collections directly.
+- Per-test fixture `real_database`: requires `MONGODB_URI`, creates a fresh
+  `AsyncMongoClient` per test, ensures the collection/indexes exist, yields the
+  real database, and cleans the `ingestion_batches` collection after the test.
+  Test runs without `MONGODB_URI` skip this real-service module instead of
+  waiting for an unavailable default host; an explicitly configured but
+  unavailable Mongo server still fails the run.
+
+The harness fails loudly if it accidentally receives a `FakeDatabase` because
+`AsyncMongoClient` and real BSON round-tripping are required.
+
+The recorded run used MongoDB 4.4.30 in the worktree-isolated replica set and
+PyMongo 4.17.0's asynchronous client.
+
+## Race reproduction
+
+`test_concurrent_distinct_item_updates_lose_one_change` reproduces a
+whole-array lost update deterministically:
+
+1. Seed one batch with two queued items (`item-a`, `item-b`).
+2. Route operations A and B through separate `_SynchronizedDatabase` proxies.
+3. Release both real `find_one` calls, wait for both reads to complete, and
+   assert that neither real `update_one` has completed.
+4. Release B's real `update_one` and wait for it to complete while A remains
+   held before persistence.
+5. Release A's real `update_one`. A writes its original snapshot with only
+   `item-a` updated, overwriting B's change to `item-b`.
+
+Final observed document:
+
+- `item-a.draft.text` == `"updated by A"` (A's write is last).
+- `item-b.draft.text` is `None` (B's change is lost).
+
+This is a deterministic event-driven interleaving, not scheduler luck or
+arbitrary sleep.
+
+## Sequential contracts observed
+
+All sequential tests run against the real Mongo server and confirm the same
+contracts as the existing fake-based `test_ingestion_persistence.py` tests,
+with one round-trip note: Mongo returns stored datetimes as naive UTC
+`datetime` objects; the tests compare them with `.replace(tzinfo=UTC)`.
+
+| Function | Return | Eligibility / idempotency | Lease | Timestamp/shape |
+|---|---|---|---|---|
+| `save_item_extraction_success` | `None` | missing item also returns `None` and rewrites the unchanged items array; missing batch raises `ValueError` | clears to `None` for a matching item | status `ready`, stores crop/draft/extraction, sets item and batch `updatedAt` |
+| `save_item_extraction_failure` | `None` | missing item also returns `None` and rewrites the unchanged items array; missing batch raises `ValueError` | clears to `None` for a matching item | status `failed`, stores extraction, sets item and batch `updatedAt` |
+| `reset_item_for_retry` | `True` if changed | `failed` or `submit-failed` | cleared to `None` | status `queued`, `updatedAt` set |
+| `reset_item_for_retry` | `TypeError` with aware `now` | `extracting` with an expired lease round-tripped from Mongo | unchanged | Mongo returns a naive UTC lease, which cannot be compared with the aware UTC `now`; no write occurs |
+| `reset_item_for_retry` | `False` | ineligible statuses, missing item | n/a | no write |
+| `reset_item_for_retry` | `ValueError` | missing batch | n/a | raises "Batch not found" |
+| `update_item_draft` | updated item | item must exist | n/a | merges allowed keys (`text`, `problemType`, `graphDsl`, `correctAnswer`, `tags`, `subject`), ignores others, sets `updatedAt` |
+| `update_item_draft` | `None` | missing item | n/a | no write; missing batch raises `ValueError` |
+| `mark_item_deleted` | `True` | item exists and not already deleted/submitted | n/a | sets `previousStatus`, `deletedAt`, `updatedAt` |
+| `mark_item_deleted` | `True` | already deleted/submitted | n/a | idempotent, no write |
+| `mark_item_deleted` | `False` | missing item | n/a | no write; missing batch raises `ValueError` |
+| `undo_item_deletion` | `True` | item is deleted and has `previousStatus` | n/a | restores `previousStatus`, removes `deletedAt` and `previousStatus`, sets `updatedAt` |
+| `undo_item_deletion` | `False` | not deleted, missing `previousStatus`, or missing item | n/a | no write; missing batch raises `ValueError` |
+
+## Shared race exposure
+
+Each function reads the full batch before conditionally changing one item and
+then replaces the full `items` array. Distinct-item operations are therefore
+compatible race pairings whenever their sequential eligibility is satisfied:
+
+| Function | Concurrent exposure |
+|---|---|
+| `save_item_extraction_success` | A later stale success write can erase another item's draft, delete, retry, or extraction result. |
+| `save_item_extraction_failure` | A later stale failure write can erase the same distinct-item changes. |
+| `reset_item_for_retry` | A successful retry writes the full array and can erase another item mutation; ineligible retries and the observed expired-lease `TypeError` return before writing. |
+| `update_item_draft` | A matching-item draft update writes the full array; this is the deterministic pairing used by the harness. |
+| `mark_item_deleted` | A new deletion writes the full array and is exposed; already deleted/submitted and missing-item paths return before writing. |
+| `undo_item_deletion` | An eligible undo writes the full array and is exposed; ineligible and missing-item paths return before writing. |
+
+The harness uses two draft updates because both are easy to make eligible on
+one seeded batch without introducing lease or status setup into the operation
+trace. It demonstrates the shared persistence mechanism, not every possible
+pairwise business-state combination.
+
+## Commands
+
+Build the agent environment once per fingerprint:
+
+```bash
+./scripts/agent-env.sh build
+```
+
+Run the focused real-Mongo harness:
+
+```bash
+./scripts/agent-env.sh shell
+# Inside the agent shell:
+cd backend
+uv run --frozen --active pytest tests/integration/test_ingestion_atomicity.py -q
+```
+
+Run the full backend suite:
+
+```bash
+./scripts/agent-env.sh test backend
+```
+
+The ordinary backend CI job does not start MongoDB or set `MONGODB_URI`, so it
+collects and skips this real-service module. The isolated agent-environment
+commands above set `MONGODB_URI` and execute the harness against MongoDB.
+
+Recorded results:
+
+- Focused real-Mongo harness: 14 passed.
+- Full agent-environment backend suite: 980 passed, 1 skipped.
+- Focused tools-image run with `MONGODB_URI` removed: 14 skipped in 0.01s.
+- `git diff --check`: passed.
+- Changed paths: this artifact and
+  `backend/tests/integration/test_ingestion_atomicity.py`; no production file.
+
+## Limitations
+
+- The harness does not attempt to start transactions or compare-and-swap; those
+  are production behavior changes and are out of scope.
+- The lost-update reproduction uses `update_item_draft` because it is the only
+  one of the six functions whose interleaving is easy to drive from a single
+  user/batch without changing leases or statuses. The same read-modify-write
+  risk applies to all six functions.
+- Mongo returns stored datetimes as naive UTC; the tests handle this explicitly
+  rather than changing the repository to normalize. For expired extracting
+  leases, that round trip exposes a current `TypeError` when the repository
+  compares the naive lease to an aware UTC `now`; the harness records the error
+  and verifies that no write occurs.
+
+## Future gate
+
+Any atomic-mutation implementation (positional updates, transactions,
+versioning, compare-and-swap, or schema change) requires:
+
+1. A new human and Safety review.
+2. A separate implementation issue.
+3. A rollback plan.
+4. Passing both this characterization harness and the existing fake-based
+   sequential tests.

--- a/backend/tests/integration/test_ingestion_atomicity.py
+++ b/backend/tests/integration/test_ingestion_atomicity.py
@@ -1,0 +1,572 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from bson import ObjectId
+from pymongo import AsyncMongoClient
+
+from app.domain.ingestion import ItemState
+from app.infrastructure.config.settings import Settings
+from app.infrastructure.ingestion.repository import (
+    INGESTION_BATCHES_COLLECTION,
+    create_batch,
+    get_batch,
+    mark_item_deleted,
+    reset_item_for_retry,
+    save_item_extraction_failure,
+    save_item_extraction_success,
+    undo_item_deletion,
+    update_item_draft,
+)
+from app.infrastructure.storage.mongo import ensure_database_setup
+
+
+class _SynchronizedCollection:
+    """Delegating collection proxy that can pause find_one and update_one calls.
+
+    The proxy forwards every operation to the real Mongo collection. When a test
+    enables synchronization, each intercepted call waits on an event before
+    proceeding and signals another event once it completes. This lets a test
+    coordinate two repository calls so both read the same batch snapshot before
+    either write is released.
+    """
+
+    def __init__(self, real_collection: Any) -> None:
+        self._real = real_collection
+        self._sync_enabled = False
+        self._find_before: asyncio.Event | None = None
+        self._find_after: asyncio.Event | None = None
+        self._update_before: asyncio.Event | None = None
+        self._update_after: asyncio.Event | None = None
+
+    def enable_sync(
+        self,
+        *,
+        find_before: asyncio.Event,
+        find_after: asyncio.Event,
+        update_before: asyncio.Event,
+        update_after: asyncio.Event,
+    ) -> None:
+        self._sync_enabled = True
+        self._find_before = find_before
+        self._find_after = find_after
+        self._update_before = update_before
+        self._update_after = update_after
+
+    async def find_one(self, *args: Any, **kwargs: Any) -> Any:
+        if self._sync_enabled:
+            assert self._find_before is not None
+            assert self._find_after is not None
+            await self._find_before.wait()
+            result = await self._real.find_one(*args, **kwargs)
+            self._find_after.set()
+            return result
+        return await self._real.find_one(*args, **kwargs)
+
+    async def update_one(self, *args: Any, **kwargs: Any) -> Any:
+        if self._sync_enabled:
+            assert self._update_before is not None
+            assert self._update_after is not None
+            await self._update_before.wait()
+            result = await self._real.update_one(*args, **kwargs)
+            self._update_after.set()
+            return result
+        return await self._real.update_one(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+class _SynchronizedDatabase:
+    """Delegating database proxy that returns a synchronized collection."""
+
+    def __init__(self, real_database: Any) -> None:
+        self._real = real_database
+        self._collection: _SynchronizedCollection | None = None
+
+    def get_collection(self, name: str) -> _SynchronizedCollection:
+        if name == INGESTION_BATCHES_COLLECTION:
+            if self._collection is None:
+                self._collection = _SynchronizedCollection(self._real[name])
+            return self._collection
+        return self._real[name]
+
+    def __getitem__(self, name: str) -> Any:
+        return self.get_collection(name)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+@pytest_asyncio.fixture(loop_scope="function")
+async def real_database() -> Any:
+    uri = os.environ.get("MONGODB_URI")
+    if uri is None:
+        pytest.skip("real Mongo integration tests require MONGODB_URI (run through agent-env.sh)")
+
+    database_name = os.environ.get("MONGODB_DATABASE", "learnloop")
+    client: AsyncMongoClient[Any] = AsyncMongoClient(uri)
+    try:
+        database = client.get_database(database_name)
+        await ensure_database_setup(database)
+        yield database
+    finally:
+        # Clean up only the ingestion batches collection after each test.
+        try:
+            await database[INGESTION_BATCHES_COLLECTION].delete_many({})
+        finally:
+            await client.close()
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(bulk_ingestion_batch_ttl_seconds=3600)
+
+
+@pytest.fixture
+def user_id() -> ObjectId:
+    return ObjectId()
+
+
+NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+async def _batch_with_two_items(
+    database: Any, user_id: ObjectId, settings: Settings
+) -> tuple[ObjectId, str, str]:
+    """Seed a batch with two queued items and return (batch_id, item_a_id, item_b_id)."""
+    from app.infrastructure.ingestion import add_source_image, add_items_for_image, build_source_image
+
+    source_image = build_source_image(
+        bucket="media",
+        object_key="users/u/img.png",
+        content_type="image/png",
+        size_bytes=42,
+        sha256="sha",
+        uploaded_at=NOW,
+    )
+
+    batch = await create_batch(database, user_id, settings, now=NOW)
+    image = await add_source_image(database, batch["_id"], user_id, source_image, order=0, now=NOW)
+    items = await add_items_for_image(
+        database, batch["_id"], user_id, image["imageId"], item_count=2, starting_order=0, now=NOW
+    )
+    return batch["_id"], items[0]["itemId"], items[1]["itemId"]
+
+
+async def _set_item_fields(
+    database: Any,
+    batch_id: ObjectId,
+    user_id: ObjectId,
+    item_id: str,
+    **fields: Any,
+) -> None:
+    result = await database[INGESTION_BATCHES_COLLECTION].update_one(
+        {"_id": batch_id, "userId": user_id, "items.itemId": item_id},
+        {"$set": {f"items.$.{key}": value for key, value in fields.items()}},
+    )
+    assert result.modified_count == 1
+
+
+@pytest.mark.asyncio
+async def test_harness_uses_real_mongo_not_fake(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    """The harness must fail clearly if it silently receives a fake database."""
+    assert isinstance(real_database.client, AsyncMongoClient)
+    batch = await create_batch(real_database, user_id, settings, now=NOW)
+    loaded = await get_batch(real_database, batch["_id"], user_id)
+    assert loaded is not None
+    assert loaded["_id"] == batch["_id"]
+    # ObjectIds from a real Mongo server are actual bson ObjectIds, not strings.
+    assert isinstance(loaded["_id"], ObjectId)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_distinct_item_updates_lose_one_change(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    """Reproduce the whole-array lost update when two item drafts update concurrently."""
+    batch_id, item_a_id, item_b_id = await _batch_with_two_items(real_database, user_id, settings)
+
+    proxy_a = _SynchronizedDatabase(real_database)
+    proxy_b = _SynchronizedDatabase(real_database)
+    collection_a = proxy_a.get_collection(INGESTION_BATCHES_COLLECTION)
+    collection_b = proxy_b.get_collection(INGESTION_BATCHES_COLLECTION)
+
+    # Events for operation A.
+    a_find_before = asyncio.Event()
+    a_find_after = asyncio.Event()
+    a_update_before = asyncio.Event()
+    a_update_after = asyncio.Event()
+
+    # Events for operation B.
+    b_find_before = asyncio.Event()
+    b_find_after = asyncio.Event()
+    b_update_before = asyncio.Event()
+    b_update_after = asyncio.Event()
+
+    a_find_before.set()
+    b_find_before.set()
+
+    collection_a.enable_sync(
+        find_before=a_find_before,
+        find_after=a_find_after,
+        update_before=a_update_before,
+        update_after=a_update_after,
+    )
+    collection_b.enable_sync(
+        find_before=b_find_before,
+        find_after=b_find_after,
+        update_before=b_update_before,
+        update_after=b_update_after,
+    )
+
+    async def update_a() -> None:
+        await update_item_draft(
+            proxy_a, batch_id, user_id, item_a_id,
+            draft_update={"text": "updated by A"}, now=NOW + timedelta(seconds=1),
+        )
+
+    async def update_b() -> None:
+        await update_item_draft(
+            proxy_b, batch_id, user_id, item_b_id,
+            draft_update={"text": "updated by B"}, now=NOW + timedelta(seconds=2),
+        )
+
+    task_a = asyncio.create_task(update_a())
+    task_b = asyncio.create_task(update_b())
+
+    # Both real reads finish before either real write is released.
+    await asyncio.gather(a_find_after.wait(), b_find_after.wait())
+    assert not a_update_after.is_set()
+    assert not b_update_after.is_set()
+
+    # Write B first, then A. A still holds the original snapshot and therefore
+    # overwrites B's distinct-item change when its full items array is persisted.
+    b_update_before.set()
+    await b_update_after.wait()
+    await task_b
+    assert not a_update_after.is_set()
+
+    a_update_before.set()
+    await a_update_after.wait()
+    await task_a
+
+    final = await get_batch(real_database, batch_id, user_id)
+    assert final is not None
+
+    item_a = next(i for i in final["items"] if i["itemId"] == item_a_id)
+    item_b = next(i for i in final["items"] if i["itemId"] == item_b_id)
+
+    # A's write is the last one, so item A reflects A's update.
+    assert item_a["draft"]["text"] == "updated by A"
+    # B's change is lost because A's whole-array replacement did not include it.
+    assert item_b["draft"]["text"] is None
+
+
+# ---------------------------------------------------------------------------
+# Sequential contract tests against real Mongo for the six mutation functions.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_item_extraction_success_sets_ready_clears_lease_and_timestamps(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    batch_id, item_a_id, _ = await _batch_with_two_items(real_database, user_id, settings)
+    await _set_item_fields(
+        real_database,
+        batch_id,
+        user_id,
+        item_a_id,
+        status=ItemState.EXTRACTING.value,
+        leaseUntil=NOW + timedelta(minutes=5),
+    )
+
+    crop = {"bucket": "b", "objectKey": "k"}
+    draft = {"text": "t"}
+    extraction = {"success": True}
+
+    result = await save_item_extraction_success(
+        real_database, batch_id, user_id, item_a_id,
+        crop=crop,
+        draft=draft,
+        extraction=extraction,
+        now=NOW,
+    )
+
+    assert result is None
+    loaded = await get_batch(real_database, batch_id, user_id)
+    assert loaded is not None
+    item = next(i for i in loaded["items"] if i["itemId"] == item_a_id)
+    assert item["status"] == ItemState.READY.value
+    assert item["crop"] == crop
+    assert item["draft"] == draft
+    assert item["extraction"] == extraction
+    assert item["leaseUntil"] is None
+    assert item["updatedAt"].replace(tzinfo=UTC) == NOW
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == NOW
+
+    later = NOW + timedelta(seconds=1)
+    items_before = loaded["items"]
+    assert await save_item_extraction_success(
+        real_database, batch_id, user_id, "missing",
+        crop={}, draft={}, extraction={}, now=later,
+    ) is None
+    loaded = await get_batch(real_database, batch_id, user_id)
+    assert loaded is not None
+    assert loaded["items"] == items_before
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == later
+
+
+@pytest.mark.asyncio
+async def test_save_item_extraction_failure_sets_failed_clears_lease_and_timestamps(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    batch_id, item_a_id, _ = await _batch_with_two_items(real_database, user_id, settings)
+    await _set_item_fields(
+        real_database,
+        batch_id,
+        user_id,
+        item_a_id,
+        status=ItemState.EXTRACTING.value,
+        leaseUntil=NOW + timedelta(minutes=5),
+    )
+
+    extraction = {"success": False, "failureCode": "X", "failureMessage": "boom"}
+    result = await save_item_extraction_failure(
+        real_database, batch_id, user_id, item_a_id, extraction=extraction, now=NOW,
+    )
+
+    assert result is None
+    loaded = await get_batch(real_database, batch_id, user_id)
+    assert loaded is not None
+    item = next(i for i in loaded["items"] if i["itemId"] == item_a_id)
+    assert item["status"] == ItemState.FAILED.value
+    assert item["extraction"] == extraction
+    assert item["leaseUntil"] is None
+    assert item["updatedAt"].replace(tzinfo=UTC) == NOW
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == NOW
+
+    later = NOW + timedelta(seconds=1)
+    items_before = loaded["items"]
+    assert await save_item_extraction_failure(
+        real_database, batch_id, user_id, "missing", extraction={}, now=later,
+    ) is None
+    loaded = await get_batch(real_database, batch_id, user_id)
+    assert loaded is not None
+    assert loaded["items"] == items_before
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == later
+
+
+@pytest.mark.asyncio
+async def test_reset_item_for_retry_eligibility_and_idempotency(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    batch_id, item_a_id, _ = await _batch_with_two_items(real_database, user_id, settings)
+
+    eligible_states = [
+        (ItemState.FAILED.value, None),
+        (ItemState.SUBMIT_FAILED.value, None),
+    ]
+    for index, (status, lease_until) in enumerate(eligible_states, start=1):
+        await _set_item_fields(
+            real_database,
+            batch_id,
+            user_id,
+            item_a_id,
+            status=status,
+            leaseUntil=lease_until,
+        )
+        changed_at = NOW + timedelta(seconds=index)
+        assert await reset_item_for_retry(
+            real_database, batch_id, user_id, item_a_id, now=changed_at,
+        ) is True
+        loaded = await get_batch(real_database, batch_id, user_id)
+        assert loaded is not None
+        item = next(i for i in loaded["items"] if i["itemId"] == item_a_id)
+        assert item["status"] == ItemState.QUEUED.value
+        assert item["leaseUntil"] is None
+        assert item["updatedAt"].replace(tzinfo=UTC) == changed_at
+        assert loaded["updatedAt"].replace(tzinfo=UTC) == changed_at
+
+    await _set_item_fields(
+        real_database,
+        batch_id,
+        user_id,
+        item_a_id,
+        status=ItemState.EXTRACTING.value,
+        leaseUntil=NOW - timedelta(seconds=1),
+    )
+    before = await get_batch(real_database, batch_id, user_id)
+    assert before is not None
+    with pytest.raises(TypeError, match="offset-naive and offset-aware"):
+        await reset_item_for_retry(real_database, batch_id, user_id, item_a_id, now=NOW)
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+    await _set_item_fields(
+        real_database,
+        batch_id,
+        user_id,
+        item_a_id,
+        status=ItemState.QUEUED.value,
+        leaseUntil=None,
+    )
+    before = await get_batch(real_database, batch_id, user_id)
+    assert before is not None
+    assert await reset_item_for_retry(
+        real_database, batch_id, user_id, item_a_id, now=NOW + timedelta(minutes=1),
+    ) is False
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+    assert await reset_item_for_retry(real_database, batch_id, user_id, "missing", now=NOW) is False
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+
+@pytest.mark.asyncio
+async def test_update_item_draft_allowed_keys_and_missing_item(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    batch_id, item_a_id, _ = await _batch_with_two_items(real_database, user_id, settings)
+
+    draft_update = {
+        "text": "Q",
+        "problemType": "short-answer",
+        "graphDsl": "graph TD",
+        "correctAnswer": "42",
+        "tags": ["algebra"],
+        "subject": "math",
+        "ignored": "x",
+    }
+    updated = await update_item_draft(
+        real_database, batch_id, user_id, item_a_id,
+        draft_update=draft_update,
+        now=NOW,
+    )
+    assert updated is not None
+    for key in {"text", "problemType", "graphDsl", "correctAnswer", "tags", "subject"}:
+        assert updated["draft"][key] == draft_update[key]
+    assert "ignored" not in updated["draft"]
+    assert updated["updatedAt"] == NOW
+
+    loaded = await get_batch(real_database, batch_id, user_id)
+    assert loaded is not None
+    stored = next(i for i in loaded["items"] if i["itemId"] == item_a_id)
+    assert stored["draft"] == updated["draft"]
+    assert stored["updatedAt"].replace(tzinfo=UTC) == NOW
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == NOW
+
+    before = loaded
+    assert await update_item_draft(
+        real_database, batch_id, user_id, "missing", draft_update={"text": "x"}, now=NOW
+    ) is None
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+
+@pytest.mark.asyncio
+async def test_mark_item_deleted_preserves_previous_status_and_idempotency(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    batch_id, item_a_id, item_b_id = await _batch_with_two_items(real_database, user_id, settings)
+
+    assert await mark_item_deleted(real_database, batch_id, user_id, item_a_id, now=NOW) is True
+    loaded = await get_batch(real_database, batch_id, user_id)
+    item = next(i for i in loaded["items"] if i["itemId"] == item_a_id)
+    assert item["status"] == ItemState.DELETED.value
+    assert item["previousStatus"] == ItemState.QUEUED.value
+    assert item["deletedAt"].replace(tzinfo=UTC) == NOW
+    assert item["updatedAt"].replace(tzinfo=UTC) == NOW
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == NOW
+
+    before = loaded
+    later = NOW + timedelta(seconds=5)
+    assert await mark_item_deleted(real_database, batch_id, user_id, item_a_id, now=later) is True
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+    await _set_item_fields(
+        real_database, batch_id, user_id, item_b_id, status=ItemState.SUBMITTED.value,
+    )
+    before = await get_batch(real_database, batch_id, user_id)
+    assert before is not None
+    assert await mark_item_deleted(real_database, batch_id, user_id, item_b_id, now=later) is True
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+    assert await mark_item_deleted(real_database, batch_id, user_id, "missing", now=later) is False
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+
+@pytest.mark.asyncio
+async def test_undo_item_deletion_restores_and_requires_previous_status(
+    real_database: Any, user_id: ObjectId, settings: Settings
+) -> None:
+    batch_id, item_a_id, item_b_id = await _batch_with_two_items(real_database, user_id, settings)
+
+    before = await get_batch(real_database, batch_id, user_id)
+    assert before is not None
+    assert await undo_item_deletion(real_database, batch_id, user_id, item_a_id, now=NOW) is False
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+    await mark_item_deleted(real_database, batch_id, user_id, item_a_id, now=NOW)
+    later = NOW + timedelta(seconds=5)
+
+    assert await undo_item_deletion(real_database, batch_id, user_id, item_a_id, now=later) is True
+    loaded = await get_batch(real_database, batch_id, user_id)
+    item = next(i for i in loaded["items"] if i["itemId"] == item_a_id)
+    assert item["status"] == ItemState.QUEUED.value
+    assert "previousStatus" not in item
+    assert "deletedAt" not in item
+    assert item["updatedAt"].replace(tzinfo=UTC) == later
+    assert loaded["updatedAt"].replace(tzinfo=UTC) == later
+
+    await _set_item_fields(
+        real_database,
+        batch_id,
+        user_id,
+        item_b_id,
+        status=ItemState.DELETED.value,
+        deletedAt=NOW,
+    )
+    before = await get_batch(real_database, batch_id, user_id)
+    assert before is not None
+    assert await undo_item_deletion(real_database, batch_id, user_id, item_b_id, now=later) is False
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+    assert await undo_item_deletion(real_database, batch_id, user_id, "missing", now=later) is False
+    assert await get_batch(real_database, batch_id, user_id) == before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mutation", "kwargs"),
+    [
+        (save_item_extraction_success, {"crop": {}, "draft": {}, "extraction": {}}),
+        (save_item_extraction_failure, {"extraction": {}}),
+        (reset_item_for_retry, {}),
+        (update_item_draft, {"draft_update": {}}),
+        (mark_item_deleted, {}),
+        (undo_item_deletion, {}),
+    ],
+    ids=[
+        "extraction-success",
+        "extraction-failure",
+        "reset-retry",
+        "update-draft",
+        "delete",
+        "undo-delete",
+    ],
+)
+async def test_mutations_raise_for_missing_batch(
+    real_database: Any,
+    user_id: ObjectId,
+    mutation: Callable[..., Awaitable[Any]],
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.raises(ValueError, match="Batch not found"):
+        await mutation(real_database, ObjectId(), user_id, "item", now=NOW, **kwargs)


### PR DESCRIPTION
Model-Signature: gpt-5

## Summary

- Adds a test-only, real-Mongo harness that deterministically reproduces the whole-array lost-update window with two synchronized repository calls.
- Characterizes the sequential real-Mongo contracts of the six issue-scoped ingestion mutation functions, including eligibility, idempotency, missing data, timestamps, lease clearing, stored shapes, and errors.
- Records the setup, operation trace, results, limitations, environment, and mandatory stop before any production fix in `.refactor-council/`.

## Linked Issue

Closes #508

## Issue Alignment

This PR implements the issue by:

- Delegating authoritative reads and writes to isolated MongoDB while test-local events hold both calls after their reads and release their writes in a fixed B-then-A order.
- Demonstrating that A's stale whole-array write preserves A's distinct-item draft change and erases B's already-persisted change.
- Exercising all six named sequential mutation contracts against real MongoDB.
- Documenting how each function participates in the shared full-array race surface and the current real-Mongo datetime behavior.

Scope covered:

- `backend/tests/integration/test_ingestion_atomicity.py`
- `.refactor-council/ingestion-concurrency-characterization.md`

Out of scope / intentionally not included:

- No production repository, schema, index, API, worker, preview, or CI workflow change.
- No atomic update, transaction, version, compare-and-swap, or production test hook.
- No `claim_item` coverage or unrelated cleanup.

## Implementation Notes

- Two `_SynchronizedDatabase` proxies independently gate each real `find_one` and `update_one`; assertions prove both reads complete before either write completes.
- The fixture requires `MONGODB_URI`. Existing unit-only CI, which does not configure MongoDB, skips this real-service module immediately; an explicitly configured but unavailable MongoDB still fails.
- The run characterized MongoDB 4.4.30 with PyMongo 4.17.0.
- Real Mongo returns an expired lease as naive UTC. Passing the repository's normal aware UTC `now` currently raises `TypeError`; the test records that behavior and verifies no write occurs instead of changing production code.

## Tests

Commands run:

- `./scripts/agent-env.sh build` — passed; reused the fingerprinted tools image.
- `./scripts/agent-env.sh shell`, then `cd backend && uv run --frozen --active pytest tests/integration/test_ingestion_atomicity.py -q` — passed, 14 tests.
- `./scripts/agent-env.sh test backend` — passed, 980 tests; 1 skipped.
- Inside the tools image, `env -u MONGODB_URI uv run --frozen --active pytest tests/integration/test_ingestion_atomicity.py -q` — passed, 14 skipped in 0.01s, matching unit-only CI availability.
- `git diff --check` — passed.

Automated tests added or updated:

- Added a deterministic two-reader/two-writer real-Mongo lost-update reproduction.
- Added sequential contract coverage for extraction success/failure, retry reset, draft update, delete, and undo-delete, including six parameterized missing-batch cases.

Manual verification:

- Inspected the synchronized trace: both reads completed with neither write released; B completed first; A remained held; A completed last; B's distinct-item change was absent from the final Mongo document.
- Confirmed the final diff contains only the integration harness and council artifact, with no production file.
- Confirmed the council artifact covers all six contracts, the race exposure, commands/results, Mongo/driver versions, limitations, and future human/Safety gate.

## Deviations From Issue Plan

- The real-Mongo expired-extracting retry does not match the fake-database success path: Mongo's naive UTC lease and the repository's aware UTC `now` raise `TypeError`. This PR characterizes the observed error and no-write result without applying the out-of-scope production fix.

## Follow-Up Work

None in this PR. Any production mutation or datetime fix requires separately approved scope; atomic mutation work additionally requires the issue-mandated human/Safety review and rollback plan.
