### PR TITLE
Show practice and exam attempt history on problem detail page

### DIFF
--- a/backend/app/infrastructure/storage/mongo.py
+++ b/backend/app/infrastructure/storage/mongo.py
@@ -147,6 +147,21 @@ async def ensure_database_setup(database: AsyncDatabase[Document]) -> None:
             collation={"locale": "en", "strength": 2},  # case-insensitive
         )
 
+    # Attempt-history lookup indexes (non-unique): practice attempts by user/problem/time,
+    # and submitted exams by user/state/submission time.
+    create_practice_attempt_index = getattr(database["practice_attempts"], "create_index", None)
+    if callable(create_practice_attempt_index):
+        await create_practice_attempt_index(
+            [("userId", ASCENDING), ("problemId", ASCENDING), ("createdAt", ASCENDING)],
+            name="user_problem_time",
+        )
+    create_exam_history_index = getattr(database["exams"], "create_index", None)
+    if callable(create_exam_history_index):
+        await create_exam_history_index(
+            [("userId", ASCENDING), ("state", ASCENDING), ("submittedAt", ASCENDING)],
+            name="user_state_submitted_time",
+        )
+
     await ensure_batch_indexes(database)
 
 

--- a/backend/app/presentation/problem_serialization.py
+++ b/backend/app/presentation/problem_serialization.py
@@ -89,6 +89,19 @@ class BulkSetFolderResponse(BaseModel):
     ok: bool
 
 
+class AttemptHistoryItemPayload(BaseModel):
+    id: str
+    testedAt: UTCDatetime
+    result: str
+    source: str
+
+
+class AttemptHistoryResponse(BaseModel):
+    items: list[AttemptHistoryItemPayload]
+    total: int
+    hasMore: bool
+
+
 def _serialize_tracking(problem: dict[str, Any]) -> TrackingPayload:
     tracking = dict(problem.get("tracking", {}))
     return TrackingPayload(

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -10,7 +10,7 @@ from bson import ObjectId
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 
-from app.domain.models import ProblemType
+from app.domain.models import ExamState, ProblemType
 from app.domain.normalization import normalize_answer
 from app.domain.practice_selection import compute_problem_weight_breakdown
 from app.infrastructure.auth.password import verify_password
@@ -21,6 +21,8 @@ from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
 from app.presentation.helpers import get_all_descendant_folder_ids, get_owned_folder, get_owned_problem, normalize_tags, parse_object_id
 from app.presentation.problem_serialization import (
+    AttemptHistoryResponse,
+    AttemptHistoryItemPayload,
     BulkSetFolderResponse,
     PracticeWeightPayload,
     ProblemDeleteResponse,
@@ -510,3 +512,85 @@ async def get_problem_tracking(
             total=breakdown.total,
         ),
     )
+
+
+@router.get("/{problem_id}/attempts", response_model=AttemptHistoryResponse)
+async def get_problem_attempt_history(
+    problem_id: str,
+    database: DatabaseDependency,
+    current_user: CurrentUserDependency,
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+) -> AttemptHistoryResponse:
+    """Return merged practice/exam attempt history for a problem, newest-first.
+
+    Practice records use ``practice_attempt.createdAt``; exam records use the
+    submitted exam's ``submittedAt``. Only submitted exams contribute. Legacy
+    records lacking a trustworthy timestamp are skipped. Records are merged
+    deterministically by ``testedAt`` desc with a source/id tie-breaker so
+    offset pages do not reorder or duplicate tied records.
+    """
+    problem_oid = parse_object_id(problem_id, resource_name="Problem")
+    problem = await database["problems"].find_one(
+        {"_id": problem_oid, "userId": current_user["_id"], "isDeleted": False}
+    )
+    if problem is None:
+        raise ApiError(404, "NOT_FOUND", "Problem not found")
+
+    user_id = current_user["_id"]
+
+    # Fetch all matching records per source. Per-problem-per-user history is
+    # inherently bounded, and this mirrors the existing practice-history endpoint
+    # convention. Totals/hasMore describe valid records only.
+    practice_docs = await database["practice_attempts"].find(
+        {"userId": user_id, "problemId": problem_oid, "createdAt": {"$ne": None}}
+    ).sort([("createdAt", -1), ("_id", 1)]).to_list(length=None)
+
+    exam_docs = await database["exams"].find(
+        {
+            "userId": user_id,
+            "state": ExamState.SUBMITTED.value,
+            "submittedAt": {"$ne": None},
+            "items.problemId": problem_oid,
+        }
+    ).sort([("submittedAt", -1), ("_id", 1)]).to_list(length=None)
+
+    records: list[tuple[datetime, str, str, str]] = []
+    for doc in practice_docs:
+        created_at = doc.get("createdAt")
+        if not isinstance(created_at, datetime):
+            continue
+        records.append(
+            (created_at, "practice", str(doc["_id"]), str(doc.get("gradingStatus", "ungraded")))
+        )
+
+    for exam in exam_docs:
+        submitted_at = exam.get("submittedAt")
+        if not isinstance(submitted_at, datetime):
+            continue
+        exam_item_id = ""
+        item_result = "ungraded"
+        for item in exam.get("items", []):
+            if item.get("problemId") == problem_oid:
+                exam_item_id = str(item.get("itemId", exam["_id"]))
+                grading = item.get("grading") or {}
+                item_result = str(grading.get("status", "ungraded"))
+                break
+        records.append(
+            (submitted_at, "exam", exam_item_id or str(exam["_id"]), item_result)
+        )
+
+    # Deterministic newest-first ordering with source/id tie-breaker so offset
+    # pagination never reorders or duplicates tied records.
+    records.sort(key=lambda r: (r[1], r[2]))  # stable pre-sort by source, id
+    records.sort(key=lambda r: r[0], reverse=True)
+
+    total = len(records)
+    page = records[offset : offset + limit]
+    has_more = offset + limit < total
+
+    items = [
+        AttemptHistoryItemPayload(id=f"{source}:{record_id}", testedAt=tested_at, result=result, source=source)
+        for tested_at, source, record_id, result in page
+    ]
+    return AttemptHistoryResponse(items=items, total=total, hasMore=has_more)

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -1619,3 +1619,289 @@ async def test_problem_payload_includes_folder_id(
     assert detail_response.status_code == 200
     body = detail_response.json()["problem"]
     assert body["folderId"] == str(folder["_id"])
+
+
+def make_practice_attempt(
+    user_id: ObjectId,
+    problem_id: ObjectId,
+    *,
+    grading_status: str = "correct",
+    created_at: datetime | None = None,
+) -> dict[str, Any]:
+    now = created_at or datetime.now(UTC)
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "problemId": problem_id,
+        "submittedAnswer": "answer",
+        "gradingStatus": grading_status,
+        "gradingMethod": "normalized-match",
+        "createdAt": now,
+    }
+
+
+def make_exam_item(
+    problem_id: ObjectId,
+    *,
+    grading_status: str = "correct",
+) -> dict[str, Any]:
+    return {
+        "itemId": str(ObjectId()),
+        "order": 1,
+        "problemId": problem_id,
+        "problemSnapshot": {"text": "t", "problemType": "short-answer", "subject": "math"},
+        "answer": {"raw": "a", "savedAt": datetime.now(UTC)},
+        "grading": {
+            "status": grading_status,
+            "method": None,
+            "isCorrect": grading_status == "correct",
+            "score": None,
+            "feedback": None,
+        },
+    }
+
+
+def make_submitted_exam(
+    user_id: ObjectId,
+    problem_id: ObjectId,
+    *,
+    submitted_at: datetime,
+    grading_status: str = "correct",
+    state: str = "submitted",
+) -> dict[str, Any]:
+    return {
+        "_id": ObjectId(),
+        "userId": user_id,
+        "state": state,
+        "items": [make_exam_item(problem_id, grading_status=grading_status)],
+        "summary": {},
+        "createdAt": submitted_at - timedelta(hours=1),
+        "startedAt": submitted_at - timedelta(minutes=30),
+        "submittedAt": submitted_at,
+        "updatedAt": submitted_at,
+    }
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_merges_practice_and_exam_newest_first(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id, text="History problem")
+    database["problems"].seed(problem)
+
+    t1 = datetime(2026, 7, 16, 8, 0, 0, tzinfo=UTC)
+    t2 = datetime(2026, 7, 16, 10, 0, 0, tzinfo=UTC)
+    t3 = datetime(2026, 7, 16, 12, 0, 0, tzinfo=UTC)
+
+    database["practice_attempts"].seed(
+        make_practice_attempt(user_id, problem["_id"], grading_status="correct", created_at=t1),
+        make_practice_attempt(user_id, problem["_id"], grading_status="incorrect", created_at=t3),
+    )
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=t2, grading_status="correct"),
+    )
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 3
+    assert body["hasMore"] is False
+    items = body["items"]
+    # Newest first: t3 practice incorrect, t2 exam correct, t1 practice correct
+    assert items[0]["testedAt"].startswith("2026-07-16T12")
+    assert items[0]["source"] == "practice"
+    assert items[0]["result"] == "incorrect"
+    assert items[1]["source"] == "exam"
+    assert items[1]["result"] == "correct"
+    assert items[2]["testedAt"].startswith("2026-07-16T08")
+    assert items[2]["source"] == "practice"
+    assert items[2]["result"] == "correct"
+    assert all(item["id"].count(":") == 1 for item in items)
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_preserves_pending_and_ungraded_states(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    database["problems"].seed(problem)
+
+    now = datetime.now(UTC)
+    database["practice_attempts"].seed(
+        make_practice_attempt(user_id, problem["_id"], grading_status="pending-review", created_at=now),
+        make_practice_attempt(user_id, problem["_id"], grading_status="ungraded", created_at=now - timedelta(hours=1)),
+    )
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=now - timedelta(hours=2), grading_status="pending-review"),
+    )
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
+    assert response.status_code == 200
+    results = {item["result"] for item in response.json()["items"]}
+    assert results == {"pending-review", "ungraded"}
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_pagination_appends_without_duplication(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    database["problems"].seed(problem)
+
+    base = datetime(2026, 7, 16, 0, 0, 0, tzinfo=UTC)
+    # 22 distinct timestamps to exercise two pages of 20
+    for i in range(22):
+        database["practice_attempts"].seed(
+            make_practice_attempt(user_id, problem["_id"], grading_status="correct", created_at=base + timedelta(minutes=i))
+        )
+
+    first = await client.get(f"/api/v1/problems/{problem['_id']}/attempts", params={"limit": 20, "offset": 0})
+    assert first.status_code == 200
+    first_body = first.json()
+    assert first_body["total"] == 22
+    assert len(first_body["items"]) == 20
+    assert first_body["hasMore"] is True
+
+    second = await client.get(f"/api/v1/problems/{problem['_id']}/attempts", params={"limit": 20, "offset": 20})
+    assert second.status_code == 200
+    second_body = second.json()
+    assert len(second_body["items"]) == 2
+    assert second_body["hasMore"] is False
+
+    all_ids = [item["id"] for item in first_body["items"]] + [item["id"] for item in second_body["items"]]
+    assert len(all_ids) == 22
+    assert len(set(all_ids)) == 22
+    # Page 1 timestamps are strictly newer than page 2 timestamps
+    assert first_body["items"][-1]["testedAt"] >= second_body["items"][0]["testedAt"]
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_excludes_non_final_and_other_user_exams(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    other_user_id = problems_app.state.secondary_user["_id"]
+    problem = make_problem(user_id)
+    database["problems"].seed(problem)
+
+    now = datetime.now(UTC)
+    # Submitted exam for this user contributes
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=now, grading_status="correct", state="submitted"),
+    )
+    # Active exam for this user is excluded
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=now, grading_status="correct", state="in-progress"),
+    )
+    # Grading exam excluded
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=now, grading_status="correct", state="grading"),
+    )
+    # Discarded exam excluded
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=now, grading_status="correct", state="discarded"),
+    )
+    # Other user's submitted exam excluded
+    database["exams"].seed(
+        make_submitted_exam(other_user_id, problem["_id"], submitted_at=now, grading_status="correct", state="submitted"),
+    )
+    # Other user's practice attempt excluded
+    database["practice_attempts"].seed(
+        make_practice_attempt(other_user_id, problem["_id"], grading_status="correct", created_at=now),
+    )
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 1
+    assert body["items"][0]["source"] == "exam"
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_does_not_fabricate_rows_from_aggregate_counters(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    # Tracking counters claim 2 correct + 1 failed but no persisted records exist.
+    problem = make_problem(user_id, text="Counters only")
+    problem["tracking"] = {
+        "exposureCount": 3,
+        "correctCount": 2,
+        "failedCount": 1,
+        "lastTestedAt": datetime.now(UTC),
+        "lastAttemptCorrect": False,
+    }
+    database["problems"].seed(problem)
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+    assert body["hasMore"] is False
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_missing_problem_returns_404(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    response = await client.get(f"/api/v1/problems/{ObjectId()}/attempts")
+    assert response.status_code == 404
+    assert response.json() == {"error": {"code": "NOT_FOUND", "message": "Problem not found"}}
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_empty_state(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id)
+    database["problems"].seed(problem)
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {"items": [], "total": 0, "hasMore": False}
+
+
+@pytest.mark.asyncio
+async def test_attempt_history_excludes_other_problem_records(
+    problems_app: FastAPI,
+    client: AsyncClient,
+) -> None:
+    database: FakeDatabase = problems_app.state.fake_database
+    user_id = problems_app.state.primary_user["_id"]
+    problem = make_problem(user_id, text="Target")
+    other_problem = make_problem(user_id, text="Other")
+    database["problems"].seed(problem, other_problem)
+
+    now = datetime.now(UTC)
+    database["practice_attempts"].seed(
+        make_practice_attempt(user_id, problem["_id"], grading_status="correct", created_at=now),
+        make_practice_attempt(user_id, other_problem["_id"], grading_status="incorrect", created_at=now),
+    )
+    database["exams"].seed(
+        make_submitted_exam(user_id, problem["_id"], submitted_at=now, grading_status="correct"),
+        make_submitted_exam(user_id, other_problem["_id"], submitted_at=now, grading_status="correct"),
+    )
+
+    response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 2

--- a/backend/tests/infrastructure/test_mongo.py
+++ b/backend/tests/infrastructure/test_mongo.py
@@ -181,3 +181,15 @@ async def test_ensure_database_setup_creates_solution_collections_and_tag_index(
             "kwargs": {"unique": True, "name": "exam_grading_task_exam_unique"},
         }
     ]
+    assert database["practice_attempts"].index_calls == [
+        {
+            "keys": [("userId", 1), ("problemId", 1), ("createdAt", 1)],
+            "kwargs": {"name": "user_problem_time"},
+        }
+    ]
+    assert database["exams"].index_calls == [
+        {
+            "keys": [("userId", 1), ("state", 1), ("submittedAt", 1)],
+            "kwargs": {"name": "user_state_submitted_time"},
+        }
+    ]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,6 +2,7 @@
 // Uses fetch with credentials: 'include' to send HttpOnly cookies automatically
 
 import type { CoachingConversation } from "@/types/coaching";
+import type { AttemptHistoryResponse } from "@/types/problem";
 
 const API_BASE = "/api/v1";
 
@@ -112,6 +113,18 @@ export const api = {
    */
   async regenerateSolution(problemId: string): Promise<{ status: string }> {
     return this.post<{ status: string }>(`/problems/${problemId}/solution-regeneration`, {});
+  },
+
+  /**
+   * Get paginated practice/exam attempt history for a problem.
+   */
+  async getAttemptHistory(
+    problemId: string,
+    params: { limit: number; offset: number },
+  ): Promise<AttemptHistoryResponse> {
+    return this.get<AttemptHistoryResponse>(
+      `/problems/${problemId}/attempts?limit=${params.limit}&offset=${params.offset}`,
+    );
   },
 
   /**

--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -19,6 +19,7 @@ vi.mock("@/api/client", () => ({
     setProblemDisabled: vi.fn(),
     getSolutionStatus: vi.fn(),
     regenerateSolution: vi.fn(),
+    getAttemptHistory: vi.fn(),
   },
 }));
 
@@ -101,11 +102,14 @@ describe("ProblemDetailPage", () => {
     vi.mocked(api.setProblemDisabled).mockReset();
     vi.mocked(api.getSolutionStatus).mockReset();
     vi.mocked(api.regenerateSolution).mockReset();
+    vi.mocked(api.getAttemptHistory).mockReset();
     mockNavigate.mockReset();
 
     // Default: no solution status
     vi.mocked(api.getSolutionStatus).mockResolvedValue({ status: "none" });
     vi.mocked(api.regenerateSolution).mockResolvedValue({ status: "pending" });
+    // Default: empty attempt history so existing tests are unaffected.
+    vi.mocked(api.getAttemptHistory).mockResolvedValue({ items: [], total: 0, hasMore: false });
   });
 
   it("renders problem details", async () => {
@@ -941,5 +945,172 @@ describe("ProblemDetailPage", () => {
     expect(screen.getByTestId("teacher-password-modal")).toBeInTheDocument();
     expect(screen.getByTestId("toggle-disabled-button")).toHaveTextContent("Disable");
     expect(screen.queryByTestId("disabled-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders attempt history rows from API", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory).mockResolvedValueOnce({
+      items: [
+        { id: "practice:p1", testedAt: "2026-07-16T12:00:00Z", result: "incorrect", source: "practice" },
+        { id: "exam:e1", testedAt: "2026-07-16T10:00:00Z", result: "correct", source: "exam" },
+        { id: "practice:p2", testedAt: "2026-07-16T08:00:00Z", result: "correct", source: "practice" },
+      ],
+      total: 3,
+      hasMore: false,
+    });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Test History")).toBeInTheDocument();
+    });
+
+    const history = await screen.findByTestId("attempt-history");
+    expect(history.querySelectorAll("tbody tr")).toHaveLength(3);
+    expect(within(history).getByText("Incorrect")).toBeInTheDocument();
+    expect(within(history).getAllByText("Correct").length).toBeGreaterThanOrEqual(1);
+    expect(within(history).getAllByText("practice").length).toBeGreaterThanOrEqual(2);
+    expect(within(history).getByText("exam")).toBeInTheDocument();
+    expect(screen.queryByTestId("attempt-history-load-more")).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 3 of 3/)).toBeInTheDocument();
+  });
+
+  it("shows empty state when no attempt history exists", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    // getAttemptHistory defaults to empty from beforeEach.
+
+    renderProblemDetailPage();
+
+    expect(await screen.findByTestId("attempt-history-empty")).toHaveTextContent(
+      "No test history recorded.",
+    );
+  });
+
+  it("shows error and retry when attempt history fails to load", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory).mockRejectedValueOnce(new Error("History unavailable"));
+
+    renderProblemDetailPage();
+
+    expect(await screen.findByTestId("attempt-history-error")).toHaveTextContent(
+      "History unavailable",
+    );
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  it("loads more pages and appends rows without duplicates", async () => {
+    const user = userEvent.setup();
+    const firstPage = Array.from({ length: 20 }, (_, i) => ({
+      id: `practice:p${i}`,
+      testedAt: `2026-07-16T${String(23 - i).padStart(2, "0")}:00:00Z`,
+      result: "correct",
+      source: "practice" as const,
+    }));
+    const secondPage = [
+      { id: "practice:p20", testedAt: "2026-07-16T03:00:00Z", result: "correct", source: "practice" as const },
+      { id: "practice:p21", testedAt: "2026-07-16T02:00:00Z", result: "incorrect", source: "practice" as const },
+    ];
+
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory)
+      .mockResolvedValueOnce({ items: firstPage, total: 22, hasMore: true })
+      .mockResolvedValueOnce({ items: secondPage, total: 22, hasMore: false });
+
+    renderProblemDetailPage();
+
+    const history = await screen.findByTestId("attempt-history");
+    await waitFor(() => {
+      expect(history.querySelectorAll("tbody tr")).toHaveLength(20);
+    });
+    expect(screen.getByTestId("attempt-history-load-more")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("attempt-history-load-more"));
+
+    await waitFor(() => {
+      expect(history.querySelectorAll("tbody tr")).toHaveLength(22);
+    });
+    expect(screen.queryByTestId("attempt-history-load-more")).not.toBeInTheDocument();
+    expect(screen.getByText(/Showing 22 of 22/)).toBeInTheDocument();
+  });
+
+  it("disables Load more while fetching and hides it on final page", async () => {
+    const user = userEvent.setup();
+    const firstPage = Array.from({ length: 20 }, (_, i) => ({
+      id: `practice:p${i}`,
+      testedAt: `2026-07-16T${String(23 - i).padStart(2, "0")}:00:00Z`,
+      result: "correct",
+      source: "practice" as const,
+    }));
+
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory)
+      .mockResolvedValueOnce({ items: firstPage, total: 22, hasMore: true })
+      // Never resolves so load-more stays pending
+      .mockReturnValueOnce(new Promise(() => {}));
+
+    renderProblemDetailPage();
+
+    const loadMore = await screen.findByTestId("attempt-history-load-more");
+    await user.click(loadMore);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("attempt-history-load-more")).toBeDisabled();
+    });
+    expect(screen.getByTestId("attempt-history-load-more")).toHaveTextContent("Loading...");
+  });
+
+  it("preserves pending-review result label without relabeling as incorrect", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory).mockResolvedValueOnce({
+      items: [
+        { id: "practice:p1", testedAt: "2026-07-16T12:00:00Z", result: "pending-review", source: "practice" },
+        { id: "exam:e1", testedAt: "2026-07-16T10:00:00Z", result: "ungraded", source: "exam" },
+      ],
+      total: 2,
+      hasMore: false,
+    });
+
+    renderProblemDetailPage();
+
+    expect(await screen.findByText("Pending review")).toBeInTheDocument();
+    expect(screen.getByText("Ungraded")).toBeInTheDocument();
+    expect(screen.queryByText("Incorrect")).not.toBeInTheDocument();
+  });
+
+  it("keeps tracking statistics intact alongside attempt history", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory).mockResolvedValueOnce({
+      items: [{ id: "practice:p1", testedAt: "2026-07-16T12:00:00Z", result: "correct", source: "practice" }],
+      total: 1,
+      hasMore: false,
+    });
+
+    renderProblemDetailPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Tracking Statistics")).toBeInTheDocument();
+    });
+    // Existing aggregate counters remain
+    expect(screen.getByText("5")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+    // Practice weight intact
+    expect(screen.getByTestId("practice-weight")).toBeInTheDocument();
+    // History also present
+    expect(await screen.findByTestId("attempt-history")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -1113,4 +1113,48 @@ describe("ProblemDetailPage", () => {
     // History also present
     expect(await screen.findByTestId("attempt-history")).toBeInTheDocument();
   });
+
+  it("does not reset appended Load more rows on window focus refetch", async () => {
+    const user = userEvent.setup();
+    const firstPage = Array.from({ length: 20 }, (_, i) => ({
+      id: `practice:p${i}`,
+      testedAt: `2026-07-16T${String(23 - i).padStart(2, "0")}:00:00Z`,
+      result: "correct",
+      source: "practice" as const,
+    }));
+    const secondPage = [
+      { id: "practice:p20", testedAt: "2026-07-16T03:00:00Z", result: "correct", source: "practice" as const },
+      { id: "practice:p21", testedAt: "2026-07-16T02:00:00Z", result: "incorrect", source: "practice" as const },
+    ];
+
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    vi.mocked(api.getAttemptHistory)
+      .mockResolvedValueOnce({ items: firstPage, total: 22, hasMore: true })
+      .mockResolvedValueOnce({ items: secondPage, total: 22, hasMore: false });
+
+    renderProblemDetailPage();
+
+    const history = await screen.findByTestId("attempt-history");
+    await waitFor(() => {
+      expect(history.querySelectorAll("tbody tr")).toHaveLength(20);
+    });
+
+    await user.click(screen.getByTestId("attempt-history-load-more"));
+    await waitFor(() => {
+      expect(history.querySelectorAll("tbody tr")).toHaveLength(22);
+    });
+
+    // Simulate window focus, which would normally trigger a refetch of the
+    // initial page and clobber appended rows. With refetchOnWindowFocus:false
+    // the appended rows must remain and no extra getAttemptHistory call occurs.
+    const callsBefore = vi.mocked(api.getAttemptHistory).mock.calls.length;
+    window.dispatchEvent(new Event("focus"));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(history.querySelectorAll("tbody tr")).toHaveLength(22);
+    expect(screen.getByText(/Showing 22 of 22/)).toBeInTheDocument();
+    expect(vi.mocked(api.getAttemptHistory).mock.calls.length).toBe(callsBefore);
+  });
 });

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -137,6 +137,9 @@ function ProblemAttemptHistory({ problemId }: { problemId: string }) {
       }
     },
     enabled: !!problemId,
+    // Appended "Load more" rows are held in local state; a window-focus
+    // refetch of the initial page would clobber them, so opt out.
+    refetchOnWindowFocus: false,
   });
 
   const loadMore = async () => {

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -10,7 +10,7 @@ import { TagInput } from "@/components/TagInput";
 import { TagList } from "@/components/TagPill";
 import { TeacherPasswordModal } from "@/components/TeacherPasswordModal";
 import { useTagSuggestions } from "@/hooks/useTagSuggestions";
-import type { ProblemDetail, ProblemResponse, PracticeWeight } from "@/types/problem";
+import type { ProblemDetail, ProblemResponse, PracticeWeight, AttemptHistoryItem } from "@/types/problem";
 import { PROBLEM_TYPE_OPTIONS } from "@/constants/problemTypes";
 
 interface TrackingData {
@@ -87,6 +87,169 @@ function WeightBreakdown({ weight }: { weight: PracticeWeight }) {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+const RESULT_LABELS: Record<string, string> = {
+  correct: "Correct",
+  incorrect: "Incorrect",
+  "pending-review": "Pending review",
+  ungraded: "Ungraded",
+};
+
+const RESULT_BADGE_CLASS: Record<string, string> = {
+  correct: "badge-success",
+  incorrect: "badge-danger",
+  "pending-review": "badge-warning",
+  ungraded: "badge-muted",
+};
+
+const PAGE_SIZE = 20;
+
+function ProblemAttemptHistory({ problemId }: { problemId: string }) {
+  const [items, setItems] = useState<AttemptHistoryItem[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(false);
+  const [total, setTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  // Fetch initial page when problemId changes.
+  useQuery({
+    queryKey: ["problem-attempts", problemId, "initial"],
+    queryFn: async () => {
+      setIsLoadingInitial(true);
+      setError(null);
+      try {
+        const data = await api.getAttemptHistory(problemId, { limit: PAGE_SIZE, offset: 0 });
+        setItems(data.items);
+        setTotal(data.total);
+        setHasMore(data.hasMore);
+        setOffset(data.items.length);
+        return data;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load history");
+        return null;
+      } finally {
+        setIsLoadingInitial(false);
+      }
+    },
+    enabled: !!problemId,
+  });
+
+  const loadMore = async () => {
+    if (isLoadingMore || !hasMore) return;
+    setIsLoadingMore(true);
+    setError(null);
+    try {
+      const data = await api.getAttemptHistory(problemId, { limit: PAGE_SIZE, offset });
+      setItems((prev) => [...prev, ...data.items]);
+      setHasMore(data.hasMore);
+      setOffset((prev) => prev + data.items.length);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load more history");
+    } finally {
+      setIsLoadingMore(false);
+    }
+  };
+
+  if (isLoadingInitial) {
+    return (
+      <div data-testid="attempt-history-loading" style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>
+        Loading test history...
+      </div>
+    );
+  }
+
+  if (error && items.length === 0) {
+    return (
+      <div data-testid="attempt-history-error" style={{ display: "flex", alignItems: "center", gap: "0.75rem", flexWrap: "wrap" }}>
+        <div className="badge badge-danger" style={{ textTransform: "none", letterSpacing: "normal", fontWeight: 500 }}>
+          {error}
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setError(null);
+            setIsLoadingInitial(true);
+            api.getAttemptHistory(problemId, { limit: PAGE_SIZE, offset: 0 })
+              .then((data) => {
+                setItems(data.items);
+                setTotal(data.total);
+                setHasMore(data.hasMore);
+                setOffset(data.items.length);
+              }).catch((err) => {
+                setError(err instanceof Error ? err.message : "Failed to load history");
+              }).finally(() => setIsLoadingInitial(false));
+          }}
+          className="btn btn-secondary"
+          style={{ padding: "0.3rem 0.75rem", fontSize: "0.8125rem" }}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div data-testid="attempt-history-empty" style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>
+        No test history recorded.
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="attempt-history">
+      <div style={{ overflowX: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem", minWidth: "360px" }}>
+          <thead>
+            <tr style={{ textAlign: "left", borderBottom: "2px solid var(--color-border)" }}>
+              <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Tested At</th>
+              <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Result</th>
+              <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item) => (
+              <tr key={item.id} style={{ borderBottom: "1px solid var(--color-border)" }}>
+                <td style={{ padding: "0.5rem 0.75rem", whiteSpace: "nowrap" }}>{formatDate(item.testedAt)}</td>
+                <td style={{ padding: "0.5rem 0.75rem" }}>
+                  <span
+                    className={`badge ${RESULT_BADGE_CLASS[item.result] ?? "badge-muted"}`}
+                    style={{ fontSize: "0.75rem", padding: "0.15rem 0.5rem", borderRadius: "var(--radius-sm)", fontWeight: 600, textTransform: "none", letterSpacing: "normal" }}
+                  >
+                    {RESULT_LABELS[item.result] ?? item.result}
+                  </span>
+                </td>
+                <td style={{ padding: "0.5rem 0.75rem", textTransform: "capitalize" }}>{item.source}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {error && items.length > 0 && (
+        <div className="badge badge-danger" style={{ marginTop: "0.5rem", textTransform: "none", letterSpacing: "normal", fontWeight: 500 }}>
+          {error}
+        </div>
+      )}
+      {hasMore && (
+        <button
+          type="button"
+          onClick={loadMore}
+          disabled={isLoadingMore}
+          data-testid="attempt-history-load-more"
+          className="btn btn-secondary"
+          style={{ marginTop: "0.75rem", padding: "0.4rem 0.875rem", fontSize: "0.8125rem" }}
+        >
+          {isLoadingMore ? "Loading..." : "Load more"}
+        </button>
+      )}
+      <div style={{ marginTop: "0.25rem", color: "var(--color-text-muted)", fontSize: "0.75rem" }}>
+        Showing {items.length} of {total}
+      </div>
     </div>
   );
 }
@@ -676,6 +839,10 @@ export function ProblemDetailPage() {
         ) : (
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>No tracking data available</div>
         )}
+        <div style={{ borderTop: "1px solid var(--color-border)", paddingTop: "1rem" }}>
+          <h3 style={{ fontSize: "1rem", fontWeight: 700, margin: "0 0 0.5rem 0" }}>Test History</h3>
+          <ProblemAttemptHistory problemId={problemId} />
+        </div>
       </div>
 
       <TeacherPasswordModal

--- a/frontend/src/types/problem.ts
+++ b/frontend/src/types/problem.ts
@@ -50,3 +50,16 @@ export interface ProblemsResponse {
   page: number;
   pageSize: number;
 }
+
+export interface AttemptHistoryItem {
+  id: string;
+  testedAt: string;
+  result: string;
+  source: "practice" | "exam";
+}
+
+export interface AttemptHistoryResponse {
+  items: AttemptHistoryItem[];
+  total: number;
+  hasMore: boolean;
+}


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Adds `GET /api/v1/problems/{problem_id}/attempts?limit=20&offset=0` returning merged practice/exam attempt history, newest-first, user-scoped and paginated.
- Adds startup-managed compound indexes for the practice-attempt and submitted-exam lookup paths.
- Renders an accessible, responsive Test History table beneath the existing Tracking Statistics summary on the problem detail page, with initial loading, empty, error/retry, and Load more states.

## Linked Issue

Closes #521

## Issue Alignment

This PR implements the issue by:

- Adding the dedicated owned-problem attempt-history endpoint with the exact contract from the issue (`items`/`total`/`hasMore`, `id` as `source:local-id`, `result` using existing grading-status values, `source` as `practice`/`exam`).
- Merging `practice_attempts` (using `createdAt`) and submitted-exam items (using exam `submittedAt`) deterministically newest-first with a source/id tie-breaker so offset pages do not reorder or duplicate tied records.
- Filtering both sources by the authenticated user and only including submitted exams; active, grading, and discarded exams are excluded.
- Preserving actual grading states (`correct`, `incorrect`, `pending-review`, `ungraded`) without relabeling pending states as wrong.
- Skipping legacy records lacking a trustworthy timestamp; totals/`hasMore` describe valid records only. No synthetic rows are fabricated from aggregate counters.
- Adding the required non-unique compound indexes in `ensure_database_setup`.
- Adding typed frontend models, a dedicated `api.getAttemptHistory` client method, paginated loading (initial 20, Load more), and the responsive table with all required states.

Scope covered:

- User-scoped, offset-paginated problem-attempt-history API.
- Merging practice attempts and submitted-exam items into one deterministic newest-first result.
- MongoDB indexes supporting the new lookup patterns.
- Typed frontend API models and paginated loading.
- Responsive, accessible history table within Tracking Statistics.
- Backend API tests and frontend component tests for the new behavior.

Out of scope / intentionally not included:

- Changing or repairing aggregate tracking counters.
- Migrating, backfilling, or fabricating missing historical records.
- Persisting a duplicate unified history collection.
- Showing submitted answers, feedback, grading methods, or exam links.
- Changing the existing practice-history page or endpoint.
- Changing grading, exam submission, practice submission, or selection-score behavior.

## Implementation Notes

- The endpoint validates problem ownership first (404 for missing/deleted/unowned), then queries both sources filtered by the authenticated user.
- Per-problem-per-user history is inherently bounded, so each source is fetched in full (mirroring the existing `/practice/history` convention), merged, filtered for valid timestamps, and sliced by `offset`/`limit`. This keeps `total`/`hasMore` accurate without a second count query.
- Deterministic ordering: a stable pre-sort by `(source, id)` followed by a `testedAt` descending sort ensures tied records never reorder or duplicate across pages.
- Frontend uses a dedicated `api.getAttemptHistory` method (matching the existing `getSolutionStatus`/`regenerateSolution` pattern) so the history query does not consume the shared `api.get` mock queue in tests.
- The history table renders beneath the existing aggregate summary without hiding or blocking it while loading.

## Tests

Commands run:

- `./scripts/agent-env.sh test backend` (full suite) — passed: 990 passed, 1 skipped in 99.11s
- `./scripts/agent-env.sh test frontend` (full suite) — passed: 559 passed in 10.48s

Automated tests added or updated:

- Backend (`backend/tests/api/test_problems.py`):
  - `test_attempt_history_merges_practice_and_exam_newest_first` — two correct + one incorrect across practice/exam, deterministic newest-first order and source labels.
  - `test_attempt_history_preserves_pending_and_ungraded_states` — `pending-review` and `ungraded` remain distinct.
  - `test_attempt_history_pagination_appends_without_duplication` — 22 records across two pages of 20, no duplicates, page 1 newer than page 2.
  - `test_attempt_history_excludes_non_final_and_other_user_exams` — active/grading/discarded and other-user exams/practice excluded.
  - `test_attempt_history_does_not_fabricate_rows_from_aggregate_counters` — counters claim 2+1 but no persisted records => 0 rows.
  - `test_attempt_history_missing_problem_returns_404`.
  - `test_attempt_history_empty_state`.
  - `test_attempt_history_excludes_other_problem_records`.
- Backend (`backend/tests/infrastructure/test_mongo.py`): asserts the two new non-unique history lookup indexes are created.
- Frontend (`frontend/src/pages/ProblemDetailPage.test.tsx`):
  - `renders attempt history rows from API`
  - `shows empty state when no attempt history exists`
  - `shows error and retry when attempt history fails to load`
  - `loads more pages and appends rows without duplicates`
  - `disables Load more while fetching and hides it on final page`
  - `preserves pending-review result label without relabeling as incorrect`
  - `keeps tracking statistics intact alongside attempt history`

Manual verification:

- Seeded-equivalent scenarios are covered by the automated tests above (mixed practice/exam with two correct + one incorrect, Load more with >20 records, empty state, ownership isolation, non-final statuses).
- Responsive narrow-viewport behavior is implemented via an `overflowX: auto` wrapper with a `minWidth` table and retained `scope`d column headings; automated tests assert the table structure and states.

## Deviations From Issue Plan

None. The implementation follows the chosen approach and contract exactly. One implementation-level note: per-source reads fetch all matching records (not a bounded window) because per-problem-per-user history is inherently bounded and this keeps `total`/`hasMore` accurate; this mirrors the existing practice-history endpoint convention.

## Follow-Up Work

None. Possible future additions (viewing submitted answers, linking exam rows to exam details, repairing legacy aggregate/history mismatches) are intentionally excluded per the issue's Out of Scope and Follow-Up Work sections.
