### PR TITLE
test: forward focused test args through agent runner (#554)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -180,6 +180,12 @@ Commands:
 ./scripts/agent-env.sh test e2e         # frontend Playwright e2e with isolated services
 ./scripts/agent-env.sh test all         # backend, frontend, and e2e in sequence
 
+# Run focused tests with forwarded runner arguments
+./scripts/agent-env.sh test backend tests/api/test_practice.py
+./scripts/agent-env.sh test backend -x tests/api/test_practice.py::test_get --tb=short
+./scripts/agent-env.sh test frontend --reporter verbose
+./scripts/agent-env.sh test e2e tests/login.spec.ts
+
 # Tear down this worktree's agent stack
 ./scripts/agent-env.sh down
 

--- a/scripts/agent-env.sh
+++ b/scripts/agent-env.sh
@@ -7,8 +7,10 @@
 # Commands:
 #   build                       Build the lockfile-keyed tools image if absent.
 #   shell                       Open an interactive shell with isolated MongoDB/RustFS.
-#   test [backend|frontend|e2e|all]
+#   test [backend|frontend|e2e|all] [runner args...]
 #                               Run tests. Defaults to "all" when no selector is given.
+#                               Focused selectors forward trailing arguments to the
+#                               underlying runner; "all" accepts no trailing arguments.
 #   down [--volumes]            Remove this worktree's agent stack.
 #   help                        Show usage.
 #
@@ -119,11 +121,11 @@ cmd_shell() {
 
 run_backend_tests() {
   compose_cmd up -d mongodb
-  run_tools bash -c 'cd /workspace/backend && uv run --frozen --active pytest'
+  run_tools bash -c 'cd /workspace/backend && uv run --frozen --active pytest "$@"' _ "$@"
 }
 
 run_frontend_tests() {
-  run_tools bash -c 'cd /workspace/frontend && npm test -- --run'
+  run_tools bash -c 'cd /workspace/frontend && npm test -- --run "$@"' _ "$@"
 }
 
 run_e2e_tests() {
@@ -139,7 +141,7 @@ run_e2e_tests() {
     compose_cmd down --volumes || true
     return "$rc"
   fi
-  run_tools bash -c 'cd /workspace/frontend && npm run test:ui' || rc=$?
+  run_tools bash -c 'cd /workspace/frontend && npm run test:ui "$@"' _ "$@" || rc=$?
   compose_cmd down --volumes || true
   return "$rc"
 }
@@ -147,19 +149,32 @@ run_e2e_tests() {
 cmd_test() {
   local selector
   selector="${1:-all}"
-  ensure_image "$(image_tag)"
-  preflight
+  if [[ $# -gt 0 ]]; then
+    shift
+  fi
   case "$selector" in
     backend)
-      run_backend_tests
+      ensure_image "$(image_tag)"
+      preflight
+      run_backend_tests "$@"
       ;;
     frontend)
-      run_frontend_tests
+      ensure_image "$(image_tag)"
+      preflight
+      run_frontend_tests "$@"
       ;;
     e2e)
-      run_e2e_tests
+      ensure_image "$(image_tag)"
+      preflight
+      run_e2e_tests "$@"
       ;;
     all)
+      if [[ $# -gt 0 ]]; then
+        printf 'Error: "test all" accepts no trailing arguments (got: %s). Use a focused selector (backend, frontend, e2e) to forward arguments.\n' "$*" >&2
+        return 1
+      fi
+      ensure_image "$(image_tag)"
+      preflight
       run_backend_tests
       run_frontend_tests
       run_e2e_tests
@@ -200,8 +215,10 @@ Usage: scripts/agent-env.sh <command> [args...]
 Commands:
   build                       Build the lockfile-keyed tools image if absent.
   shell                       Open an interactive shell with isolated MongoDB/RustFS.
-  test [backend|frontend|e2e|all]
+  test [backend|frontend|e2e|all] [runner args...]
                               Run tests. Defaults to "all" when no selector is given.
+                              Focused selectors forward trailing arguments to the
+                              underlying runner; "all" accepts no trailing arguments.
   down [--volumes]            Remove this worktree's agent stack.
   help                        Show this message.
 
@@ -209,8 +226,9 @@ Examples:
   scripts/agent-env.sh build
   scripts/agent-env.sh shell
   scripts/agent-env.sh test backend
-  scripts/agent-env.sh test frontend
-  scripts/agent-env.sh test e2e
+  scripts/agent-env.sh test backend tests/api/test_practice.py
+  scripts/agent-env.sh test frontend --reporter verbose
+  scripts/agent-env.sh test e2e tests/login.spec.ts
   scripts/agent-env.sh test all
   scripts/agent-env.sh down
   scripts/agent-env.sh down --volumes

--- a/scripts/agent-env.test.sh
+++ b/scripts/agent-env.test.sh
@@ -151,6 +151,163 @@ test_invalid_args() {
   if [ "$rc" -eq 0 ]; then pass "help exits zero"; else fail "help exits zero (rc=$rc)"; fi
 }
 
+# ---------------------------------------------------------------------------
+# Regression tests for focused test-argument forwarding (issue #554).
+# Source agent-env.sh, stub the Docker/image functions, and capture the argv
+# that reaches run_backend_tests/run_frontend_tests/run_e2e_tests.
+# ---------------------------------------------------------------------------
+
+CAPTURE_FILE=""
+
+setup_forwarding_stubs() {
+  CAPTURE_FILE="$(mktemp)"
+  : > "$CAPTURE_FILE"
+  # Override Docker-touching functions so cmd_test never calls Docker.
+  ensure_image() { :; }
+  preflight() { :; }
+  compose_cmd() { :; }
+  # Capture the argv array as one arg per line into CAPTURE_FILE.
+  run_backend_tests() {
+    local i=0
+    for a in "$@"; do printf '%s\n' "$a" >> "$CAPTURE_FILE"; i=$((i+1)); done
+    printf 'BACKEND:%s\n' "$i" >> "$CAPTURE_FILE"
+  }
+  run_frontend_tests() {
+    local i=0
+    for a in "$@"; do printf '%s\n' "$a" >> "$CAPTURE_FILE"; i=$((i+1)); done
+    printf 'FRONTEND:%s\n' "$i" >> "$CAPTURE_FILE"
+  }
+  run_e2e_tests() {
+    local i=0
+    for a in "$@"; do printf '%s\n' "$a" >> "$CAPTURE_FILE"; i=$((i+1)); done
+    printf 'E2E:%s\n' "$i" >> "$CAPTURE_FILE"
+  }
+}
+
+teardown_forwarding_stubs() {
+  [ -n "$CAPTURE_FILE" ] && rm -f "$CAPTURE_FILE"
+  unset -f ensure_image preflight run_backend_tests run_frontend_tests run_e2e_tests
+  unset CAPTURE_FILE
+  # Re-source agent-env.sh to restore the original functions we overrode.
+  # shellcheck source=agent-env.sh
+  source "$script_dir/agent-env.sh"
+}
+
+# Call cmd_test with the given args and return the captured argv lines.
+capture_cmd_test() {
+  : > "$CAPTURE_FILE"
+  cmd_test "$@" 2>/dev/null || true
+  cat "$CAPTURE_FILE"
+}
+
+test_forward_backend_single_arg() {
+  printf '%s\n' "test_forward_backend_single_arg"
+  setup_forwarding_stubs
+  local out
+  out="$(capture_cmd_test backend tests/api/test_practice.py)"
+  local count
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/BACKEND://')"
+  assert_eq "backend forwards 1 arg" "$count" "1"
+  assert_eq "backend arg is the file path" "$(printf '%s' "$out" | head -1)" "tests/api/test_practice.py"
+  teardown_forwarding_stubs
+}
+
+test_forward_backend_multiple_args_preserve_order() {
+  printf '%s\n' "test_forward_backend_multiple_args_preserve_order"
+  setup_forwarding_stubs
+  local out
+  out="$(capture_cmd_test backend -x tests/api/test_practice.py::test_get --tb=short)"
+  local count
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/BACKEND://')"
+  assert_eq "backend forwards 3 args" "$count" "3"
+  assert_eq "backend arg 1 order preserved" "$(printf '%s\n' "$out" | sed -n '1p')" "-x"
+  assert_eq "backend arg 2 order preserved" "$(printf '%s\n' "$out" | sed -n '2p')" "tests/api/test_practice.py::test_get"
+  assert_eq "backend arg 3 order preserved" "$(printf '%s\n' "$out" | sed -n '3p')" "--tb=short"
+  teardown_forwarding_stubs
+}
+
+test_forward_backend_arg_with_space() {
+  printf '%s\n' "test_forward_backend_arg_with_space"
+  setup_forwarding_stubs
+  local out
+  out="$(capture_cmd_test backend "some path with spaces.py")"
+  local count
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/BACKEND://')"
+  assert_eq "backend forwards 1 arg with spaces" "$count" "1"
+  assert_eq "backend arg with spaces is one arg" "$(printf '%s' "$out" | head -1)" "some path with spaces.py"
+  teardown_forwarding_stubs
+}
+
+test_forward_frontend_args() {
+  printf '%s\n' "test_forward_frontend_args"
+  setup_forwarding_stubs
+  local out
+  out="$(capture_cmd_test frontend --reporter verbose)"
+  local count
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/FRONTEND://')"
+  assert_eq "frontend forwards 2 args" "$count" "2"
+  assert_eq "frontend arg 1 preserved" "$(printf '%s\n' "$out" | sed -n '1p')" "--reporter"
+  assert_eq "frontend arg 2 preserved" "$(printf '%s\n' "$out" | sed -n '2p')" "verbose"
+  teardown_forwarding_stubs
+}
+
+test_forward_e2e_args() {
+  printf '%s\n' "test_forward_e2e_args"
+  setup_forwarding_stubs
+  local out
+  out="$(capture_cmd_test e2e tests/login.spec.ts --grep auth)"
+  local count
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/E2E://')"
+  assert_eq "e2e forwards 3 args" "$count" "3"
+  assert_eq "e2e arg 1 preserved" "$(printf '%s\n' "$out" | sed -n '1p')" "tests/login.spec.ts"
+  assert_eq "e2e arg 2 preserved" "$(printf '%s\n' "$out" | sed -n '2p')" "--grep"
+  assert_eq "e2e arg 3 preserved" "$(printf '%s\n' "$out" | sed -n '3p')" "auth"
+  teardown_forwarding_stubs
+}
+
+test_reject_test_all_with_trailing_args() {
+  printf '%s\n' "test_reject_test_all_with_trailing_args"
+  setup_forwarding_stubs
+  : > "$CAPTURE_FILE"
+  local rc=0
+  cmd_test all extra-arg 2>/dev/null && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "test all with trailing args exits non-zero"; else fail "test all with trailing args exits non-zero (rc=$rc)"; fi
+  # No runner should have been called.
+  if [ -s "$CAPTURE_FILE" ]; then
+    fail "test all with trailing args must not invoke any runner"
+  else
+    pass "test all with trailing args invokes no runner"
+  fi
+  teardown_forwarding_stubs
+}
+
+test_reject_bare_test_with_trailing_args() {
+  printf '%s\n' "test_reject_bare_test_with_trailing_args"
+  setup_forwarding_stubs
+  : > "$CAPTURE_FILE"
+  local rc=0
+  cmd_test --some-flag 2>/dev/null && rc=$? || rc=$?
+  if [ "$rc" -ne 0 ]; then pass "bare test with trailing args exits non-zero"; else fail "bare test with trailing args exits non-zero (rc=$rc)"; fi
+  teardown_forwarding_stubs
+}
+
+test_selector_only_commands_unchanged() {
+  printf '%s\n' "test_selector_only_commands_unchanged"
+  setup_forwarding_stubs
+  local out
+  out="$(capture_cmd_test backend)"
+  local count
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/BACKEND://')"
+  assert_eq "backend with no args forwards 0 args" "$count" "0"
+  out="$(capture_cmd_test frontend)"
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/FRONTEND://')"
+  assert_eq "frontend with no args forwards 0 args" "$count" "0"
+  out="$(capture_cmd_test e2e)"
+  count="$(printf '%s\n' "$out" | tail -1 | sed 's/E2E://')"
+  assert_eq "e2e with no args forwards 0 args" "$count" "0"
+  teardown_forwarding_stubs
+}
+
 test_config_no_fixed_names_no_host_ports() {
   printf '%s\n' "test_config_no_fixed_names_no_host_ports"
   reset_repo_root
@@ -1162,6 +1319,14 @@ main() {
   test_fingerprint_stable
   test_fingerprint_changes
   test_invalid_args
+  test_forward_backend_single_arg
+  test_forward_backend_multiple_args_preserve_order
+  test_forward_backend_arg_with_space
+  test_forward_frontend_args
+  test_forward_e2e_args
+  test_reject_test_all_with_trailing_args
+  test_reject_bare_test_with_trailing_args
+  test_selector_only_commands_unchanged
   test_config_no_fixed_names_no_host_ports
   test_image_build_and_exit_code
   test_cleanup_scoped_to_worktree


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Forward trailing runner arguments verbatim through focused `test backend|frontend|e2e` selectors while rejecting trailing arguments for bare `test` and explicit `test all`.
- `cmd_test` shifts the selector and passes `"$@"` to the selected runner function; `all` rejects any trailing arguments with a clear message and nonzero status.
- Runner functions (`run_backend_tests`, `run_frontend_tests`, `run_e2e_tests`) forward `"$@"` into the in-container command via `bash -c '... "$@"' _ "$@"`, preserving argument order, quoting, and whitespace.

## Linked Issue

Closes #554

## Issue Alignment

This PR implements the issue by:

- Shifting the selector in `cmd_test` and retaining the remaining argument array for forwarding.
- Forwarding trailing arguments to the existing backend, frontend, and E2E runner functions via `"$@"` without reparsing.
- Rejecting trailing arguments for implicit `all` (bare `test` with extra args hits unknown selector) and explicit `test all`.
- Adding shell stub tests capturing exact argv boundaries for all three focused selectors.
- Adding rejection tests for `test all` and bare `test` with trailing args.
- Updating `scripts/agent-env.sh` usage/help and `DEVELOPMENT.md` examples.

Scope covered:

- Focused selector grammar and argv forwarding.
- Rejection of ambiguous `all` arguments.
- Shell stub tests for forwarding and rejection.
- Usage and development documentation.

Out of scope / intentionally not included:

- `backend-real` lifecycle (T-01 / #555 owns it).
- New test-runner abstraction.
- Docker/service lifecycle changes.

## Implementation Notes

- `run_tools bash -c 'cmd "$@"' _ "$@"` pattern: the `_` is `$0` for the `bash -c` script, and `"$@"` passes the forwarded args as positional parameters inside the script. This preserves quoting and whitespace without string re-evaluation.
- `ensure_image` and `preflight` are called per-branch (only when a valid selector is chosen), so unknown selectors and `all`-with-args fail fast without touching Docker.
- `all` branch checks `[[ $# -gt 0 ]]` before invoking any runner, so no Docker lifecycle is started when trailing args are supplied.

## Tests

Commands run:

- `bash scripts/agent-env.test.sh` — passed (140 passed, 0 failed)
- `bash scripts/agent-env.sh help` — passed (usage shows forwarding grammar)
- `bash scripts/agent-env.sh test all extra-arg` — failed as expected (rc=1, clear error)
- `bash scripts/agent-env.sh test unknown-selector` — failed as expected (rc=1)

Automated tests added or updated:

- `test_forward_backend_single_arg` — single argument reaches backend runner.
- `test_forward_backend_multiple_args_preserve_order` — 3 args preserve order including option/value pairs.
- `test_forward_backend_arg_with_space` — quoted whitespace stays one argument.
- `test_forward_frontend_args` — 2 args forwarded to frontend runner.
- `test_forward_e2e_args` — 3 args forwarded to e2e runner.
- `test_reject_test_all_with_trailing_args` — nonzero exit, no runner invoked.
- `test_reject_bare_test_with_trailing_args` — nonzero exit (unknown selector path).
- `test_selector_only_commands_unchanged` — selector-only commands forward 0 args.

Manual verification:

- Verified `test all extra-arg` prints: `Error: "test all" accepts no trailing arguments (got: extra-arg). Use a focused selector (backend, frontend, e2e) to forward arguments.` and exits rc=1.
- Verified `test unknown-selector` prints unknown selector error and exits rc=1.
- Verified help text matches tested grammar.

## Deviations From Issue Plan

None.

## Follow-Up Work

#555 adds `backend-real [pytest args...]` using this forwarding grammar.
