### PR TITLE
feat(selection): status-specific recency daily growth rates

### DIFF
--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -62,11 +62,19 @@ def compute_score_breakdown(
     config: ProblemSelectionConfig,
     now: datetime,
 ) -> ScoreBreakdown:
-    # Recency score
-    last_dt = problem.tracking.lastTestedAt or problem.createdAt
-    if last_dt is not None:
-        days_since = (now - ensure_utc(last_dt)).days
-        recency_score = 1.0 + days_since / 30.0
+    # Recency score with status-specific daily growth rate.
+    # Never tested grows fastest (1/10), last-correct slowest (1/60),
+    # last-failed and tested-unknown retain the original pace (1/30).
+    if problem.tracking.lastTestedAt is None:
+        reference_dt = problem.createdAt
+        daily_rate = 1 / 10
+    else:
+        reference_dt = problem.tracking.lastTestedAt
+        daily_rate = 1 / 60 if problem.tracking.lastAttemptCorrect is True else 1 / 30
+
+    if reference_dt is not None:
+        days_since = (now - ensure_utc(reference_dt)).days
+        recency_score = 1.0 + days_since * daily_rate
     else:
         recency_score = 1.0
 

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -804,12 +804,12 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     database: FakeDatabase = home_app.state.fake_database
     user_id = home_app.state.user["_id"]
     now = datetime.now(UTC)
-    sixty_days_ago = now - timedelta(days=60)  # recency = 1.0 + 60/30 = 3.0
+    sixty_days_ago = now - timedelta(days=60)
 
-    # Never-tested: recency=1.0 (createdAt ~now), failure=0.0, last_wrong=1.0 -> raw=2.0 (bucket 2)
+    # Never-tested: recency=1.0 (createdAt ~now, days_since=0), failure=0.0, last_wrong=1.0 -> raw=2.0 (bucket 2)
     never_tested = make_problem(user_id, created_at=now)
 
-    # Tested correct: recency=3.0, failure=0.0, last_wrong=0.5 -> raw=3.5 (bucket 3)
+    # Tested correct: rate 1/60 -> recency=1.0+60/60=2.0, failure=0.0, last_wrong=0.5 -> raw=2.5 (bucket 2)
     tested_correct = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -817,7 +817,7 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
         created_at=sixty_days_ago,
     )
 
-    # Tested incorrect, more failures than corrects: failure=2.0, last_wrong=2.0 -> raw=3.0+2.0+2.0=7.0 (bucket 7)
+    # Tested incorrect, more failures than corrects: rate 1/30 -> recency=3.0, failure=2.0, last_wrong=2.0 -> raw=7.0 (bucket 7)
     tested_incorrect = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -835,19 +835,17 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     by_start = {b["start"]: b for b in buckets}
     assert list(b["start"] for b in buckets) == sorted(b["start"] for b in buckets)
 
-    # Bucket range spans 2..7 with contiguous empty buckets at 4, 5, 6.
+    # Bucket range spans 2..7 with contiguous empty buckets at 3, 4, 5, 6.
     assert list(by_start.keys()) == [2, 3, 4, 5, 6, 7]
 
-    # Raw score 2.0 lands in bucket 2 (boundary: exact integer belongs to its own bucket).
-    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 0, "cooldown": 0}
-
-    # Raw score 3.5 lands in bucket 3.
-    assert by_start[3] == {"start": 3, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
+    # Raw scores 2.0 (never tested) and 2.5 (tested correct) both land in bucket 2.
+    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 1, "cooldown": 0}
 
     # Raw score 7.0 lands in bucket 7 (exact integer boundary).
     assert by_start[7] == {"start": 7, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
 
     # Empty intermediate buckets emitted contiguously.
+    assert by_start[3] == {"start": 3, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
     assert by_start[4] == {"start": 4, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
     assert by_start[5] == {"start": 5, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
     assert by_start[6] == {"start": 6, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
@@ -929,8 +927,8 @@ async def test_summary_score_distribution_raw_not_clamped_regression(
 
     # Tested correct with many more corrects than failures -> negative failure score.
     # correctCount=10, failedCount=0 -> failure = -sqrt(10) ~ -3.162.
-    # lastTestedAt 60d ago -> recency=3.0; lastAttemptCorrect -> last_wrong=0.5.
-    # raw = 3.0 + (-3.162) + 0.5 ~ 0.338 -> floor 0.
+    # lastTestedAt 60d ago, lastAttemptCorrect -> rate 1/60 -> recency=1.0+60/60=2.0; last_wrong=0.5.
+    # raw = 2.0 + (-3.162) + 0.5 ~ -0.662 -> floor -1.
     problem = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -944,7 +942,7 @@ async def test_summary_score_distribution_raw_not_clamped_regression(
     response = await client.get("/api/v1/home/summary")
     buckets = response.json()["scoreDistribution"]["buckets"]
     assert len(buckets) == 1
-    assert buckets[0]["start"] == 0
+    assert buckets[0]["start"] == -1
     assert buckets[0]["tested"] == 1
 
 

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -420,9 +420,9 @@ def test_compute_problem_weight_breakdown_never_tested():
 
     assert breakdown.lastWrong == 1.0
     assert breakdown.failure == 0.0
-    # Recency falls back to createdAt (30 days ago): score = 1.0 + 30/30 = 2.0
-    assert breakdown.recency == 2.0
-    assert breakdown.total == 3.0
+    # Never tested: createdAt (30 days ago), rate 1/10 -> 1.0 + 30*(1/10) = 4.0
+    assert breakdown.recency == 4.0
+    assert breakdown.total == 5.0
 
 
 def test_compute_problem_weight_breakdown_zero_attempts():
@@ -433,9 +433,9 @@ def test_compute_problem_weight_breakdown_zero_attempts():
 
     assert breakdown.lastWrong == 1.0
     assert breakdown.failure == 0.0
-    # Recency falls back to createdAt (30 days ago): score = 1.0 + 30/30 = 2.0
-    assert breakdown.recency == 2.0
-    assert breakdown.total == 3.0
+    # Never tested: createdAt (30 days ago), rate 1/10 -> 1.0 + 30*(1/10) = 4.0
+    assert breakdown.recency == 4.0
+    assert breakdown.total == 5.0
 
 
 def test_compute_problem_weight_breakdown_uses_same_total_as_selection():

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -155,7 +155,7 @@ def test_recency_uses_last_tested_when_present():
     problem = create_test_problem("p1", last_tested_at=last_tested)
     config = ProblemSelectionConfig(recency_weight=1.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    # days_since = 60, recency_score = 1.0 + 60/30 = 3.0
+    # Tested with unknown last result: rate 1/30, days_since = 60 -> 1.0 + 60*(1/30) = 3.0
     assert breakdown.recency == 3.0
 
 
@@ -165,8 +165,49 @@ def test_recency_uses_created_at_when_not_tested():
     problem = create_test_problem("p1", last_tested_at=None, created_at=created_at)
     config = ProblemSelectionConfig(recency_weight=1.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    # days_since = 45, recency_score = 1.0 + 45/30 = 2.5
-    assert breakdown.recency == 2.5
+    # Never tested: rate 1/10, days_since = 45 -> 1.0 + 45*(1/10) = 5.5
+    assert breakdown.recency == 5.5
+
+
+def test_recency_status_specific_rates():
+    """Verify the four tracking states use their confirmed date references and rates."""
+    now = datetime.now(timezone.utc)
+    config = ProblemSelectionConfig(recency_weight=1.0)
+
+    # Never tested, created 30 days ago -> createdAt reference, rate 1/10 -> 4.0
+    never_tested = create_test_problem(
+        "never", last_tested_at=None, created_at=now - timedelta(days=30)
+    )
+    assert compute_score_breakdown(never_tested, config, now).recency == 4.0
+
+    # Last correct, tested 60 days ago -> lastTestedAt reference, rate 1/60 -> 2.0
+    last_correct = create_test_problem(
+        "correct", last_tested_at=now - timedelta(days=60), last_attempt_correct=True
+    )
+    assert compute_score_breakdown(last_correct, config, now).recency == 2.0
+
+    # Last failed, tested 60 days ago -> lastTestedAt reference, rate 1/30 -> 3.0
+    last_failed = create_test_problem(
+        "failed", last_tested_at=now - timedelta(days=60), last_attempt_correct=False
+    )
+    assert compute_score_breakdown(last_failed, config, now).recency == 3.0
+
+    # Tested 60 days ago with unknown last result -> lastTestedAt reference, rate 1/30 -> 3.0
+    tested_unknown = create_test_problem(
+        "unknown", last_tested_at=now - timedelta(days=60)
+    )
+    assert compute_score_breakdown(tested_unknown, config, now).recency == 3.0
+
+
+def test_recency_weight_scales_status_specific_component():
+    now = datetime.now(timezone.utc)
+    # Never tested 30 days ago: raw recency = 4.0, scaled by recency_weight=2.0 -> 8.0
+    problem = create_test_problem(
+        "p1", last_tested_at=None, created_at=now - timedelta(days=30)
+    )
+    config = ProblemSelectionConfig(recency_weight=2.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.recency == 8.0
 
 
 def test_failure_score_no_attempts():


### PR DESCRIPTION
Model-Signature: ark-coding-plan/glm-5.2

## Summary

- Make the shared problem-selection recency component use a status-specific daily growth rate: `1/10` for never-tested, `1/60` for last-correct, and `1/30` for last-failed / tested-unknown.
- Never-tested problems now rise faster, previously-correct problems rise slower, and previously-failed / tested-unknown retain the original pace.
- Update affected domain, practice-selection, and home score-distribution test expectations to the new derived values.

## Linked Issue

Closes #520

## Issue Alignment

This PR implements the issue by:

- Rewriting only the recency branch of `compute_score_breakdown` in `backend/app/domain/selection.py` to select both the date reference and the exact fractional daily rate from the tracking state.
- Keeping the `1.0` base, UTC normalization, `timedelta.days` complete-day granularity, and multiplication of the full raw recency value by `recency_weight` unchanged.
- Letting `lastTestedAt is None` remain the authoritative definition of never-tested even when inconsistent data carries a non-null `lastAttemptCorrect`.

Scope covered:

- Updating the shared domain recency calculation.
- Applying exact fractional rates (`1/10`, `1/60`, `1/30`) rather than rounded decimal constants.
- Updating unit and API tests whose score or score-bucket expectations change.
- Preserving shared behavior across practice selection, exam selection, problem score sorting/details, and home score distribution (all reuse `compute_score_breakdown`).

Out of scope / intentionally not included:

- No new configuration settings, API fields, or UI controls for the rates.
- No changes to the `failure` or `last_wrong` components.
- No changes to cooldown, minimum-age eligibility, total-score clamping, or weighted sampling.
- No data migration/backfill; selection scores are derived at runtime.
- No refactoring of adjacent selection code.

## Implementation Notes

The recency branch now picks the reference date and rate in one place:

```python
if problem.tracking.lastTestedAt is None:
    reference_dt = problem.createdAt
    daily_rate = 1 / 10
else:
    reference_dt = problem.tracking.lastTestedAt
    daily_rate = 1 / 60 if problem.tracking.lastAttemptCorrect is True else 1 / 30
```

The pre-existing fallback (`recency_score = 1.0` when both `lastTestedAt` and `createdAt` are `None`) is preserved. Representative results with `recency_weight = 1.0` match the issue goal table exactly: never-tested 30d -> 4.0; last-correct 60d -> 2.0; last-failed 60d -> 3.0; tested-unknown 60d -> 3.0.

## Tests

Commands run:

- `pytest tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/api/test_home.py -q` (via agent-env tools container) — passed (106 passed).
- `pytest -q` full backend suite (via agent-env tools container with isolated MongoDB/RustFS) — passed (982 passed, 1 skipped; the single skip is a pre-existing environmental skip unrelated to recency).

Automated tests added or updated:

- `test_selection.py::test_recency_status_specific_rates` (new) — covers all four tracking states (never-tested, last-correct, last-failed, tested-unknown) with the issue representative numeric examples.
- `test_selection.py::test_recency_weight_scales_status_specific_component` (new) — verifies a non-default `recency_weight` scales the entire status-specific recency component.
- `test_selection.py::test_recency_uses_created_at_when_not_tested` — updated never-tested expectation from 2.5 to 5.5 (45 days at 1/10).
- `test_selection.py::test_recency_uses_last_tested_when_present` — comment updated to clarify tested-unknown at 1/30 (value unchanged at 3.0).
- `test_practice_selection.py::test_compute_problem_weight_breakdown_never_tested` — recency 2.0 -> 4.0, total 3.0 -> 5.0.
- `test_practice_selection.py::test_compute_problem_weight_breakdown_zero_attempts` — recency 2.0 -> 4.0, total 3.0 -> 5.0.
- `test_home.py::test_summary_score_distribution_negative_zero_positive_buckets` — tested-correct raw score moves from 3.5 (bucket 3) to 2.5 (bucket 2); empty contiguous buckets now 3-6.
- `test_home.py::test_summary_score_distribution_raw_not_clamped_regression` — tested-correct raw score moves from 0.338 (bucket 0) to -0.662 (bucket -1); still proves raw (non-clamped) negative buckets appear.

Manual verification:

- Inspected the recency values for a never-tested, last-correct, and last-failed problem via the domain tests and confirmed they match the issue goal table (4.0 / 2.0 / 3.0).
- Confirmed complete-day rounding, failure scoring, last-wrong scoring, eligibility, clamping, and sampling logic are untouched by the passing full suite.

## Deviations From Issue Plan

None.

## Follow-Up Work

None. Making the three rates configurable is explicitly excluded from this issue.