### PR TITLE
test: observe Active Exam cache effects (#541)

### DIFF
--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -26,14 +26,17 @@ function createQueryClient() {
   });
 }
 
-function renderActiveExamPage() {
-  return render(
-    <QueryClientProvider client={createQueryClient()}>
-      <MemoryRouter>
-        <ActiveExamPage />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
+function renderActiveExamPage(queryClient = createQueryClient()) {
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ActiveExamPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    ),
+  };
 }
 
 const baseExamItem = {
@@ -400,6 +403,8 @@ describe("ActiveExamPage", () => {
       expect(screen.getByText("Exam Paper")).toBeInTheDocument();
     });
 
+    const paper = screen.getByTestId("print-preview-paper");
+    expect(paper).toHaveTextContent("Exam Paper");
     const previewItems = screen.getAllByTestId("print-preview-item");
     expect(previewItems).toHaveLength(2);
     expect(previewItems[0]).toHaveTextContent("First question?");
@@ -419,8 +424,11 @@ describe("ActiveExamPage", () => {
     });
   });
 
-  it("invalidates active-exam cache and navigates to detail on submit success", async () => {
+  it("removes active-exam cache, invalidates exams, and navigates on submit success", async () => {
     const user = userEvent.setup();
+    const queryClient = createQueryClient();
+    queryClient.setQueryData(["active-exam"], { exam: baseExam });
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
@@ -429,13 +437,9 @@ describe("ActiveExamPage", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ exam: { ...baseExam, state: "submitted" } }),
-      })
-      .mockResolvedValue({
-        ok: true,
-        json: async () => ({ exam: baseExam }),
       });
 
-    renderActiveExamPage();
+    renderActiveExamPage(queryClient);
 
     await waitFor(() => {
       expect(screen.getByText("Active Exam")).toBeInTheDocument();
@@ -445,6 +449,8 @@ describe("ActiveExamPage", () => {
     await user.click(screen.getByRole("button", { name: "Submit" }));
 
     await waitFor(() => {
+      expect(queryClient.getQueryData(["active-exam"])).toBeUndefined();
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["exams"] });
       expect(mockNavigate).toHaveBeenCalledWith("/exams/exam123");
     });
   });
@@ -566,28 +572,6 @@ describe("ActiveExamPage", () => {
       expect.stringContaining("/api/v1/exams/exam123/items/item1/answer"),
       expect.anything(),
     );
-  });
-
-  it("renders the printable paper wrapper when print preview is open", async () => {
-    const user = userEvent.setup();
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ exam: baseExam }),
-    });
-
-    renderActiveExamPage();
-
-    await waitFor(() => {
-      expect(screen.getByText("Active Exam")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole("button", { name: "Print" }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("print-preview-paper")).toBeInTheDocument();
-    });
-    expect(screen.getByTestId("print-preview-paper")).toHaveTextContent("Exam Paper");
-    expect(screen.getByTestId("print-preview-paper")).toHaveTextContent("What is 2+2?");
   });
 
   it("does not render uploaded images in the print preview", async () => {


### PR DESCRIPTION
Model-Signature: photonmark/gpt-5.6-terra

## Summary

- Make submit-confirm coverage distinguish active-exam cache removal from exams-list invalidation.
- Fold the print-paper assertion into the existing two-item content/order test and remove the redundant wrapper-only test.

## Linked Issue

Closes #541

## Issue Alignment

This PR implements the issue by:

- Returning a fresh QueryClient from the render helper and allowing the submit test to seed and spy on it before render.
- Asserting the seeded active-exam entry is absent and `invalidateQueries({ queryKey: ["exams"] })` is called after submit confirmation.
- Moving `print-preview-paper` coverage into the two-item print-content/order test and removing only the redundant strict-subset test.

Scope covered:

- `frontend/src/pages/ActiveExamPage.test.tsx` only.
- Fresh QueryClients, separate cache-removal/list-invalidation checks, and consolidated print coverage.

Out of scope / intentionally not included:

- No changes to `ActiveExamPage.tsx`, Playwright specs, runtime cache behavior, or shared test infrastructure.

## Implementation Notes

- The invalidation spy is attached before render; the test seeds the active-exam cache before rendering.
- The submit test retains its POST and navigation assertions.
- The two-item test continues to prove content order while now asserting the printable paper wrapper.

## Tests

Commands run:

- Agent-environment equivalent of `cd frontend && npm test -- --run src/pages/ActiveExamPage.test.tsx` — passed (17 tests).
- `./scripts/agent-env.sh test frontend` — passed (565 tests across 36 files).
- `./scripts/agent-env.sh test e2e` — passed (59 tests).

Automated tests added or updated:

- Updated submit-confirm coverage to observe distinct cache effects.
- Consolidated the existing print-wrapper assertion into the broader two-item print test.

Manual verification:

- Confirmed the diff changes only `ActiveExamPage.test.tsx`; production page and Playwright print spec remain untouched.
- Confirmed the invalidation spy is created before render and cache removal is asserted separately.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.