### PR TITLE
test: remove dead backend visual helpers (#561)

### DIFF
--- a/backend/tests/visual/test_graph_rendering.py
+++ b/backend/tests/visual/test_graph_rendering.py
@@ -8,13 +8,11 @@ from __future__ import annotations
 
 import base64
 import json
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-from .conftest import GRAPH_TEST_CORPUS, GraphTestCase
+from .conftest import GRAPH_TEST_CORPUS
 
 
 def test_harness_file_exists(harness_html_path: Path) -> None:
@@ -62,109 +60,3 @@ def test_url_encoding() -> None:
     padded = encoded + "=" * (4 - len(encoded) % 4)
     decoded = json.loads(base64.urlsafe_b64decode(padded.encode()).decode())
     assert decoded["dsl"] == test_dsl, "Decoded DSL should match original"
-
-
-@pytest.mark.skip(reason="Visual validation requires agent environment with browser tools")
-def test_graph_rendering_corpus_full(
-    visual_evidence_dir: Path,
-    harness_html_path: Path,
-) -> None:
-    """Full visual validation test - runs in agent environment.
-    
-    This test is skipped in normal pytest runs because it requires
-    the agent environment with access to playwright browser tools.
-    To run visual validation, execute the test via the agent with
-    the browser automation tools available.
-    """
-    pass
-
-
-def run_visual_validation(
-    visual_evidence_dir: Path,
-    harness_html_path: Path,
-    browser_viewport_size: dict,
-) -> list[tuple[str, str]]:
-    """Run visual validation for all test cases.
-    
-    This function is called when the test is run in agent mode.
-    It uses the actual browser tools to capture screenshots and
-    validate them using look_at.
-    
-    Returns list of (test_name, error_message) tuples. Empty error
-    message means the test passed.
-    """
-    import asyncio
-    
-    results = []
-    for test_case in GRAPH_TEST_CORPUS:
-        result = asyncio.run(_validate_single_case(
-            test_case=test_case,
-            visual_evidence_dir=visual_evidence_dir,
-            harness_html_path=harness_html_path,
-            browser_viewport_size=browser_viewport_size,
-        ))
-        results.append((test_case.name, result))
-    return results
-
-
-async def _validate_single_case(
-    test_case: GraphTestCase,
-    visual_evidence_dir: Path,
-    harness_html_path: Path,
-    browser_viewport_size: dict,
-) -> str:
-    """Validate a single test case.
-    
-    Returns empty string on success, error message on failure.
-    """
-    import sys
-    sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
-    from tools import playwright_browser_navigate, playwright_browser_resize, playwright_browser_wait_for, playwright_browser_take_screenshot, look_at
-    
-    url = _build_harness_url(test_case.dsl, harness_html_path)
-    screenshot_path = visual_evidence_dir / f"{test_case.name}.png"
-    
-    try:
-        await playwright_browser_navigate(url=url)
-        await playwright_browser_resize(width=browser_viewport_size["width"], height=browser_viewport_size["height"])
-        await playwright_browser_wait_for(time=1.5)
-        await playwright_browser_take_screenshot(filename=str(screenshot_path))
-    except Exception as exc:
-        return f"Screenshot capture failed: {exc}"
-    
-    # Validate the screenshot
-    if test_case.expect_error:
-        goal = (
-            f"Analyze this JSXGraph rendering screenshot for test case '{test_case.name}'. "
-            f"Expected: {test_case.description}. "
-            f"Confirm that an error state is shown (error message, empty area, or no valid graph). "
-            f"Answer with ONLY 'PASS' if the error state is correctly shown, or 'FAIL: <reason>' if not."
-        )
-    else:
-        goal = (
-            f"Analyze this JSXGraph rendering screenshot for test case '{test_case.name}'. "
-            f"Expected visual content: {test_case.description}. "
-            f"Answer with ONLY 'PASS' if the described visual content is present and correctly rendered, "
-            f"or 'FAIL: <reason>' if the expected geometry is missing or incorrect."
-        )
-    
-    try:
-        result = look_at(file_path=str(screenshot_path), goal=goal)
-    except Exception as exc:
-        return f"Multimodal validation error: {exc}"
-    
-    result_text = result.lower().strip() if isinstance(result, str) else str(result).lower().strip()
-    
-    if result_text.startswith("pass"):
-        return ""
-    elif result_text.startswith("fail"):
-        return result_text[5:].strip() if result_text.startswith("fail:") else "Visual validation failed"
-    else:
-        return f"Unexpected validation response: {result}"
-
-
-def _build_harness_url(dsl: str, harness_html_path: Path) -> str:
-    """Build the harness URL with DSL encoded in hash parameter."""
-    json_payload = json.dumps({"dsl": dsl})
-    encoded = base64.urlsafe_b64encode(json_payload.encode()).decode().rstrip("=")
-    return f"file://{harness_html_path}#{encoded}"


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Removed the unreachable skipped `test_graph_rendering_corpus_full` and its dead helper chain (`run_visual_validation`, `_validate_single_case`, `_build_harness_url`) that import agent-only browser tooling unavailable in the backend pytest suite.
- Removed imports orphaned solely by this deletion: `subprocess`, `sys`, and `GraphTestCase`.
- Retained `GRAPH_TEST_CORPUS`, the four live structural/encoding tests, `visual-test-harness.html`, and `GraphSandbox.iframe.ts` unchanged.

## Linked Issue

Closes #561

## Issue Alignment

This PR implements the issue by:

- Performing a repository-wide consumer search for all five named symbols (`test_graph_rendering_corpus_full`, `run_visual_validation`, `_validate_single_case`, `_build_harness_url`) — all confined to `backend/tests/visual/test_graph_rendering.py` with no external callers.
- Deleting exactly the dead test and three helper functions.
- Removing only imports made unused by this deletion: `subprocess` (unused after deletion), `sys` (used only in deleted `_validate_single_case`), and `GraphTestCase` (used only in deleted `_validate_single_case`).
- Retaining `GRAPH_TEST_CORPUS`, structural tests/fixtures, harness HTML, and iframe source.

Scope covered:

- Dead test and helper chain deletion.
- Orphaned import removal.

Out of scope / intentionally not included:

- New screenshot/multimodal/visual-testing platform.
- Changes to frontend graph assets or behavior.
- Changes to corpus cases or structural assertions.
- Adjacent formatting/refactoring.

## Implementation Notes

- The four remaining tests (`test_harness_file_exists`, `test_evidence_directory_exists`, `test_corpus_definitions`, `test_url_encoding`) use `base64`, `json`, `Path`, `pytest`, and `GRAPH_TEST_CORPUS` — all retained.
- `GraphTestCase` remains exported from `conftest.py`; only the unused import in this file was removed.

## Tests

Commands run:

- `pytest tests/visual/test_graph_rendering.py -v` — passed (4 passed, 0 skipped; previously 4 passed + 1 skipped)
- `pytest -q` (full backend suite) — passed (971 passed, 14 skipped, 0 errors)

Automated tests added or updated:

- None; this is a deletion-only change. The skipped test count dropped by one in the visual module (0 skips now).

Manual verification:

- Confirmed `backend/tests/visual/conftest.py`, `frontend/src/visual-test-harness.html`, `frontend/src/components/GraphSandbox.iframe.ts`, and `frontend/tests/graph-sandbox-security.spec.ts` are unchanged (only `test_graph_rendering.py` modified).
- Repository-wide `rg` search confirmed the five symbols have no consumers outside the deleted file.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
