### PR TITLE
feat(selection): raise recency base for last-wrong to 0.5

### DIFF
--- a/backend/app/domain/selection.py
+++ b/backend/app/domain/selection.py
@@ -66,7 +66,9 @@ def compute_score_breakdown(
     # Never tested grows fastest (1/20), last-correct slowest (1/40),
     # last-failed and tested-unknown retain the original pace (1/30).
     # The 1.0 base represents the special priority of a never-tested
-    # problem; ever-tested problems start at 0.0 and grow with elapsed days.
+    # problem; last-wrong problems start from a 0.5 floor so a recently
+    # failed problem still contributes a recency signal on day zero;
+    # last-correct and tested-unknown problems start at 0.0.
     if problem.tracking.lastTestedAt is None:
         reference_dt = problem.createdAt
         daily_rate = 1 / 20
@@ -74,7 +76,10 @@ def compute_score_breakdown(
     else:
         reference_dt = problem.tracking.lastTestedAt
         daily_rate = 1 / 40 if problem.tracking.lastAttemptCorrect is True else 1 / 30
-        base = 0.0
+        if problem.tracking.lastAttemptCorrect is False:
+            base = 0.5
+        else:
+            base = 0.0
 
     if reference_dt is not None:
         days_since = (now - ensure_utc(reference_dt)).days

--- a/backend/tests/api/test_home.py
+++ b/backend/tests/api/test_home.py
@@ -817,7 +817,7 @@ async def test_summary_score_distribution_negative_zero_positive_buckets(
         created_at=sixty_days_ago,
     )
 
-    # Tested incorrect, more failures than corrects: base 0.0, rate 1/30 -> recency=0.0+60/30=2.0, failure=2.0, last_wrong=2.0 -> raw=6.0 (bucket 6)
+    # Tested incorrect, more failures than corrects: base 0.5, rate 1/30 -> recency=0.5+60/30=2.5, failure=2.0, last_wrong=2.0 -> raw=6.5 (bucket 6)
     tested_incorrect = make_problem(
         user_id,
         last_tested_at=sixty_days_ago,

--- a/backend/tests/domain/test_practice_selection.py
+++ b/backend/tests/domain/test_practice_selection.py
@@ -404,11 +404,11 @@ def test_compute_problem_weight_breakdown_all_components():
     # failure = (7/3) * 2.0 ≈ 4.6666666667
     assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
 
-    # days_since = 30, recency_score = 0.0 + 30/30 = 1.0
-    # recency = 1.0 * 1.0 = 1.0
-    assert breakdown.recency == 1.0
+    # days_since = 30, recency_score = 0.5 + 30/30 = 1.5
+    # recency = 1.5 * 1.0 = 1.5
+    assert breakdown.recency == 1.5
 
-    assert breakdown.total == pytest.approx(3.0 + (7 / 3) * 2.0 + 1.0)
+    assert breakdown.total == pytest.approx(3.0 + (7 / 3) * 2.0 + 1.5)
     assert breakdown.total == pytest.approx(breakdown.lastWrong + breakdown.failure + breakdown.recency)
 
 

--- a/backend/tests/domain/test_selection.py
+++ b/backend/tests/domain/test_selection.py
@@ -186,11 +186,11 @@ def test_recency_status_specific_rates():
     )
     assert compute_score_breakdown(last_correct, config, now).recency == 1.5
 
-    # Last failed, tested 60 days ago -> lastTestedAt reference, base 0.0, rate 1/30 -> 2.0
+    # Last failed, tested 60 days ago -> lastTestedAt reference, base 0.5, rate 1/30 -> 2.5
     last_failed = create_test_problem(
         "failed", last_tested_at=now - timedelta(days=60), last_attempt_correct=False
     )
-    assert compute_score_breakdown(last_failed, config, now).recency == 2.0
+    assert compute_score_breakdown(last_failed, config, now).recency == 2.5
 
     # Tested 60 days ago with unknown last result -> lastTestedAt reference, base 0.0, rate 1/30 -> 2.0
     tested_unknown = create_test_problem(
@@ -200,14 +200,14 @@ def test_recency_status_specific_rates():
 
 
 def test_recency_tested_today_starts_at_zero():
-    """A problem tested today has 0.0 recency; a never-tested problem created today has 1.0."""
+    """A last-wrong problem tested today has 0.5 recency; a never-tested problem created today has 1.0."""
     now = datetime.now(timezone.utc)
     config = ProblemSelectionConfig(recency_weight=1.0)
 
     tested_today = create_test_problem(
         "tested", last_tested_at=now, last_attempt_correct=False
     )
-    assert compute_score_breakdown(tested_today, config, now).recency == 0.0
+    assert compute_score_breakdown(tested_today, config, now).recency == 0.5
 
     never_tested_today = create_test_problem(
         "never", last_tested_at=None, created_at=now
@@ -229,13 +229,13 @@ def test_recency_weight_scales_status_specific_component():
 def test_recency_weight_scales_tested_component_and_base():
     """recency_weight scales the entire revised component (base + age) for tested problems too."""
     now = datetime.now(timezone.utc)
-    # Last failed, tested 60 days ago: raw recency = 0.0 + 60*(1/30) = 2.0, scaled by 2.0 -> 4.0
+    # Last failed, tested 60 days ago: raw recency = 0.5 + 60*(1/30) = 2.5, scaled by 2.0 -> 5.0
     problem = create_test_problem(
         "p1", last_tested_at=now - timedelta(days=60), last_attempt_correct=False
     )
     config = ProblemSelectionConfig(recency_weight=2.0)
     breakdown = compute_score_breakdown(problem, config, now)
-    assert breakdown.recency == 4.0
+    assert breakdown.recency == 5.0
 
 
 def test_failure_score_no_attempts():
@@ -380,14 +380,14 @@ def test_weighted_total_equals_component_sum():
         last_wrong_weight=1.5,
     )
     breakdown = compute_score_breakdown(problem, config, now)
-    # recency_score = 0.0 + 30/30 = 1.0, recency = 1.0 * 1.0 = 1.0
-    assert breakdown.recency == 1.0
+    # recency_score = 0.5 + 30/30 = 1.5, recency = 1.5 * 1.0 = 1.5
+    assert breakdown.recency == 1.5
     # failedCount=7 > correctCount=3 and correctCount>0 => ratio: 7/3
     # failure = (7/3) * 2.0 ≈ 4.6666666667
     assert breakdown.failure == pytest.approx((7 / 3) * 2.0)
     # last_wrong_score = 2.0, last_wrong = 2.0 * 1.5 = 3.0
     assert breakdown.last_wrong == 3.0
-    assert breakdown.total == pytest.approx(1.0 + (7 / 3) * 2.0 + 3.0)
+    assert breakdown.total == pytest.approx(1.5 + (7 / 3) * 2.0 + 3.0)
     assert breakdown.total == pytest.approx(breakdown.recency + breakdown.failure + breakdown.last_wrong)
 
 


### PR DESCRIPTION
Model-Signature: zhipuai-coding-plan/glm-5.2

## Summary

- Raise the recency base score for ever-tested problems whose last attempt was wrong from `0.0` to `0.5`, so a recently-failed problem still contributes a small recency floor on day zero instead of zero.
- Daily growth rates, weighting, UTC normalization, clamping, eligibility, and weighted sampling are unchanged.

## Linked Issue

Closes #536

## Issue Alignment

This PR implements the issue by:

- Splitting the `base` assignment inside the ever-tested branch of `compute_score_breakdown` so `tracking.lastAttemptCorrect is False` uses `base = 0.5`, while last-correct and tested-unknown remain at `0.0` and never-tested remains at `1.0`.
- Keeping the existing `daily_rate` branching (`1/40` for last-correct, `1/30` for last-wrong and tested-unknown, `1/20` for never-tested) untouched.
- Refreshing the adjacent comment block to document the new `0.5` floor.
- Updating only the affected test expectations and inline comments in the domain, practice, and home test files.

Scope covered:

- Single source-of-truth change in `backend/app/domain/selection.py`.
- Inline comment refresh.
- Affected test updates in `backend/tests/domain/test_selection.py`, `backend/tests/domain/test_practice_selection.py`, and `backend/tests/api/test_home.py`.

Out of scope / intentionally not included:

- No change to any daily growth rate.
- No change to the `last_wrong` score component (`1.0` / `0.5` / `2.0`) or `last_wrong_weight`.
- No new user-configurable setting, API field, migration, frontend change, or unrelated refactor.

## Implementation Notes

- The change is the smallest possible branch inside the existing ever-tested `else` block:

  ```python
  if problem.tracking.lastAttemptCorrect is False:
      base = 0.5
  else:
      base = 0.0
  ```

- The `daily_rate` line above is preserved, so last-correct keeps `1/40` and last-wrong / tested-unknown keep `1/30`.
- Updated examples with `recency_weight = 1.0`:
  - Last wrong today: `recency = 0.5`.
  - Last wrong 30 days ago: `recency = 0.5 + 30/30 = 1.5`.
  - Last wrong 60 days ago: `recency = 0.5 + 60/30 = 2.5`.
- With `recency_weight = 2.0`, last-wrong 60 days ago becomes `(0.5 + 60/30) * 2.0 = 5.0`.
- Home score-distribution raw score for a last-wrong problem (60 days ago, more failures than corrects) becomes `0.5 + 60/30 + 2.0 + 2.0 = 6.5`, which still floors to bucket `6`, so the bucket assertion is unchanged.

## Tests

Commands run:

- `./scripts/agent-env.sh test backend` (full backend pytest; completed through ~78% before hitting unrelated environment failures — see below).
- Focused re-run via the same tools image: `pytest tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/api/test_home.py -v` — passed.

Focused results:

- `108 passed in 3.92s` across `test_selection.py`, `test_practice_selection.py`, and `test_home.py`.
- This covers all four updated test cases plus the unchanged never-tested / last-correct / tested-unknown regressions.

Automated tests added or updated:

- `backend/tests/domain/test_selection.py`:
  - `test_recency_status_specific_rates`: last-failed 60 days ago now asserts recency `2.5` (was `2.0`); comment updated to `base 0.5`.
  - `test_recency_tested_today_starts_at_zero`: last-wrong tested today now asserts recency `0.5` (was `0.0`); docstring updated; never-tested assertion stays at `1.0`.
  - `test_recency_weight_scales_tested_component_and_base`: last-failed 60 days ago with `recency_weight=2.0` now asserts recency `5.0` (was `4.0`); comment updated.
  - `test_weighted_total_equals_component_sum`: last-failed 30 days ago now asserts recency `1.5` (was `1.0`) and the new total `1.5 + (7/3)*2.0 + 3.0`.
- `backend/tests/domain/test_practice_selection.py`:
  - `test_compute_problem_weight_breakdown_all_components`: recency becomes `1.5` and the total recomputed accordingly; comment updated.
- `backend/tests/api/test_home.py`:
  - `test_summary_score_distribution_negative_zero_positive_buckets`: inline comment now reads raw `6.5`; the bucket-6 assertion is unchanged because `math.floor(6.5) == 6`.

Manual verification:

- Confirmed via the focused pytest run that:
  - A last-wrong problem tested today produces recency `0.5`.
  - A last-wrong problem tested 60 days ago produces recency `2.5`.
  - A last-wrong problem tested 60 days ago with `recency_weight=2.0` produces recency `5.0` (which proves base + age + weight scaling).
  - The existing never-tested (`2.5` at 30 days), last-correct (`1.5` at 60 days), and tested-unknown (`2.0` at 60 days) recency values remain green.

## Deviations From Issue Plan

None. The change matches the issue's Chosen Implementation Approach and Implementation Plan exactly. No new abstractions, settings, or configuration fields were introduced.

Note on the full backend suite: `./scripts/agent-env.sh test backend` runs `pytest` without starting the MongoDB/RustFS services for the backend selector, so the integration tests in `tests/integration/test_ingestion_atomicity.py` (which require a live `MONGODB_URI`) error in this worktree just as they do on a fresh checkout. This is a pre-existing environment characteristic unrelated to this PR's domain-level change. All affected domain, practice, and home tests pass.

## Follow-Up Work

None.
