### PR TITLE
test(vlm): canonicalize JSON-fence behavior matrix (#538)

### DIFF
--- a/backend/tests/infrastructure/test_solution_coaching_client.py
+++ b/backend/tests/infrastructure/test_solution_coaching_client.py
@@ -487,58 +487,6 @@ async def test_coaching_vlm_client_reasoning_content_none_when_absent() -> None:
     assert result.reasoning_content is None
 
 
-def test_solution_coaching_strip_json_code_fences_leaves_plain_json_unchanged() -> None:
-    plain = '{"text":"hello"}'
-
-    assert SolutionVLMClient._strip_json_code_fences(plain) == plain
-
-
-def test_solution_coaching_strip_json_code_fences_strips_json_fence() -> None:
-    fenced = '```json\n{"text":"hello"}\n```'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_solution_coaching_strip_json_code_fences_strips_plain_fence() -> None:
-    fenced = '```\n{"text":"hello"}\n```'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_solution_coaching_strip_json_code_fences_strips_any_fence_language() -> None:
-    fenced = '```python\n{"text":"hello"}\n```'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_solution_coaching_strip_json_code_fences_preserves_incomplete_closing_fence() -> None:
-    fenced = '```json\n{"text":"hello"}'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == fenced
-
-
-def test_solution_coaching_strip_json_code_fences_preserves_single_line_fence() -> None:
-    fenced = '```json {"text":"hello"} ```'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == fenced
-
-
-def test_solution_coaching_strip_json_code_fences_returns_empty_string_for_empty_input() -> None:
-    assert SolutionVLMClient._strip_json_code_fences("") == ""
-
-
-def test_solution_coaching_strip_json_code_fences_strips_fence_with_whitespace_in_opening() -> None:
-    fenced = '``` json\n{"text":"hello"}\n```'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_solution_coaching_strip_json_code_fences_strips_multiline_json_content() -> None:
-    fenced = '```json\n{\n  "text": "hello",\n  "value": 42\n}\n```'
-
-    assert SolutionVLMClient._strip_json_code_fences(fenced) == '{\n  "text": "hello",\n  "value": 42\n}'
-
-
 @pytest.mark.asyncio
 async def test_solution_vlm_client_extracts_embedded_json_without_fences() -> None:
     async def completion_fn(**kwargs):

--- a/backend/tests/infrastructure/test_vlm.py
+++ b/backend/tests/infrastructure/test_vlm.py
@@ -424,62 +424,37 @@ async def test_vlm_parser_rejects_empty_choices() -> None:
     assert str(exc_info.value) == "VLM provider returned no choices"
 
 
-def test_strip_json_code_fences_leaves_plain_json_unchanged() -> None:
-    plain = '{"text":"hello"}'
-
-    assert VLMClient._strip_json_code_fences(plain) == plain
-
-
-def test_strip_json_code_fences_strips_json_fence() -> None:
-    fenced = '```json\n{"text":"hello"}\n```'
-
-    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_strip_json_code_fences_strips_plain_fence() -> None:
-    fenced = '```\n{"text":"hello"}\n```'
-
-    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_strip_json_code_fences_strips_non_json_fence_language() -> None:
-    fenced = '```python\n{"text":"hello"}\n```'
-
-    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_strip_json_code_fences_preserves_incomplete_opening_fence() -> None:
-    fenced = '```json\n{"text":"hello"}'
-
-    assert VLMClient._strip_json_code_fences(fenced) == fenced
-
-
-def test_strip_json_code_fences_preserves_incomplete_closing_fence() -> None:
-    fenced = '{"text":"hello"}\n```'
-
-    assert VLMClient._strip_json_code_fences(fenced) == fenced
-
-
-def test_strip_json_code_fences_preserves_single_line_fence() -> None:
-    fenced = '```json {"text":"hello"} ```'
-
-    assert VLMClient._strip_json_code_fences(fenced) == fenced
-
-
-def test_strip_json_code_fences_strips_fence_with_trailing_whitespace() -> None:
-    fenced = '  ```json\n{"text":"hello"}\n```  '
-
-    assert VLMClient._strip_json_code_fences(fenced) == '{"text":"hello"}'
-
-
-def test_strip_json_code_fences_returns_empty_string_for_empty_input() -> None:
-    assert VLMClient._strip_json_code_fences("") == ""
-
-
-def test_strip_json_code_fences_strips_multiline_json_content() -> None:
-    fenced = '```json\n{\n  "text": "hello",\n  "value": 42\n}\n```'
-
-    assert VLMClient._strip_json_code_fences(fenced) == '{\n  "text": "hello",\n  "value": 42\n}'
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ('{"text":"hello"}', '{"text":"hello"}'),
+        ('```json\n{"text":"hello"}\n```', '{"text":"hello"}'),
+        ('```\n{"text":"hello"}\n```', '{"text":"hello"}'),
+        ('```python\n{"text":"hello"}\n```', '{"text":"hello"}'),
+        ('```json\n{"text":"hello"}', '```json\n{"text":"hello"}'),
+        ('{"text":"hello"}\n```', '{"text":"hello"}\n```'),
+        ('```json {"text":"hello"} ```', '```json {"text":"hello"} ```'),
+        ('  ```json\n{"text":"hello"}\n```  ', '{"text":"hello"}'),
+        ('', ''),
+        ('```json\n{\n  "text": "hello",\n  "value": 42\n}\n```', '{\n  "text": "hello",\n  "value": 42\n}'),
+        ('``` json\n{"text":"hello"}\n```', '{"text":"hello"}'),
+    ],
+    ids=[
+        "plain_json_unchanged",
+        "strips_json_fence",
+        "strips_plain_fence",
+        "strips_non_json_fence_language",
+        "preserves_incomplete_opening_fence",
+        "preserves_incomplete_closing_fence",
+        "preserves_single_line_fence",
+        "strips_fence_with_trailing_whitespace",
+        "empty_input_returns_empty",
+        "strips_multiline_json_content",
+        "strips_fence_with_whitespace_in_opening",
+    ],
+)
+def test_strip_json_code_fences(content: str, expected: str) -> None:
+    assert VLMClient._strip_json_code_fences(content) == expected
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Model-Signature: photonmark/gpt-5.6-luna

## Summary

- Consolidate the 10 individual `_strip_json_code_fences` unit tests in `test_vlm.py` into one parameterized 11-case matrix covering the union of distinct fence-stripper inputs.
- Add the unique whitespace-in-opening fence case (```` ``` json ````) previously only covered in `test_solution_coaching_client.py` to the canonical matrix in `test_vlm.py`.
- Remove the 9 inherited-duplicate strip tests from `test_solution_coaching_client.py` (the method is inherited unchanged from `BaseVLMClient`, so the `VLMClient` matrix fully covers it).
- Keep the full-pipeline `test_vlm_extraction_accepts_fenced_json_content` test separate from the unit matrix.
- Test-only; no production source changes.

## Linked Issue

Closes #538

## Issue Alignment

This PR implements the issue by:

- Parameterizing the union of 11 distinct fence-stripper unit inputs in `backend/tests/infrastructure/test_vlm.py`, preserving every existing input/output pair exactly.
- Adding the unique ```` ``` json ```` whitespace case to the canonical matrix (it was the only solution/coaching-only input).
- Removing only the exact inherited-duplicate strip tests from `backend/tests/infrastructure/test_solution_coaching_client.py`.

Scope covered:

- Parameterized 11-case matrix in `test_vlm.py` (10 existing distinct inputs + 1 unique whitespace-in-opening input).
- Full-pipeline `test_vlm_extraction_accepts_fenced_json_content` remains independent.
- Deletion of 9 exact inherited-duplicate strip tests from `test_solution_coaching_client.py`.

Out of scope / intentionally not included:

- No changes to `backend/app/**` or any production behavior.
- No changes to fence-stripping semantics, VLM prompts, parsing, or model definitions.
- No removal of any unique solution/coaching-specific coverage (the whitespace case was relocated, not removed).

## Implementation Notes

- Both `VLMClient` and `SolutionVLMClient`/`CoachingVLMClient` inherit `_strip_json_code_fences` from `BaseVLMClient` (`backend/app/infrastructure/vlm/base_client.py:207`) with no overrides. This makes the 9 solution/coaching strip tests exact inherited duplicates of the canonical matrix cases (same input -> same expected output, via the same inherited method).
- The 11 distinct inputs in the matrix:
  1. plain JSON (unchanged)
  2. `json` fence (stripped)
  3. plain fence (stripped)
  4. `python` fence language (stripped)
  5. incomplete opening fence (preserved)
  6. incomplete closing fence (preserved)
  7. single-line fence (preserved)
  8. fence with trailing whitespace (stripped)
  9. empty input (empty output)
  10. multiline JSON content (stripped)
  11. whitespace-in-opening fence ```` ``` json ```` (stripped) — the unique case relocated from the solution/coaching module.
- Used `pytest.mark.parametrize` with explicit `ids=` for readable per-case test IDs matching the original case semantics.

## Tests

Commands run:

- `cd backend && uv run --frozen --extra dev pytest tests/infrastructure/test_vlm.py tests/infrastructure/test_solution_coaching_client.py -q` — passed (108 passed in 0.08s)
- `uv run --frozen --extra dev pytest` (full backend suite) — passed (971 passed, 15 skipped in 97.75s)

Automated tests added or updated:

- `test_vlm.py::test_strip_json_code_fences` — parameterized 11-case matrix (replaces 10 individual tests + adds the whitespace case).
- Removed 9 `test_solution_coaching_strip_json_code_fences_*` inherited-duplicate tests from `test_solution_coaching_client.py`.

Manual verification:

- Confirmed via `pytest -v -k "strip_json_code_fences or accepts_fenced_json"` that all 11 parameterized IDs are collected and pass, and that `test_vlm_extraction_accepts_fenced_json_content` remains a separate, independent test (12 selected, 12 passed).
- Confirmed the diff touches only the two named test modules and that `SolutionVLMClient` is still used elsewhere in `test_solution_coaching_client.py` (no orphaned import).
- Confirmed no `backend/app/**` production source files changed.

## Deviations From Issue Plan

None. The implementation follows the chosen approach exactly: parameterize the 11-case union in `test_vlm.py`, keep the full-pipeline test separate, and delete only exact inherited duplicates from the solution/coaching module.

## Follow-Up Work

None.

