### PR TITLE
ci(backend): run real-MongoDB integration tests on PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,9 +30,36 @@ jobs:
             backend/pyproject.toml
             backend/uv.lock
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Start MongoDB
+        run: docker compose up -d mongodb
+
+      - name: Wait for MongoDB replica set
+        run: |
+          for i in {1..30}; do
+            if docker compose exec -T mongodb mongo --quiet --host 127.0.0.1 --port 27017 --eval 'try { rs.status().ok === 1 ? quit(0) : quit(1) } catch (error) { quit(1) }'; then
+              echo "MongoDB replica set is ready"
+              exit 0
+            fi
+            echo "Waiting for MongoDB... ($i)"
+            sleep 2
+          done
+          echo "MongoDB did not become ready in time"
+          docker compose logs mongodb
+          exit 1
+
       - name: Run backend test suite
         working-directory: backend
         run: uv run --frozen --extra dev pytest
+        env:
+          MONGODB_URI: mongodb://localhost:27017/learnloop?replicaSet=rs0&directConnection=true
+          MONGODB_DATABASE: learnloop
+
+      - name: Tear down MongoDB
+        if: always()
+        run: docker compose down --volumes
 
   frontend-tests:
     name: Frontend Tests

--- a/scripts/agent-env.sh
+++ b/scripts/agent-env.sh
@@ -118,6 +118,7 @@ cmd_shell() {
 }
 
 run_backend_tests() {
+  compose_cmd up -d mongodb
   run_tools bash -c 'cd /workspace/backend && uv run --frozen --active pytest'
 }
 


### PR DESCRIPTION
## What

The `backend-tests` CI job ran pytest without any MongoDB service. The 14 real-MongoDB integration tests in `backend/tests/integration/test_ingestion_atomicity.py` gate on `MONGODB_URI` (`pytest.skip` when unset), so they **silently skipped on every PR** — including the lost-update concurrency sentinel that exists specifically to reproduce a data-loss race and cannot be covered by the `FakeDatabase` used everywhere else.

CI reported `971 passed, 15 skipped`; locally `agent-env.sh test backend` ran `985 passed, 1 skipped`. The 14-test gap was the entire real-Mongo coverage of the ingestion atomicity invariant.

## Changes

1. **`.github/workflows/pr-checks.yml`** — `backend-tests` job now starts `mongodb` via `docker compose up -d mongodb`, waits for the replica set (same loop the `playwright-tests` job uses), sets `MONGODB_URI`/`MONGODB_DATABASE` env on the pytest step, and tears down. Modeled on the existing e2e job setup.
2. **`scripts/agent-env.sh`** — `run_backend_tests` now runs `compose_cmd up -d mongodb` before pytest. `docker-compose.agent.yml` already set `MONGODB_URI` for the tools container, but `run_backend_tests` never started the service (only `run_e2e_tests` did), so the same 14 tests hung locally.

## Validation

- **Local (simulating CI exactly):** `docker compose up -d mongodb` + replica-set wait + `MONGODB_URI=...` env → `985 passed, 1 skipped` in 99s.
- **Local (`agent-env.sh test backend` after fix):** `985 passed, 1 skipped` in 96s.
- `test_ingestion_atomicity.py` alone: 14 passed (previously 14 skipped on CI, 14 hung/errored on local agent-env).

## Risk

The lost-update test uses `asyncio.Event`-based synchronization for a deterministic operation interleaving — it does not race on wall-clock timing, so CI runner load should not make it flake. MongoDB adds ~5-10s to the backend job (replica-set init), well under the 15-min timeout.