### PR TITLE
test(e2e): share Playwright session helpers across specs (#539)

### DIFF
--- a/frontend/tests/active-exam-print.spec.ts
+++ b/frontend/tests/active-exam-print.spec.ts
@@ -3,20 +3,11 @@ import { expect, test } from "@playwright/test";
 import {
   addAuthenticatedSession,
   APP_BASE,
-  DEFAULT_TEST_PASSWORD,
-  registerAndLogin,
+  createSession,
   seedActiveExam,
-  type AuthSession,
 } from "./helpers";
 
 test.use({ baseURL: APP_BASE });
-
-async function createSession(
-  request: Parameters<typeof registerAndLogin>[0],
-  prefix: string,
-): Promise<AuthSession> {
-  return registerAndLogin(request, `e2e_${prefix}_${Date.now()}_${Math.random()}`, DEFAULT_TEST_PASSWORD);
-}
 
 test.describe("Active Exam print preview", () => {
   test("renders all exam content in the print preview for a one-problem exam", async ({ page, request }) => {

--- a/frontend/tests/helpers.ts
+++ b/frontend/tests/helpers.ts
@@ -154,3 +154,18 @@ export async function seedActiveExam(
   expect(createPayload.exam?.id, "created exam id should be present").toBeTruthy();
   return createPayload.exam;
 }
+
+export async function createSession(request: APIRequestContext, prefix: string): Promise<AuthSession> {
+  return registerAndLogin(request, `e2e_${prefix}_${Date.now()}_${Math.random()}`, DEFAULT_TEST_PASSWORD);
+}
+
+export async function createSessionWithProblem(request: APIRequestContext, prefix: string) {
+  const session = await createSession(request, prefix);
+  const problem = await seedProblem(request, session, {
+    text: "What is 2+2?",
+    problemType: "fill-in-the-blank",
+    correctAnswer: "4",
+  });
+
+  return { session, problem };
+}

--- a/frontend/tests/practice.spec.ts
+++ b/frontend/tests/practice.spec.ts
@@ -1,31 +1,14 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import {
   addAuthenticatedSession,
   APP_BASE,
-  DEFAULT_TEST_PASSWORD,
-  registerAndLogin,
-  seedProblem,
+  createSession,
+  createSessionWithProblem,
   submitPracticeAttempt,
-  type AuthSession,
 } from "./helpers";
 
 test.use({ baseURL: APP_BASE });
-
-async function createSession(request: APIRequestContext, prefix: string): Promise<AuthSession> {
-  return registerAndLogin(request, `e2e_${prefix}_${Date.now()}_${Math.random()}`, DEFAULT_TEST_PASSWORD);
-}
-
-async function createSessionWithProblem(request: APIRequestContext, prefix: string) {
-  const session = await createSession(request, prefix);
-  const problem = await seedProblem(request, session, {
-    text: "What is 2+2?",
-    problemType: "fill-in-the-blank",
-    correctAnswer: "4",
-  });
-
-  return { session, problem };
-}
 
 test.describe("Practice E2E", () => {
   test("loads the protected practice page for an authenticated user", async ({ page, request }) => {

--- a/frontend/tests/teacher-password.spec.ts
+++ b/frontend/tests/teacher-password.spec.ts
@@ -1,31 +1,14 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import {
   addAuthenticatedSession,
   APP_BASE,
+  createSession,
+  createSessionWithProblem,
   DEFAULT_TEACHER_PASSWORD,
-  DEFAULT_TEST_PASSWORD,
-  registerAndLogin,
-  seedProblem,
-  type AuthSession,
 } from "./helpers";
 
 test.use({ baseURL: APP_BASE });
-
-async function createSession(request: APIRequestContext, prefix: string): Promise<AuthSession> {
-  return registerAndLogin(request, `e2e_${prefix}_${Date.now()}_${Math.random()}`, DEFAULT_TEST_PASSWORD);
-}
-
-async function createSessionWithProblem(request: APIRequestContext, prefix: string) {
-  const session = await createSession(request, prefix);
-  const problem = await seedProblem(request, session, {
-    text: "What is 2+2?",
-    problemType: "fill-in-the-blank",
-    correctAnswer: "4",
-  });
-
-  return { session, problem };
-}
 
 test.describe("Teacher Password E2E", () => {
   test("reveals a protected problem answer with the teacher password", async ({ page, request }) => {

--- a/frontend/tests/theme.spec.ts
+++ b/frontend/tests/theme.spec.ts
@@ -1,30 +1,13 @@
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 import {
   addAuthenticatedSession,
   APP_BASE,
-  DEFAULT_TEST_PASSWORD,
-  registerAndLogin,
-  seedProblem,
-  type AuthSession,
+  createSession,
+  createSessionWithProblem,
 } from "./helpers";
 
 test.use({ baseURL: APP_BASE });
-
-async function createSession(request: APIRequestContext, prefix: string): Promise<AuthSession> {
-  return registerAndLogin(request, `e2e_${prefix}_${Date.now()}_${Math.random()}`, DEFAULT_TEST_PASSWORD);
-}
-
-async function createSessionWithProblem(request: APIRequestContext, prefix: string) {
-  const session = await createSession(request, prefix);
-  const problem = await seedProblem(request, session, {
-    text: "What is 2+2?",
-    problemType: "fill-in-the-blank",
-    correctAnswer: "4",
-  });
-
-  return { session, problem };
-}
 
 // Helper to set theme before navigation
 async function setTheme(page: Page, theme: "light" | "dark") {


### PR DESCRIPTION
Model-Signature: ark-coding-plan/glm-5.2

## Summary

- Extract the duplicate `createSession` and `createSessionWithProblem` wrappers verbatim into `frontend/tests/helpers.ts` (exported).
- Migrate the four selected specs (`practice.spec.ts`, `theme.spec.ts`, `teacher-password.spec.ts`, `active-exam-print.spec.ts`) to consume the shared wrappers from `helpers.ts`.
- Remove now-unused imports (`DEFAULT_TEST_PASSWORD`, `registerAndLogin`, `seedProblem`, `AuthSession`, `APIRequestContext`) from each migrated spec where the local helpers were the only consumers.
- Leave the bulk-ingestion variant untouched (it has a different signature with no `prefix` parameter).
- Test-only refactor; per-call username generation, default password, and seeded problem data are preserved exactly.

## Linked Issue

Closes #539

## Issue Alignment

This PR implements the issue by:

- Adding the exact `createSession` and `createSessionWithProblem` wrappers to `frontend/tests/helpers.ts`, copied verbatim from the common local definition used by `practice.spec.ts`, `theme.spec.ts`, and `teacher-password.spec.ts`.
- Migrating only the four named specs to import the shared wrappers and removing their local duplicate definitions.
- Preserving the existing call signatures and generated/default data behavior (username pattern `e2e_${prefix}_${Date.now()}_${Math.random()}`, `DEFAULT_TEST_PASSWORD`, and the `{text: "What is 2+2?", problemType: "fill-in-the-blank", correctAnswer: "4"}` seed).

Scope covered:

- `createSession` and `createSessionWithProblem` added (exported) to `helpers.ts`.
- `practice.spec.ts`, `theme.spec.ts`, `teacher-password.spec.ts` migrated (both wrappers).
- `active-exam-print.spec.ts` migrated (`createSession` only; it never had `createSessionWithProblem`).
- Orphaned imports removed from each migrated spec.

Out of scope / intentionally not included:

- No changes to test scenarios, routes, assertions, seeding semantics, or authentication behavior.
- The bulk-ingestion helper variant (`createSession(request)` with no `prefix`) is unchanged.
- No broader E2E helper framework introduced.

## Implementation Notes

- All four specs had identical `createSession` bodies. Three (`practice`, `theme`, `teacher-password`) also had identical `createSessionWithProblem` bodies. `active-exam-print` only defined `createSession`.
- The shared wrappers were copied verbatim, including the username generation pattern, default password, and seeded problem data.
- Each migrated spec had its imports cleaned up: `DEFAULT_TEST_PASSWORD`, `registerAndLogin`, `seedProblem`, `AuthSession`, and `APIRequestContext` were removed where the local helpers were the only consumers. `DEFAULT_TEACHER_PASSWORD` was kept in `teacher-password.spec.ts` (still used in a test body), and `Page` was kept in `theme.spec.ts` (still used by the local `setTheme` helper).
- The bulk-ingestion spec's `createSession` has a different signature (`(request: APIRequestContext)` with no `prefix`) and was correctly left untouched.

## Tests

Commands run:

- `./scripts/agent-env.sh test frontend` - passed (566 passed, 36 test files, 10.37s)
- Targeted E2E run of the 4 migrated specs via the agent-env tools container (`npx playwright test tests/practice.spec.ts tests/theme.spec.ts tests/teacher-password.spec.ts tests/active-exam-print.spec.ts`) - passed (51 passed in 1.2m, exit code 0)

Automated tests added or updated:

- No new tests. This is a pure refactor moving existing helper definitions into the shared `helpers.ts` module. The 4 migrated specs continue to run with their existing setup and assertions via the shared wrappers.

Manual verification:

- Confirmed the diff touches only `helpers.ts` and the four named specs (5 files total, 25 insertions, 70 deletions).
- Confirmed the bulk-ingestion spec is not touched.
- Confirmed per-call username generation works in the E2E run: backend logs show unique usernames like `e2e_coaching_dark_bg_1784475703159_0.8903553906374766`, verifying the shared `createSession` preserves the `Date.now()` + `Math.random()` pattern.
- Confirmed all 51 E2E tests across the 4 migrated specs pass with no regressions.

## Deviations From Issue Plan

One small implementation-level deviation: `active-exam-print.spec.ts`'s local `createSession` used `Parameters<typeof registerAndLogin>[0]` for the request parameter type, while the shared wrapper uses the explicit `APIRequestContext` type (matching the other three specs). These are the same type, since `registerAndLogin`'s first parameter is `APIRequestContext`, so this is behaviorally identical.

## Follow-Up Work

None. (Note: issue #543 "Test: reduce Theme E2E rendering boilerplate safely" lists this helper extraction as a dependency and can proceed once this PR is merged.)
