### PR TITLE
feat(activities): add Created activity to problem detail history

### DIFF
--- a/backend/app/presentation/problem_serialization.py
+++ b/backend/app/presentation/problem_serialization.py
@@ -92,7 +92,7 @@ class BulkSetFolderResponse(BaseModel):
 class AttemptHistoryItemPayload(BaseModel):
     id: str
     testedAt: UTCDatetime
-    result: str
+    result: str | None
     source: str
 
 

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -522,10 +522,11 @@ async def get_problem_attempt_history(
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
 ) -> AttemptHistoryResponse:
-    """Return merged practice/exam attempt history for a problem, newest-first.
+    """Return merged activity history for a problem, newest-first.
 
     Practice records use ``practice_attempt.createdAt``; exam records use the
-    submitted exam's ``submittedAt``. Only submitted exams contribute. Legacy
+    submitted exam's ``submittedAt``. A derived ``created`` activity uses the
+    problem document's ``createdAt``. Only submitted exams contribute. Legacy
     records lacking a trustworthy timestamp are skipped. Records are merged
     deterministically by ``testedAt`` desc with a source/id tie-breaker so
     offset pages do not reorder or duplicate tied records.
@@ -555,7 +556,7 @@ async def get_problem_attempt_history(
         }
     ).sort([("submittedAt", -1), ("_id", 1)]).to_list(length=None)
 
-    records: list[tuple[datetime, str, str, str]] = []
+    records: list[tuple[datetime, str, str, str | None]] = []
     for doc in practice_docs:
         created_at = doc.get("createdAt")
         if not isinstance(created_at, datetime):
@@ -579,6 +580,13 @@ async def get_problem_attempt_history(
         records.append(
             (submitted_at, "exam", exam_item_id or str(exam["_id"]), item_result)
         )
+
+    # Derived creation activity: the problem document already stores the
+    # canonical ``createdAt`` timestamp, so synthesize one row at read time
+    # rather than persisting a separate activity record.
+    problem_created_at = problem.get("createdAt")
+    if isinstance(problem_created_at, datetime):
+        records.append((problem_created_at, "created", str(problem_oid), None))
 
     # Deterministic newest-first ordering with source/id tie-breaker so offset
     # pagination never reorders or duplicates tied records.

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -1694,7 +1694,11 @@ async def test_attempt_history_merges_practice_and_exam_newest_first(
 ) -> None:
     database: FakeDatabase = problems_app.state.fake_database
     user_id = problems_app.state.primary_user["_id"]
-    problem = make_problem(user_id, text="History problem")
+    problem = make_problem(
+        user_id,
+        text="History problem",
+        created_at=datetime(2026, 7, 16, 6, 0, 0, tzinfo=UTC),
+    )
     database["problems"].seed(problem)
 
     t1 = datetime(2026, 7, 16, 8, 0, 0, tzinfo=UTC)
@@ -1712,10 +1716,11 @@ async def test_attempt_history_merges_practice_and_exam_newest_first(
     response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
     assert response.status_code == 200
     body = response.json()
-    assert body["total"] == 3
+    assert body["total"] == 4
     assert body["hasMore"] is False
     items = body["items"]
-    # Newest first: t3 practice incorrect, t2 exam correct, t1 practice correct
+    # Newest first: t3 practice incorrect, t2 exam correct, t1 practice correct,
+    # then the derived created activity (oldest) with a null result.
     assert items[0]["testedAt"].startswith("2026-07-16T12")
     assert items[0]["source"] == "practice"
     assert items[0]["result"] == "incorrect"
@@ -1724,6 +1729,10 @@ async def test_attempt_history_merges_practice_and_exam_newest_first(
     assert items[2]["testedAt"].startswith("2026-07-16T08")
     assert items[2]["source"] == "practice"
     assert items[2]["result"] == "correct"
+    assert items[3]["testedAt"].startswith("2026-07-16T06")
+    assert items[3]["source"] == "created"
+    assert items[3]["result"] is None
+    assert items[3]["id"] == f"created:{problem['_id']}"
     assert all(item["id"].count(":") == 1 for item in items)
 
 
@@ -1749,7 +1758,7 @@ async def test_attempt_history_preserves_pending_and_ungraded_states(
     response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
     assert response.status_code == 200
     results = {item["result"] for item in response.json()["items"]}
-    assert results == {"pending-review", "ungraded"}
+    assert results == {"pending-review", "ungraded", None}
 
 
 @pytest.mark.asyncio
@@ -1763,7 +1772,8 @@ async def test_attempt_history_pagination_appends_without_duplication(
     database["problems"].seed(problem)
 
     base = datetime(2026, 7, 16, 0, 0, 0, tzinfo=UTC)
-    # 22 distinct timestamps to exercise two pages of 20
+    # 22 distinct timestamps plus the derived created row (23 total) to
+    # exercise two pages of 20.
     for i in range(22):
         database["practice_attempts"].seed(
             make_practice_attempt(user_id, problem["_id"], grading_status="correct", created_at=base + timedelta(minutes=i))
@@ -1772,19 +1782,21 @@ async def test_attempt_history_pagination_appends_without_duplication(
     first = await client.get(f"/api/v1/problems/{problem['_id']}/attempts", params={"limit": 20, "offset": 0})
     assert first.status_code == 200
     first_body = first.json()
-    assert first_body["total"] == 22
+    assert first_body["total"] == 23
     assert len(first_body["items"]) == 20
     assert first_body["hasMore"] is True
 
     second = await client.get(f"/api/v1/problems/{problem['_id']}/attempts", params={"limit": 20, "offset": 20})
     assert second.status_code == 200
     second_body = second.json()
-    assert len(second_body["items"]) == 2
+    assert len(second_body["items"]) == 3
     assert second_body["hasMore"] is False
 
     all_ids = [item["id"] for item in first_body["items"]] + [item["id"] for item in second_body["items"]]
-    assert len(all_ids) == 22
-    assert len(set(all_ids)) == 22
+    assert len(all_ids) == 23
+    assert len(set(all_ids)) == 23
+    # The derived created activity participates in pagination exactly once.
+    assert all_ids.count(f"created:{problem['_id']}") == 1
     # Page 1 timestamps are strictly newer than page 2 timestamps
     assert first_body["items"][-1]["testedAt"] >= second_body["items"][0]["testedAt"]
 
@@ -1829,8 +1841,9 @@ async def test_attempt_history_excludes_non_final_and_other_user_exams(
     response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
     assert response.status_code == 200
     body = response.json()
-    assert body["total"] == 1
-    assert body["items"][0]["source"] == "exam"
+    # Only the valid submitted exam and the derived created activity remain.
+    assert body["total"] == 2
+    assert {item["source"] for item in body["items"]} == {"exam", "created"}
 
 
 @pytest.mark.asyncio
@@ -1854,8 +1867,12 @@ async def test_attempt_history_does_not_fabricate_rows_from_aggregate_counters(
     response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
     assert response.status_code == 200
     body = response.json()
-    assert body["total"] == 0
-    assert body["items"] == []
+    # Aggregate counters never fabricate practice/exam rows; only the derived
+    # created activity (from the problem's createdAt) is present.
+    assert body["total"] == 1
+    assert len(body["items"]) == 1
+    assert body["items"][0]["source"] == "created"
+    assert body["items"][0]["result"] is None
     assert body["hasMore"] is False
 
 
@@ -1870,19 +1887,27 @@ async def test_attempt_history_missing_problem_returns_404(
 
 
 @pytest.mark.asyncio
-async def test_attempt_history_empty_state(
+async def test_attempt_history_creation_only_returns_single_created_row(
     problems_app: FastAPI,
     client: AsyncClient,
 ) -> None:
     database: FakeDatabase = problems_app.state.fake_database
     user_id = problems_app.state.primary_user["_id"]
-    problem = make_problem(user_id)
+    created_at = datetime(2026, 7, 16, 9, 0, 0, tzinfo=UTC)
+    problem = make_problem(user_id, created_at=created_at)
     database["problems"].seed(problem)
 
     response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
     assert response.status_code == 200
     body = response.json()
-    assert body == {"items": [], "total": 0, "hasMore": False}
+    # A problem with no test attempts returns exactly one derived created row.
+    assert body["total"] == 1
+    assert body["hasMore"] is False
+    item = body["items"][0]
+    assert item["source"] == "created"
+    assert item["result"] is None
+    assert item["id"] == f"created:{problem['_id']}"
+    assert item["testedAt"] == "2026-07-16T09:00:00Z"
 
 
 @pytest.mark.asyncio
@@ -1909,4 +1934,4 @@ async def test_attempt_history_excludes_other_problem_records(
     response = await client.get(f"/api/v1/problems/{problem['_id']}/attempts")
     assert response.status_code == 200
     body = response.json()
-    assert body["total"] == 2
+    assert body["total"] == 3

--- a/frontend/src/pages/ProblemDetailPage.test.tsx
+++ b/frontend/src/pages/ProblemDetailPage.test.tsx
@@ -956,25 +956,30 @@ describe("ProblemDetailPage", () => {
         { id: "practice:p1", testedAt: "2026-07-16T12:00:00Z", result: "incorrect", source: "practice" },
         { id: "exam:e1", testedAt: "2026-07-16T10:00:00Z", result: "correct", source: "exam" },
         { id: "practice:p2", testedAt: "2026-07-16T08:00:00Z", result: "correct", source: "practice" },
+        { id: "created:abc123", testedAt: "2026-07-16T06:00:00Z", result: null, source: "created" },
       ],
-      total: 3,
+      total: 4,
       hasMore: false,
     });
 
     renderProblemDetailPage();
 
     await waitFor(() => {
-      expect(screen.getByText("Test History")).toBeInTheDocument();
+      expect(screen.getByText("Activities")).toBeInTheDocument();
     });
 
     const history = await screen.findByTestId("attempt-history");
-    expect(history.querySelectorAll("tbody tr")).toHaveLength(3);
+    expect(within(history).getByRole("columnheader", { name: "Timestamp" })).toBeInTheDocument();
+    expect(history.querySelectorAll("tbody tr")).toHaveLength(4);
     expect(within(history).getByText("Incorrect")).toBeInTheDocument();
     expect(within(history).getAllByText("Correct").length).toBeGreaterThanOrEqual(1);
     expect(within(history).getAllByText("practice").length).toBeGreaterThanOrEqual(2);
     expect(within(history).getByText("exam")).toBeInTheDocument();
+    // The created row renders a dash instead of a result badge.
+    expect(within(history).getByText("created")).toBeInTheDocument();
+    expect(within(history).getByText("-")).toBeInTheDocument();
     expect(screen.queryByTestId("attempt-history-load-more")).not.toBeInTheDocument();
-    expect(screen.getByText(/Showing 3 of 3/)).toBeInTheDocument();
+    expect(screen.getByText(/Showing 4 of 4/)).toBeInTheDocument();
   });
 
   it("shows empty state when no attempt history exists", async () => {
@@ -986,7 +991,21 @@ describe("ProblemDetailPage", () => {
     renderProblemDetailPage();
 
     expect(await screen.findByTestId("attempt-history-empty")).toHaveTextContent(
-      "No test history recorded.",
+      "No activities recorded.",
+    );
+  });
+
+  it("shows activities loading text while history is loading", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ problem: baseProblem })
+      .mockResolvedValueOnce(baseTracking);
+    // Never resolves so the initial loading state persists.
+    vi.mocked(api.getAttemptHistory).mockReturnValue(new Promise(() => {}));
+
+    renderProblemDetailPage();
+
+    expect(await screen.findByTestId("attempt-history-loading")).toHaveTextContent(
+      "Loading activities...",
     );
   });
 

--- a/frontend/src/pages/ProblemDetailPage.tsx
+++ b/frontend/src/pages/ProblemDetailPage.tsx
@@ -161,7 +161,7 @@ function ProblemAttemptHistory({ problemId }: { problemId: string }) {
   if (isLoadingInitial) {
     return (
       <div data-testid="attempt-history-loading" style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>
-        Loading test history...
+        Loading activities...
       </div>
     );
   }
@@ -199,7 +199,7 @@ function ProblemAttemptHistory({ problemId }: { problemId: string }) {
   if (items.length === 0) {
     return (
       <div data-testid="attempt-history-empty" style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>
-        No test history recorded.
+        No activities recorded.
       </div>
     );
   }
@@ -210,7 +210,7 @@ function ProblemAttemptHistory({ problemId }: { problemId: string }) {
         <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.875rem", minWidth: "360px" }}>
           <thead>
             <tr style={{ textAlign: "left", borderBottom: "2px solid var(--color-border)" }}>
-              <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Tested At</th>
+              <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Timestamp</th>
               <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Result</th>
               <th scope="col" style={{ padding: "0.5rem 0.75rem", fontWeight: 700 }}>Source</th>
             </tr>
@@ -220,12 +220,16 @@ function ProblemAttemptHistory({ problemId }: { problemId: string }) {
               <tr key={item.id} style={{ borderBottom: "1px solid var(--color-border)" }}>
                 <td style={{ padding: "0.5rem 0.75rem", whiteSpace: "nowrap" }}>{formatDate(item.testedAt)}</td>
                 <td style={{ padding: "0.5rem 0.75rem" }}>
-                  <span
-                    className={`badge ${RESULT_BADGE_CLASS[item.result] ?? "badge-muted"}`}
-                    style={{ fontSize: "0.75rem", padding: "0.15rem 0.5rem", borderRadius: "var(--radius-sm)", fontWeight: 600, textTransform: "none", letterSpacing: "normal" }}
-                  >
-                    {RESULT_LABELS[item.result] ?? item.result}
-                  </span>
+                  {item.result === null ? (
+                    <span style={{ color: "var(--color-text-muted)" }}>-</span>
+                  ) : (
+                    <span
+                      className={`badge ${RESULT_BADGE_CLASS[item.result] ?? "badge-muted"}`}
+                      style={{ fontSize: "0.75rem", padding: "0.15rem 0.5rem", borderRadius: "var(--radius-sm)", fontWeight: 600, textTransform: "none", letterSpacing: "normal" }}
+                    >
+                      {RESULT_LABELS[item.result] ?? item.result}
+                    </span>
+                  )}
                 </td>
                 <td style={{ padding: "0.5rem 0.75rem", textTransform: "capitalize" }}>{item.source}</td>
               </tr>
@@ -843,7 +847,7 @@ export function ProblemDetailPage() {
           <div style={{ color: "var(--color-text-muted)", fontSize: "0.875rem" }}>No tracking data available</div>
         )}
         <div style={{ borderTop: "1px solid var(--color-border)", paddingTop: "1rem" }}>
-          <h3 style={{ fontSize: "1rem", fontWeight: 700, margin: "0 0 0.5rem 0" }}>Test History</h3>
+          <h3 style={{ fontSize: "1rem", fontWeight: 700, margin: "0 0 0.5rem 0" }}>Activities</h3>
           <ProblemAttemptHistory problemId={problemId} />
         </div>
       </div>

--- a/frontend/src/types/problem.ts
+++ b/frontend/src/types/problem.ts
@@ -54,8 +54,8 @@ export interface ProblemsResponse {
 export interface AttemptHistoryItem {
   id: string;
   testedAt: string;
-  result: string;
-  source: "practice" | "exam";
+  result: string | null;
+  source: "practice" | "exam" | "created";
 }
 
 export interface AttemptHistoryResponse {


### PR DESCRIPTION
Model-Signature: ark-coding-plan/glm-5.2

## Summary

- Derive a `created` activity at read time from each problem's existing `createdAt` timestamp and include it in the merged activity-history response (`GET /api/v1/problems/{id}/attempts`).
- Make the activity `result` nullable (`str | None`) in the backend payload and frontend type; the `created` row carries a `null` result.
- Rename the problem-detail history UI from `Test History` / `Tested At` to `Activities` / `Timestamp`, render `Created` for the new source and a `-` for null results, and update loading/empty-state text.
- Update backend and frontend tests for creation-only history, merged ordering, pagination, filtering, labels, and nullable results.

## Linked Issue

Closes #530

## Issue Alignment

This PR implements the issue by:

- Appending one derived `created` record (`id=created:<problem-id>`, `testedAt=problem.createdAt`, `source=created`, `result=null`) in `get_problem_attempt_history`, included in the existing deterministic newest-first sort and the `total`/`hasMore`/offset slicing.
- Changing `AttemptHistoryItemPayload.result` to `str | None` and the frontend `AttemptHistoryItem.result` to `string | null` with `source` extended to include `"created"`.
- Renaming the UI heading to `Activities`, the timestamp column to `Timestamp`, the loading text to `Loading activities...`, the empty-state text to `No activities recorded.`, and rendering a dash for null results instead of a badge.
- Preserving the lowercase `practice`/`exam` API source values and their existing result semantics; `created` follows the same lowercase convention and is rendered via the existing capitalize presentation.

Scope covered:

- Backend derivation of the creation record and nullable payload.
- Frontend type and rendering changes (labels, dash, loading/empty text).
- Backend and frontend test updates.

Out of scope / intentionally not included:

- No persisted activity collection or migration (derived at read time, per the chosen approach).
- No changes to aggregate tracking counters, Practice submission, Exam grading, or the endpoint URL.
- No title-casing of existing API source values.

## Implementation Notes

- The creation record is appended to the same in-memory `records` list used for practice/exam rows, so it participates in the existing stable pre-sort (`source`, `id`) then `testedAt` desc sort, guaranteeing it appears exactly once in pagination with no reordering of tied rows.
- A `datetime` guard (`isinstance(problem_created_at, datetime)`) mirrors the existing practice/exam timestamp guards; the canonical creation path always stores `createdAt`, so every valid problem gets exactly one `created` row.
- The frontend renders `item.result === null` as a muted `-` span; all non-null results keep their existing badge rendering unchanged.
- The source cell continues to use CSS `text-transform: capitalize`, so `created` displays as `Created` with no extra mapping.

## Tests

Commands run:

- `./scripts/agent-env.sh test backend` (full backend pytest) — 978 passed, 1 skipped, 14 errors. The 14 errors are all in `tests/integration/test_ingestion_atomicity.py` and are environmental (`pymongo ServerSelectionTimeoutError`: the `test backend` selector does not provision a MongoDB replica set; only `shell`/`e2e` do). They are unrelated to this change, which touches only the problem activity-history endpoint.
- Targeted backend run `pytest tests/api/test_problems.py -q` — 61 passed (includes all attempt-history tests).
- `./scripts/agent-env.sh test frontend` (full vitest `--run`) — 561 passed across 36 files.
- Targeted frontend run `npm test -- --run src/pages/ProblemDetailPage.test.tsx` — 45 passed.
- `npx tsc -b` (frontend typecheck) — passed with no errors.

Automated tests added or updated:

- Backend (`backend/tests/api/test_problems.py`):
  - `test_attempt_history_creation_only_returns_single_created_row` (renamed from `test_attempt_history_empty_state`): a problem with no test attempts returns exactly one `created` row with `result: null`, `id: created:<problem-id>`, and `testedAt` equal to the problem's `createdAt`.
  - `test_attempt_history_merges_practice_and_exam_newest_first`: now asserts the `created` row merges in timestamp order with a null result and the expected id.
  - `test_attempt_history_pagination_appends_without_duplication`: updated counts (22 practice + 1 created = 23) and asserts the `created` row participates in pagination exactly once.
  - `test_attempt_history_excludes_non_final_and_other_user_exams`, `test_attempt_history_preserves_pending_and_ungraded_states`, `test_attempt_history_does_not_fabricate_rows_from_aggregate_counters`, `test_attempt_history_excludes_other_problem_records`: updated to account for the always-present derived `created` row while preserving their original filtering intent.
- Frontend (`frontend/src/pages/ProblemDetailPage.test.tsx`):
  - `renders attempt history rows from API`: asserts the `Activities` heading, `Timestamp` column header, a `created` row rendering a `-` dash instead of a result badge, and existing Practice/Exam/Correct/Incorrect rendering.
  - `shows activities loading text while history is loading`: asserts the `Loading activities...` text.
  - `shows empty state when no attempt history exists`: asserts the `No activities recorded.` text.

Manual verification:

Interactive browser verification was not performed in this environment. The issue's four manual-verification scenarios are mapped below to the specific passing assertion-level tests that prove each contract. Note: no Playwright E2E test directly targets the problem-detail Activities section (existing E2E covers the `/practice` page history and problem-detail theme rendering only), so the contract is proven at the backend integration and frontend unit level; the final interactive visual confirmation is deferred to the human reviewer.

1. A problem with no test attempts shows one Created row at the creation timestamp with `-` -> backend `test_attempt_history_creation_only_returns_single_created_row` proves exactly one `created` row with `result: null`, `id: created:<problem-id>`, and `testedAt == createdAt`; frontend `renders attempt history rows from API` proves a `created` row renders a `-` dash instead of a badge.
2. Submitting through Practice mode adds a Practice activity -> backend `test_attempt_history_merges_practice_and_exam_newest_first` proves practice rows appear with their existing `result` values in newest-first order; the practice-attempt persistence path is unchanged by this PR.
3. Submitting an Exam containing the problem adds an Exam activity -> the same merge test proves exam rows appear with their existing `result` values; only submitted exams contribute (proven by `test_attempt_history_excludes_non_final_and_other_user_exams`).
4. Aggregate Tracking Statistics are unchanged -> backend `test_attempt_history_does_not_fabricate_rows_from_aggregate_counters` proves aggregate counters are not used to fabricate rows and only the derived `created` row is present; no tracking-serialization or counter code was modified, and frontend `keeps tracking statistics intact alongside attempt history` proves the tracking counters render unchanged alongside the history.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (derive at read time from `createdAt`, lowercase `created` source, nullable result rendered as `-`).

## Follow-Up Work

None.

