### PR TITLE
Apply recency base point only to never-tested problems

### DIFF
--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -65,18 +65,22 @@ def compute_score_breakdown(
     # Recency score with status-specific daily growth rate.
     # Never tested grows fastest (1/10), last-correct slowest (1/60),
     # last-failed and tested-unknown retain the original pace (1/30).
+    # The 1.0 base represents the special priority of a never-tested
+    # problem; ever-tested problems start at 0.0 and grow with elapsed days.
     if problem.tracking.lastTestedAt is None:
         reference_dt = problem.createdAt
         daily_rate = 1 / 10
+        base = 1.0
     else:
         reference_dt = problem.tracking.lastTestedAt
         daily_rate = 1 / 60 if problem.tracking.lastAttemptCorrect is True else 1 / 30
+        base = 0.0
 
     if reference_dt is not None:
         days_since = (now - ensure_utc(reference_dt)).days
-        recency_score = 1.0 + days_since * daily_rate
+        recency_score = base + days_since * daily_rate
     else:
-        recency_score = 1.0
+        recency_score = base
 
     # Failure score
     failed_count = problem.tracking.failedCount

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -809,7 +809,7 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     # Never-tested: recency=1.0 (createdAt ~now, days_since=0), failure=0.0, last_wrong=1.0 -> raw=2.0 (bucket 2)
     never_tested = make_problem(user_id, created_at=now)
 
-    # Tested correct: rate 1/60 -> recency=1.0+60/60=2.0, failure=0.0, last_wrong=0.5 -> raw=2.5 (bucket 2)
+    # Tested correct: base 0.0, rate 1/60 -> recency=0.0+60/60=1.0, failure=0.0, last_wrong=0.5 -> raw=1.5 (bucket 1)
     tested_correct = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -817,7 +817,7 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
         created_at=sixty_days_ago,
     )
 
-    # Tested incorrect, more failures than corrects: rate 1/30 -> recency=3.0, failure=2.0, last_wrong=2.0 -> raw=7.0 (bucket 7)
+    # Tested incorrect, more failures than corrects: base 0.0, rate 1/30 -> recency=0.0+60/30=2.0, failure=2.0, last_wrong=2.0 -> raw=6.0 (bucket 6)
     tested_incorrect = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -835,20 +835,22 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     by_start = {b["start"]: b for b in buckets}
     assert list(b["start"] for b in buckets) == sorted(b["start"] for b in buckets)
 
-    # Bucket range spans 2..7 with contiguous empty buckets at 3, 4, 5, 6.
-    assert list(by_start.keys()) == [2, 3, 4, 5, 6, 7]
+    # Bucket range spans 1..6 with contiguous empty buckets at 2, 3, 4, 5.
+    assert list(by_start.keys()) == [1, 2, 3, 4, 5, 6]
 
-    # Raw scores 2.0 (never tested) and 2.5 (tested correct) both land in bucket 2.
-    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 1, "cooldown": 0}
+    # Raw score 1.5 (tested correct) lands in bucket 1.
+    assert by_start[1] == {"start": 1, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
 
-    # Raw score 7.0 lands in bucket 7 (exact integer boundary).
-    assert by_start[7] == {"start": 7, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
+    # Raw score 2.0 (never tested) lands in bucket 2.
+    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 0, "cooldown": 0}
+
+    # Raw score 6.0 lands in bucket 6 (exact integer boundary).
+    assert by_start[6] == {"start": 6, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
 
     # Empty intermediate buckets emitted contiguously.
     assert by_start[3] == {"start": 3, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
     assert by_start[4] == {"start": 4, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
     assert by_start[5] == {"start": 5, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
-    assert by_start[6] == {"start": 6, "neverTested": 0, "minAged": 0, "tested": 0, "cooldown": 0}
 
 
 @pytest.mark.asyncio
@@ -927,8 +929,8 @@ async def test_summary_score_distribution_raw_not_clamped_regression(
 
     # Tested correct with many more corrects than failures -> negative failure score.
     # correctCount=10, failedCount=0 -> failure = -sqrt(10) ~ -3.162.
-    # lastTestedAt 60d ago, lastAttemptCorrect -> rate 1/60 -> recency=1.0+60/60=2.0; last_wrong=0.5.
-    # raw = 2.0 + (-3.162) + 0.5 ~ -0.662 -> floor -1.
+    # lastTestedAt 60d ago, lastAttemptCorrect -> base 0.0, rate 1/60 -> recency=0.0+60/60=1.0; last_wrong=0.5.
+    # raw = 1.0 + (-3.162) + 0.5 ~ -1.662 -> floor -2.
     problem = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -942,7 +944,7 @@ async def test_summary_score_distribution_raw_not_clamped_regression(
     response = await client.get("/api/v1/home/summary")
     buckets = response.json()["scoreDistribution"]["buckets"]
     assert len(buckets) == 1
-    assert buckets[0]["start"] == -1
+    assert buckets[0]["start"] == -2
     assert buckets[0]["tested"] == 1
 
 

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -317,7 +317,12 @@ async def test_list_detail_update_delete_tags_and_tracking(
     assert "practiceWeight" in tracking_body
     weight = tracking_body["practiceWeight"]
     assert set(weight.keys()) == {"lastWrong", "failure", "recency", "total"}
-    assert weight["total"] == weight["lastWrong"] + weight["failure"] + weight["recency"]
+    # newest_problem is tested today (lastTestedAt ~now, lastAttemptCorrect True),
+    # so recency base is 0.0 and 0 elapsed days -> recency 0.0. With more correct
+    # than failed (2 vs 1) the failure component is negative, so the raw component
+    # sum is negative and the returned total is the zero-clamped value.
+    raw_total = weight["lastWrong"] + weight["failure"] + weight["recency"]
+    assert weight["total"] == max(0.0, raw_total)
 
     tags_response = await client.get("/api/v1/problems/tags")
     assert tags_response.status_code == 200

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -404,11 +404,11 @@ def test_compute_problem_weight_breakdown_all_components():
     # failure = (7/3) * 2.0 ≈ 4.6666666667
     assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
 
-    # days_since = 30, recency_score = 1.0 + 30/30 = 2.0
-    # recency = 2.0 * 1.0 = 2.0
-    assert breakdown.recency == 2.0
+    # days_since = 30, recency_score = 0.0 + 30/30 = 1.0
+    # recency = 1.0 * 1.0 = 1.0
+    assert breakdown.recency == 1.0
 
-    assert breakdown.total == pytest.approx(3.0 + (7 / 3) * 2.0 + 2.0)
+    assert breakdown.total == pytest.approx(3.0 + (7 / 3) * 2.0 + 1.0)
     assert breakdown.total == pytest.approx(breakdown.lastWrong + breakdown.failure + breakdown.recency)
 
 

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -155,8 +155,8 @@ def test_recency_uses_last_tested_when_present():
     problem = create_test_problem("p1", last_tested_at=last_tested)
     config = ProblemSelectionConfig(recency_weight=1.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    # Tested with unknown last result: rate 1/30, days_since = 60 -> 1.0 + 60*(1/30) = 3.0
-    assert breakdown.recency == 3.0
+    # Tested with unknown last result: base 0.0, rate 1/30, days_since = 60 -> 0.0 + 60*(1/30) = 2.0
+    assert breakdown.recency == 2.0
 
 
 def test_recency_uses_created_at_when_not_tested():
@@ -165,7 +165,7 @@ def test_recency_uses_created_at_when_not_tested():
     problem = create_test_problem("p1", last_tested_at=None, created_at=created_at)
     config = ProblemSelectionConfig(recency_weight=1.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    # Never tested: rate 1/10, days_since = 45 -> 1.0 + 45*(1/10) = 5.5
+    # Never tested: base 1.0, rate 1/10, days_since = 45 -> 1.0 + 45*(1/10) = 5.5
     assert breakdown.recency == 5.5
 
 
@@ -174,29 +174,45 @@ def test_recency_status_specific_rates():
     now = datetime.now(timezone.utc)
     config = ProblemSelectionConfig(recency_weight=1.0)
 
-    # Never tested, created 30 days ago -> createdAt reference, rate 1/10 -> 4.0
+    # Never tested, created 30 days ago -> createdAt reference, base 1.0, rate 1/10 -> 4.0
     never_tested = create_test_problem(
         "never", last_tested_at=None, created_at=now - timedelta(days=30)
     )
     assert compute_score_breakdown(never_tested, config, now).recency == 4.0
 
-    # Last correct, tested 60 days ago -> lastTestedAt reference, rate 1/60 -> 2.0
+    # Last correct, tested 60 days ago -> lastTestedAt reference, base 0.0, rate 1/60 -> 1.0
     last_correct = create_test_problem(
         "correct", last_tested_at=now - timedelta(days=60), last_attempt_correct=True
     )
-    assert compute_score_breakdown(last_correct, config, now).recency == 2.0
+    assert compute_score_breakdown(last_correct, config, now).recency == 1.0
 
-    # Last failed, tested 60 days ago -> lastTestedAt reference, rate 1/30 -> 3.0
+    # Last failed, tested 60 days ago -> lastTestedAt reference, base 0.0, rate 1/30 -> 2.0
     last_failed = create_test_problem(
         "failed", last_tested_at=now - timedelta(days=60), last_attempt_correct=False
     )
-    assert compute_score_breakdown(last_failed, config, now).recency == 3.0
+    assert compute_score_breakdown(last_failed, config, now).recency == 2.0
 
-    # Tested 60 days ago with unknown last result -> lastTestedAt reference, rate 1/30 -> 3.0
+    # Tested 60 days ago with unknown last result -> lastTestedAt reference, base 0.0, rate 1/30 -> 2.0
     tested_unknown = create_test_problem(
         "unknown", last_tested_at=now - timedelta(days=60)
     )
-    assert compute_score_breakdown(tested_unknown, config, now).recency == 3.0
+    assert compute_score_breakdown(tested_unknown, config, now).recency == 2.0
+
+
+def test_recency_tested_today_starts_at_zero():
+    """A problem tested today has 0.0 recency; a never-tested problem created today has 1.0."""
+    now = datetime.now(timezone.utc)
+    config = ProblemSelectionConfig(recency_weight=1.0)
+
+    tested_today = create_test_problem(
+        "tested", last_tested_at=now, last_attempt_correct=False
+    )
+    assert compute_score_breakdown(tested_today, config, now).recency == 0.0
+
+    never_tested_today = create_test_problem(
+        "never", last_tested_at=None, created_at=now
+    )
+    assert compute_score_breakdown(never_tested_today, config, now).recency == 1.0
 
 
 def test_recency_weight_scales_status_specific_component():
@@ -208,6 +224,18 @@ def test_recency_weight_scales_status_specific_component():
     config = ProblemSelectionConfig(recency_weight=2.0)
     breakdown = compute_score_breakdown(problem, config, now)
     assert breakdown.recency == 8.0
+
+
+def test_recency_weight_scales_tested_component_and_base():
+    """recency_weight scales the entire revised component (base + age) for tested problems too."""
+    now = datetime.now(timezone.utc)
+    # Last failed, tested 60 days ago: raw recency = 0.0 + 60*(1/30) = 2.0, scaled by 2.0 -> 4.0
+    problem = create_test_problem(
+        "p1", last_tested_at=now - timedelta(days=60), last_attempt_correct=False
+    )
+    config = ProblemSelectionConfig(recency_weight=2.0)
+    breakdown = compute_score_breakdown(problem, config, now)
+    assert breakdown.recency == 4.0
 
 
 def test_failure_score_no_attempts():
@@ -352,14 +380,14 @@ def test_weighted_total_equals_component_sum():
         last_wrong_weight=1.5,
     )
     breakdown = compute_score_breakdown(problem, config, now)
-    # recency_score = 1.0 + 30/30 = 2.0, recency = 2.0 * 1.0 = 2.0
-    assert breakdown.recency == 2.0
+    # recency_score = 0.0 + 30/30 = 1.0, recency = 1.0 * 1.0 = 1.0
+    assert breakdown.recency == 1.0
     # failedCount=7 > correctCount=3 and correctCount>0 => ratio: 7/3
     # failure = (7/3) * 2.0 ≈ 4.6666666667
     assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
     # last_wrong_score = 2.0, last_wrong = 2.0 * 1.5 = 3.0
     assert breakdown.last_wrong == 3.0
-    assert breakdown.total == pytest.approx(2.0 + (7 / 3) * 2.0 + 3.0)
+    assert breakdown.total == pytest.approx(1.0 + (7 / 3) * 2.0 + 3.0)
     assert breakdown.total == pytest.approx(breakdown.recency + breakdown.failure + breakdown.last_wrong)
 
 


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Changes the shared selection-score recency formula so the `1.0` base point is awarded only to never-tested problems. Ever-tested problems now start at `0.0` recency on the test day and grow only with elapsed complete days at their status-specific rate.
- Updates domain, practice-selection, and home/API assertions affected by the one-point reduction for tested problems, and adds focused tests for the zero-day tested vs never-tested cases and `recency_weight` scaling of the tested component.

## Linked Issue

Closes #523

## Issue Alignment

This PR implements the issue by:

- Updating only the recency branch of `compute_score_breakdown` to choose a status-specific base (`1.0` when `lastTestedAt is None`, `0.0` otherwise) alongside the existing reference date and daily rate.
- Preserving the existing status-specific rates (`1/10`, `1/60`, `1/30`) and date references (`createdAt` for never-tested, `lastTestedAt` for tested).
- Keeping UTC normalization and `timedelta.days` complete-day granularity unchanged.
- Keeping `recency_weight` scaling the entire revised component (base + age).
- Updating domain, practice-selection, and API assertions affected by tested recency decreasing by `1.0 * recency_weight`.
- Verifying downstream total-score and home score-distribution behavior with mathematically recalculated bucket expectations.

Scope covered:

- Updating the shared recency calculation introduced by PR #522.
- Preserving the existing status-specific rates and date references.
- Updating domain, practice-selection, and API assertions affected by the one-point reduction for tested problems.
- Verifying downstream total-score and home score-distribution behavior.

Out of scope / intentionally not included:

- Changing the `1/10`, `1/60`, or `1/30` daily rates.
- Changing `recency_weight` behavior or adding configuration.
- Changing failure or last-wrong components.
- Changing cooldown, minimum-age eligibility, total-score clamping, or weighted sampling.
- Adding or changing API schemas or UI controls.
- Migrating or backfilling data; scores are derived at runtime.
- Refactoring adjacent selection code.

## Implementation Notes

- The change is a single recency branch in `compute_score_breakdown`: a `base` variable (`1.0` for never-tested, `0.0` for ever-tested) replaces the previous unconditional `1.0`. The formula is now `recency = (base + complete_days_since_reference * daily_rate) * recency_weight`.
- `lastTestedAt is None` remains the authoritative definition of never tested, even if inconsistent data contains a non-null `lastAttemptCorrect`.
- Home score-distribution bucket expectations were recalculated from the revised raw component sums (not blindly updated): tested-correct 60d raw drops from 2.5 to 1.5 (bucket 1), tested-incorrect 60d raw drops from 7.0 to 6.0 (bucket 6), and the negative-raw regression drops from floor -1 to floor -2.
- The `test_list_detail_update_delete_tags_and_tracking` practice-weight total assertion was updated to `max(0.0, raw_sum)` to reflect that a problem tested today with more corrects than failures now has a negative raw sum (recency 0.0 + negative failure + 0.5 last-wrong), so the returned total is the zero-clamped value.

## Tests

Commands run:

- `./scripts/agent-env.sh test backend` (full suite) — passed: 984 passed, 1 skipped in 97.78s

Automated tests added or updated:

- `backend/tests/domain/test_selection.py`:
  - Updated `test_recency_uses_last_tested_when_present` (tested unknown 60d: 2.0).
  - Updated `test_recency_status_specific_rates` (last-correct 60d: 1.0; last-failed 60d: 2.0; tested-unknown 60d: 2.0; never-tested 30d: 4.0 unchanged).
  - Added `test_recency_tested_today_starts_at_zero` (tested today → 0.0; never-tested created today → 1.0).
  - Added `test_recency_weight_scales_tested_component_and_base` (last-failed 60d raw 2.0 × weight 2.0 → 4.0).
  - Updated the combined-component total test (tested last-failed 30d recency 1.0).
- `backend/tests/domain/test_practice_selection.py`:
  - Updated `test_compute_problem_weight_breakdown_all_components` (tested last-failed 30d recency 1.0).
- `backend/tests/api/test_home.py`:
  - Updated `test_summary_score_distribution_negative_zero_positive_buckets` (recalculated buckets 1..6).
  - Updated `test_summary_score_distribution_raw_not_clamped_regression` (raw floor -2).
- `backend/tests/api/test_problems.py`:
  - Updated `test_list_detail_update_delete_tags_and_tracking` practice-weight total assertion to `max(0.0, raw_sum)`.

Manual verification:

- Representative numeric examples from the issue's Goal section are covered by the domain tests: never-tested 30d → 4.0; last-correct 60d → 1.0; last-failed 60d → 2.0; tested-unknown 60d → 2.0; tested today → 0.0; never-tested created today → 1.0.
- Non-default `recency_weight` scaling of both the never-tested base and the tested age component is covered.
- Home score-distribution buckets were mathematically recalculated and asserted contiguously.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly.

## Follow-Up Work

None. Making recency bases or rates configurable remains out of scope per the issue.
