### PR TITLE
test: assert Active Practice navigation (#540)

### DIFF
--- a/frontend/src/pages/ActivePracticePage.test.tsx
+++ b/frontend/src/pages/ActivePracticePage.test.tsx
@@ -10,6 +10,15 @@ import { ActivePracticePage } from "./ActivePracticePage";
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -37,6 +46,7 @@ const mockProblem = {
 describe("ActivePracticePage", () => {
   beforeEach(() => {
     mockFetch.mockReset();
+    mockNavigate.mockReset();
     vi.spyOn(api, "getSolutionStatus").mockResolvedValue({ status: "none" });
   });
 
@@ -175,8 +185,7 @@ describe("ActivePracticePage", () => {
 
     screen.getByTestId("quit-button").click();
 
-    // The navigation happens via useNavigate, which we can't fully test in MemoryRouter
-    // without a route to render, but we can check the button exists and fires
+    expect(mockNavigate).toHaveBeenCalledWith("/practice");
   });
 
   it("shows loading state during grading", async () => {
@@ -224,11 +233,8 @@ describe("ActivePracticePage", () => {
   it("redirects to landing page when no problem provided", async () => {
     renderActivePracticePage(undefined);
 
-    // Since we're using MemoryRouter with no matching route for /practice,
-    // the redirect will navigate but we can't fully test the destination
-    // We just check that the component handles the case
     await waitFor(() => {
-      // Component should render nothing (null) when no problem
+      expect(mockNavigate).toHaveBeenCalledWith("/practice", { replace: true });
     });
   });
 


### PR DESCRIPTION
Model-Signature: photonmark/gpt-5.6-terra

## Summary

- Assert the quit and missing-problem navigation calls in `ActivePracticePage` tests.
- Reuse the existing partial-router mock pattern while preserving real `useLocation` and MemoryRouter state.

## Linked Issue

Closes #540

## Issue Alignment

This PR implements the issue by:

- Mocking only `useNavigate` and resetting the mock per test.
- Replacing the two no-op navigation tests with exact assertions for `/practice` and `/practice` with `{ replace: true }`.

Scope covered:

- `frontend/src/pages/ActivePracticePage.test.tsx` only.
- Separate quit and missing-problem scenarios with direct navigation assertions.

Out of scope / intentionally not included:

- No product routing, cache, or component changes.
- No scenario consolidation or broader test refactor.

## Implementation Notes

- The partial `react-router-dom` mock follows `ActiveExamPage.test.tsx`, retaining actual exports including `useLocation`.
- MemoryRouter continues to supply each test location state.

## Tests

Commands run:

- `cd frontend && npm test -- --run src/pages/ActivePracticePage.test.tsx` — failed: local `vitest` is unavailable because host dependencies are not installed.
- Agent-environment equivalent: `docker compose -f docker-compose.yml -f docker-compose.agent.yml -p learnloop-agent-issue-540-active-practice-navi-30e8a98c run --rm tools bash -c "cd /workspace/frontend && npm test -- --run src/pages/ActivePracticePage.test.tsx"` — passed (17 tests).
- `./scripts/agent-env.sh test frontend` — passed (566 tests across 36 files).

Automated tests added or updated:

- Updated the existing quit and missing-problem tests to assert their exact `useNavigate` calls.

Manual verification:

- Confirmed the diff changes only the specified test file; real router exports and MemoryRouter location state remain in use.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.