### PR TITLE
feat(selection): adjust recency growth rates to 1/20 and 1/40 (#528)

### DIFF
--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -63,17 +63,17 @@ def compute_score_breakdown(
     now: datetime,
 ) -> ScoreBreakdown:
     # Recency score with status-specific daily growth rate.
-    # Never tested grows fastest (1/10), last-correct slowest (1/60),
+    # Never tested grows fastest (1/20), last-correct slowest (1/40),
     # last-failed and tested-unknown retain the original pace (1/30).
     # The 1.0 base represents the special priority of a never-tested
     # problem; ever-tested problems start at 0.0 and grow with elapsed days.
     if problem.tracking.lastTestedAt is None:
         reference_dt = problem.createdAt
-        daily_rate = 1 / 10
+        daily_rate = 1 / 20
         base = 1.0
     else:
         reference_dt = problem.tracking.lastTestedAt
-        daily_rate = 1 / 60 if problem.tracking.lastAttemptCorrect is True else 1 / 30
+        daily_rate = 1 / 40 if problem.tracking.lastAttemptCorrect is True else 1 / 30
         base = 0.0
 
     if reference_dt is not None:

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -809,7 +809,7 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     # Never-tested: recency=1.0 (createdAt ~now, days_since=0), failure=0.0, last_wrong=1.0 -> raw=2.0 (bucket 2)
     never_tested = make_problem(user_id, created_at=now)
 
-    # Tested correct: base 0.0, rate 1/60 -> recency=0.0+60/60=1.0, failure=0.0, last_wrong=0.5 -> raw=1.5 (bucket 1)
+    # Tested correct: base 0.0, rate 1/40 -> recency=0.0+60/40=1.5, failure=0.0, last_wrong=0.5 -> raw=2.0 (bucket 2)
     tested_correct = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,
@@ -835,14 +835,11 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
     by_start = {b["start"]: b for b in buckets}
     assert list(b["start"] for b in buckets) == sorted(b["start"] for b in buckets)
 
-    # Bucket range spans 1..6 with contiguous empty buckets at 2, 3, 4, 5.
-    assert list(by_start.keys()) == [1, 2, 3, 4, 5, 6]
+    # Bucket range spans 2..6 with contiguous empty buckets at 3, 4, 5.
+    assert list(by_start.keys()) == [2, 3, 4, 5, 6]
 
-    # Raw score 1.5 (tested correct) lands in bucket 1.
-    assert by_start[1] == {"start": 1, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
-
-    # Raw score 2.0 (never tested) lands in bucket 2.
-    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 0, "cooldown": 0}
+    # Raw score 2.0 (never tested + tested correct) both land in bucket 2.
+    assert by_start[2] == {"start": 2, "neverTested": 1, "minAged": 0, "tested": 1, "cooldown": 0}
 
     # Raw score 6.0 lands in bucket 6 (exact integer boundary).
     assert by_start[6] == {"start": 6, "neverTested": 0, "minAged": 0, "tested": 1, "cooldown": 0}
@@ -929,8 +926,8 @@ async def test_summary_score_distribution_raw_not_clamped_regression(
 
     # Tested correct with many more corrects than failures -> negative failure score.
     # correctCount=10, failedCount=0 -> failure = -sqrt(10) ~ -3.162.
-    # lastTestedAt 60d ago, lastAttemptCorrect -> base 0.0, rate 1/60 -> recency=0.0+60/60=1.0; last_wrong=0.5.
-    # raw = 1.0 + (-3.162) + 0.5 ~ -1.662 -> floor -2.
+    # lastTestedAt 60d ago, lastAttemptCorrect -> base 0.0, rate 1/40 -> recency=0.0+60/40=1.5; last_wrong=0.5.
+    # raw = 1.5 + (-3.162) + 0.5 ~ -1.162 -> floor -2.
     problem = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -420,9 +420,9 @@ def test_compute_problem_weight_breakdown_never_tested():
 
     assert breakdown.lastWrong == 1.0
     assert breakdown.failure == 0.0
-    # Never tested: createdAt (30 days ago), rate 1/10 -> 1.0 + 30*(1/10) = 4.0
-    assert breakdown.recency == 4.0
-    assert breakdown.total == 5.0
+    # Never tested: createdAt (30 days ago), rate 1/20 -> 1.0 + 30*(1/20) = 2.5
+    assert breakdown.recency == 2.5
+    assert breakdown.total == 3.5
 
 
 def test_compute_problem_weight_breakdown_zero_attempts():
@@ -433,9 +433,9 @@ def test_compute_problem_weight_breakdown_zero_attempts():
 
     assert breakdown.lastWrong == 1.0
     assert breakdown.failure == 0.0
-    # Never tested: createdAt (30 days ago), rate 1/10 -> 1.0 + 30*(1/10) = 4.0
-    assert breakdown.recency == 4.0
-    assert breakdown.total == 5.0
+    # Never tested: createdAt (30 days ago), rate 1/20 -> 1.0 + 30*(1/20) = 2.5
+    assert breakdown.recency == 2.5
+    assert breakdown.total == 3.5
 
 
 def test_compute_problem_weight_breakdown_uses_same_total_as_selection():

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -165,8 +165,8 @@ def test_recency_uses_created_at_when_not_tested():
     problem = create_test_problem("p1", last_tested_at=None, created_at=created_at)
     config = ProblemSelectionConfig(recency_weight=1.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    # Never tested: base 1.0, rate 1/10, days_since = 45 -> 1.0 + 45*(1/10) = 5.5
-    assert breakdown.recency == 5.5
+    # Never tested: base 1.0, rate 1/20, days_since = 45 -> 1.0 + 45*(1/20) = 3.25
+    assert breakdown.recency == 3.25
 
 
 def test_recency_status_specific_rates():
@@ -174,17 +174,17 @@ def test_recency_status_specific_rates():
     now = datetime.now(timezone.utc)
     config = ProblemSelectionConfig(recency_weight=1.0)
 
-    # Never tested, created 30 days ago -> createdAt reference, base 1.0, rate 1/10 -> 4.0
+    # Never tested, created 30 days ago -> createdAt reference, base 1.0, rate 1/20 -> 2.5
     never_tested = create_test_problem(
         "never", last_tested_at=None, created_at=now - timedelta(days=30)
     )
-    assert compute_score_breakdown(never_tested, config, now).recency == 4.0
+    assert compute_score_breakdown(never_tested, config, now).recency == 2.5
 
-    # Last correct, tested 60 days ago -> lastTestedAt reference, base 0.0, rate 1/60 -> 1.0
+    # Last correct, tested 60 days ago -> lastTestedAt reference, base 0.0, rate 1/40 -> 1.5
     last_correct = create_test_problem(
         "correct", last_tested_at=now - timedelta(days=60), last_attempt_correct=True
     )
-    assert compute_score_breakdown(last_correct, config, now).recency == 1.0
+    assert compute_score_breakdown(last_correct, config, now).recency == 1.5
 
     # Last failed, tested 60 days ago -> lastTestedAt reference, base 0.0, rate 1/30 -> 2.0
     last_failed = create_test_problem(
@@ -217,13 +217,13 @@ def test_recency_tested_today_starts_at_zero():
 
 def test_recency_weight_scales_status_specific_component():
     now = datetime.now(timezone.utc)
-    # Never tested 30 days ago: raw recency = 4.0, scaled by recency_weight=2.0 -> 8.0
+    # Never tested 30 days ago: raw recency = 2.5, scaled by recency_weight=2.0 -> 5.0
     problem = create_test_problem(
         "p1", last_tested_at=None, created_at=now - timedelta(days=30)
     )
     config = ProblemSelectionConfig(recency_weight=2.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    assert breakdown.recency == 8.0
+    assert breakdown.recency == 5.0
 
 
 def test_recency_weight_scales_tested_component_and_base():


### PR DESCRIPTION
Model-Signature: glm-5.2

## Summary

- Adjust the shared selection-score recency daily growth rates in `compute_score_breakdown`:
  - Never-tested problems: `1/10` -> `1/20` per elapsed day (retains the `1.0` base).
  - Tested-and-correct problems: `1/60` -> `1/40` per elapsed day (retains the `0.0` base).
  - Tested-incorrect and tested-unknown problems: unchanged at `1/30`.
- Update the adjacent explanatory comment to reflect the new rates.
- Update affected domain, practice-selection, and home score-distribution test expectations to match the new shared values.

Because the calculation is centralized, the new rates flow consistently through practice selection, exam selection, problem-list score sorting, and the home score distribution. Scores are derived at runtime, so no data migration is required.

## Linked Issue

Closes #528

## Issue Alignment

This PR implements the issue by replacing only the two shared daily-rate constants in `backend/app/domain/selection.py` and updating the comments/tests that describe those rates.

Scope covered:

- Never-tested uses exactly `1/20` per elapsed day, retaining the `1.0` base.
- Tested-and-correct uses exactly `1/40` per elapsed day, retaining the `0.0` base.
- Tested-incorrect/unknown remain at `1/30`.
- Updated domain tests for never-tested, tested-correct, tested-incorrect, tested-unknown, and `recency_weight` scaling.
- Updated practice weight-breakdown totals for never-tested cases.
- Updated affected home score-distribution bucket assertions and comments.

Out of scope / intentionally not included:

- Changing the tested-incorrect or tested-unknown rate.
- Any user-configurable rate, settings, or API contract change.
- Any migration or rewrite of persisted problem-tracking data.
- Frontend or unrelated refactor changes.

## Implementation Notes

- The change is a minimal, surgical edit to two literals (`1 / 10` -> `1 / 20`, `1 / 60` -> `1 / 40`) inside the existing conditional structure of `compute_score_breakdown`. The tested-failed/tested-unknown branch still uses `1 / 30`.
- With `recency_weight = 1.0`, the issue's examples hold exactly:
  - Never tested 30 days ago: `1 + 30/20 = 2.5`.
  - Never tested 45 days ago: `1 + 45/20 = 3.25`.
  - Tested-and-correct 60 days ago: `60/40 = 1.5`.
- In `test_home.py::test_summary_score_distribution_negative_zero_positive_buckets`, the tested-correct problem (60 days ago) now scores `recency=1.5`, giving `raw=2.0`, which lands it in the same bucket (2) as the never-tested problem (also `raw=2.0`). The bucket set changed from `[1,2,3,4,5,6]` to `[2,3,4,5,6]`, with bucket 2 holding both a `neverTested` and a `tested` problem. The contiguous empty-bucket behavior (3,4,5) is still exercised.

## Tests

Commands run:

- `pytest tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/api/test_home.py -q` (via `./scripts/agent-env.sh` tools container) — **108 passed**.
- `pytest -q` (full backend suite via `./scripts/agent-env.sh test backend`) — **978 passed, 1 skipped, 14 errors**.

Regarding the 14 errors: all are in `tests/integration/test_ingestion_atomicity.py` and fail at connection setup with `ServerSelectionTimeoutError: client is configured to connect to a replica set named 'rs0' but this node belongs to a set named 'None'`. This is an environmental MongoDB replica-set provisioning issue in the agent test environment for this worktree (the standalone Mongo node was not initialized as replica set `rs0`), not a regression from this change. Those integration tests are about ingestion atomicity / MongoDB transactions and do not reference the selection scoring code. No selection-related test failed.

Automated tests added or updated:

- `backend/tests/domain/test_selection.py`: updated never-tested (30d, 45d), tested-correct (60d), tested-incorrect/unknown (60d), and `recency_weight` scaling expectations.
- `backend/tests/domain/test_practice_selection.py`: updated never-tested weight-breakdown `recency` and `total` for 30-day-old problems.
- `backend/tests/api/test_home.py`: updated tested-correct bucket placement, bucket-key set, and the `raw_not_clamped` comment (bucket `-2` is preserved since `floor(1.5 - sqrt(10) + 0.5) = -2`).

Manual verification:

- Confirmed no stale references to the old rates (`1/10`, `1/60`) remain anywhere in `backend/`.
- Confirmed the new rates (`1/20`, `1/40`, `1/30`) appear consistently in source and test comments.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach exactly (replace the two rate values, preserve the conditional structure, extend existing tests).

## Follow-Up Work

None.
