### PR TITLE
Isolate tests from local dotenv configuration

### DIFF
--- a/backend/app/infrastructure/config/settings.py
+++ b/backend/app/infrastructure/config/settings.py
@@ -10,7 +10,10 @@ _BACKEND_DIR = Path(__file__).resolve().parent.parent.parent.parent
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(
-        env_file=str(_BACKEND_DIR / ".env"),
+        # Keep direct Settings construction deterministic for tests and callers
+        # that provide configuration explicitly. Runtime loading of the local
+        # dotenv file is kept at the get_settings() boundary below.
+        env_file=None,
         env_file_encoding="utf-8",
         extra="ignore",
     )
@@ -126,4 +129,4 @@ class Settings(BaseSettings):
 
 @lru_cache(maxsize=1)
 def get_settings() -> Settings:
-    return Settings()
+    return Settings(_env_file=_BACKEND_DIR / ".env")

--- a/backend/tests/worker/test_exam_grading_worker.py
+++ b/backend/tests/worker/test_exam_grading_worker.py
@@ -535,25 +535,11 @@ async def test_run_worker_loop_processes_task_and_exits(
 
     settings = _make_settings(exam_grading_lease_seconds=60)
 
-    # Patch the VLMClient constructor so the worker uses our fake.
+    # Patch the worker's VLM builder so this test never makes a provider request.
     import app.infrastructure.worker.exam_grading_worker as worker_mod
 
-    original_init = worker_mod.VLMClient
-
-    class _FakeVLMWrapper:
-        def __init__(self, **kwargs: Any) -> None:
-            self._inner = vlm
-
-        async def __aenter__(self):
-            return self
-
-        async def grade_short_answer(self, **kwargs: Any):
-            return await self._inner.grade_short_answer(**kwargs)
-
-        async def aclose(self):
-            pass
-
-    worker_mod.VLMClient = lambda **kwargs: vlm  # type: ignore[misc]
+    original_builder = worker_mod.build_grading_vlm_client
+    worker_mod.build_grading_vlm_client = lambda settings: vlm  # type: ignore[assignment]
     try:
         stop = asyncio.Event()
         # Run worker briefly; it should process the one task then idle.
@@ -565,7 +551,7 @@ async def test_run_worker_loop_processes_task_and_exits(
 
         await _run_briefly()
     finally:
-        worker_mod.VLMClient = original_init  # type: ignore[misc]
+        worker_mod.build_grading_vlm_client = original_builder
 
     stored_exam = await db["exams"].find_one({"_id": exam["_id"]})
     assert stored_exam["state"] == ExamState.SUBMITTED.value


### PR DESCRIPTION
## Summary

- Keep direct `Settings()` construction deterministic by disabling implicit `backend/.env` loading.
- Load the local dotenv file explicitly at the runtime `get_settings()` boundary.
- Fix the exam grading worker test to patch the builder actually used by the worker, preventing accidental provider requests.

## Validation

- `./scripts/agent-env.sh test all`
  - Backend: 985 passed, 1 skipped
  - Frontend: 565 passed
  - E2E: 59 passed