### PR TITLE
feat(bulk-review): add Alt+PageUp/PageDown keyboard navigation

### DIFF
--- a/frontend/src/components/BulkReviewStep.test.tsx
+++ b/frontend/src/components/BulkReviewStep.test.tsx
@@ -368,6 +368,142 @@ describe("BulkReviewStep", () => {
     expect(screen.getByTestId("bulk-review-next")).toBeDisabled();
   });
 
+  it("navigates to the next item on Alt+PageDown", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("1 / 2");
+
+    fireEvent(
+      window,
+      new KeyboardEvent("keydown", { key: "PageDown", altKey: true }),
+    );
+
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("2 / 2");
+  });
+
+  it("navigates to the previous item on Alt+PageUp", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("2 / 2");
+
+    fireEvent(
+      window,
+      new KeyboardEvent("keydown", { key: "PageUp", altKey: true }),
+    );
+
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("1 / 2");
+  });
+
+  it("navigates via Alt+PageDown while a Review text field has focus", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    const textField = screen.getByTestId("bulk-review-text");
+    textField.focus();
+    expect(textField).toHaveFocus();
+
+    fireEvent(
+      window,
+      new KeyboardEvent("keydown", { key: "PageDown", altKey: true }),
+    );
+
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("2 / 2");
+  });
+
+  it("does not wrap item selection at the first or last item", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    // At first item: Alt+PageUp keeps the first item selected.
+    fireEvent(
+      window,
+      new KeyboardEvent("keydown", { key: "PageUp", altKey: true }),
+    );
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("1 / 2");
+
+    // Move to the last item; Alt+PageDown keeps the last item selected.
+    fireEvent.click(screen.getByTestId("bulk-review-next"));
+    fireEvent(
+      window,
+      new KeyboardEvent("keydown", { key: "PageDown", altKey: true }),
+    );
+    expect(screen.getByTestId("bulk-review-position")).toHaveTextContent("2 / 2");
+  });
+
+  it("prevents the default browser behavior for Alt+PageDown and Alt+PageUp", () => {
+    render(
+      <BulkReviewStep
+        batch={makeBatch({
+          items: [
+            makeItem("item-1", { order: 0 }),
+            makeItem("item-2", { order: 1 }),
+          ],
+        })}
+        isLoading={false}
+        {...handlers}
+      />,
+    );
+
+    const downEvent = new KeyboardEvent("keydown", {
+      key: "PageDown",
+      altKey: true,
+      cancelable: true,
+    });
+    fireEvent(window, downEvent);
+    expect(downEvent.defaultPrevented).toBe(true);
+
+    const upEvent = new KeyboardEvent("keydown", {
+      key: "PageUp",
+      altKey: true,
+      cancelable: true,
+    });
+    fireEvent(window, upEvent);
+    expect(upEvent.defaultPrevented).toBe(true);
+  });
+
   it("edits every draft field and routes the correct key to onUpdateDraft", async () => {
     render(
       <BulkReviewStep

--- a/frontend/src/components/BulkReviewStep.tsx
+++ b/frontend/src/components/BulkReviewStep.tsx
@@ -282,6 +282,21 @@ export function BulkReviewStep({
     [items, selectedIndex],
   );
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.altKey) return;
+      if (event.key === "PageDown") {
+        navigate(1);
+        event.preventDefault();
+      } else if (event.key === "PageUp") {
+        navigate(-1);
+        event.preventDefault();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [navigate]);
+
   if (!selectedItem) {
     return (
       <div data-testid="bulk-wizard-review-step">


### PR DESCRIPTION
Model-Signature: zhipuai-coding-plan/glm-5.2

## Summary

- Add Review-stage keyboard shortcuts `Alt+PageDown` (next item) and `Alt+PageUp` (previous item) to `BulkReviewStep`.
- Reuse the existing `navigate(-1 | 1)` so item ordering and first/last-item boundary behavior are preserved.
- Prevent the browser default only for the two handled `Alt` combinations.

## Linked Issue

Closes #534

## Issue Alignment

This PR implements the issue by:

- Registering a single window `keydown` listener inside `BulkReviewStep` that recognizes only `Alt+PageDown` and `Alt+PageUp`, delegates to the existing `navigate`, and calls `preventDefault()` on handled events.
- Cleaning up the listener on unmount via the `useEffect` return.
- Adding the required component tests covering both directions, focused-field behavior, boundaries, and default prevention.

Scope covered:

- `frontend/src/components/BulkReviewStep.tsx`: new keyboard handler effect next to `navigate`.
- `frontend/src/components/BulkReviewStep.test.tsx`: five new tests.

Out of scope / intentionally not included:

- No changes to APIs, persisted batch data, or wizard-stage transitions.
- No changes to the visible Previous/Next buttons.
- No shortcuts in Upload, Detect, Submit, or Complete stages.
- No additional shortcuts or wraparound navigation.

## Implementation Notes

- The listener is attached to `window`, so it fires regardless of which Review control (input, textarea, select, tag field) currently has focus — directly satisfying the "works while a Review field is focused" criterion without per-field wiring.
- The effect depends on `navigate`, which is a `useCallback` over `items`/`selectedIndex`; the listener is re-bound only when `navigate` changes, and `navigate` itself enforces the `nextIndex >= 0 && nextIndex < items.length` bounds, so no wrapping can occur.
- Only `Alt+PageDown` and `Alt+PageUp` are intercepted; all other keys (including plain PageUp/PageDown and other Alt combinations) are ignored and their defaults run normally.

## Tests

Commands run:

- `./scripts/agent-env.sh test frontend src/components/BulkReviewStep.test.tsx` — passed. `src/components/BulkReviewStep.test.tsx (34 tests)` all green; full frontend suite also ran clean (`36 passed (36)`, `566 passed (566)`).

Automated tests added or updated:

- `navigates to the next item on Alt+PageDown`
- `navigates to the previous item on Alt+PageUp`
- `navigates via Alt+PageDown while a Review text field has focus`
- `does not wrap item selection at the first or last item`
- `prevents the default browser behavior for Alt+PageDown and Alt+PageUp`

Manual verification:

- The targeted frontend test command from the issue was executed and passed as shown above. Browser-level manual clicking of `Alt+PageDown`/`Alt+PageUp` in a live batch was not re-run here because jsdom coverage of the same code path (window listener + `navigate`) is exact and the issue lists the test command as the verification step.

## Deviations From Issue Plan

None. The chosen approach (window `keydown` listener delegating to `navigate`) matches the issue's Chosen Implementation Approach exactly.

## Follow-Up Work

None.