### PR TITLE
ci: add Compose browser smoke workflow for merge-queue and nightly (#559)

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -1,0 +1,111 @@
+name: Compose Browser Smoke
+
+on:
+  merge_group:
+    types: [checks_requested]
+  schedule:
+    # Nightly at 03:00 UTC
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: compose-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compose-browser-smoke:
+    name: Compose Browser Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create backend .env
+        run: |
+          mkdir -p backend
+          echo "VLM_API_KEY=ci-placeholder" >> backend/.env
+          echo "S3_ACCESS_KEY=minioadmin" >> backend/.env
+          echo "S3_SECRET_KEY=minioadmin" >> backend/.env
+
+      - name: Build and start full Compose
+        run: docker compose up -d --build --wait
+        env:
+          DOCKER_BUILDKIT: 1
+
+      - name: Bootstrap storage
+        run: docker compose --profile bootstrap run --rm rustfs-bootstrap
+
+      - name: Verify backend readiness
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://localhost:8000/api/health; then
+              echo "Backend is ready"
+              exit 0
+            fi
+            echo "Waiting for backend... ($i)"
+            sleep 2
+          done
+          echo "Backend did not become ready in time"
+          docker compose logs backend
+          exit 1
+
+      - name: Verify frontend readiness
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://localhost:8080/healthz; then
+              echo "Frontend is ready"
+              exit 0
+            fi
+            echo "Waiting for frontend... ($i)"
+            sleep 2
+          done
+          echo "Frontend did not become ready in time"
+          docker compose logs frontend
+          exit 1
+
+      - name: Run Compose browser smoke
+        id: smoke
+        working-directory: frontend
+        run: npm run test:smoke:compose
+
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-smoke-test-results
+          path: frontend/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+        continue-on-error: true
+
+      - name: Tear down Compose
+        if: always()
+        run: docker compose down --volumes

--- a/frontend/playwright.compose.config.ts
+++ b/frontend/playwright.compose.config.ts
@@ -9,5 +9,7 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:8080",
     headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
 });


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Created a dedicated `.github/workflows/compose-smoke.yml` workflow triggered only by `merge_group: checks_requested` and nightly cron `0 3 * * *` — never on `pull_request`.
- The workflow builds the full Compose stack, bootstraps storage, verifies backend/frontend readiness, runs the existing Compose browser smoke spec, uploads failure-only diagnostics, and always tears down volumes.
- Added `trace: "retain-on-failure"` and `screenshot: "only-on-failure"` to `frontend/playwright.compose.config.ts` so smoke failures produce inspectable evidence.

## Linked Issue

Closes #559

## Issue Alignment

This PR implements the issue by:

- Creating a separate Compose-browser workflow with only merge-group and nightly triggers (no PR trigger).
- Setting up Node 20, npm ci, and Chromium with system dependencies.
- Creating `backend/.env` with CI placeholder values.
- Building/starting full Compose, bootstrapping storage, and verifying `/api/health` (8000) and `/healthz` (8080).
- Running `npm run test:smoke:compose` against 8080/8000.
- Configuring Compose Playwright trace/screenshot failure retention.
- Adding a failure-only artifact upload with unique name, 7-day retention, `if-no-files-found: ignore`, and `continue-on-error: true`.
- Adding always-run `docker compose down --volumes` teardown.

Scope covered:

- Dedicated workflow file with exact triggers.
- Ordered setup → start → readiness → smoke → upload → teardown steps.
- Compose Playwright failure diagnostics configuration.

Out of scope / intentionally not included:

- A pull-request trigger.
- Changes to the direct-uvicorn E2E job/config.
- Merging Playwright configs.
- Retries, worker increases, or broader browser coverage.

## Implementation Notes

- The workflow uses `docker compose up -d --build --wait` to build and wait for all services to be healthy before proceeding.
- Readiness probes use bounded loops (30 iterations × 2s) for both backend (`/api/health` on 8000) and frontend (`/healthz` on 8080).
- The smoke step has `id: smoke` so the upload step can condition on `if: failure()`.
- The artifact upload step uses `continue-on-error: true` so a broken upload cannot mask a smoke failure.
- The teardown step uses `if: always()` so volumes are cleaned up regardless of outcome.
- The `playwright.compose.config.ts` additions are minimal: only `trace` and `screenshot` options in the `use` block.

## Tests

Commands run:

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/compose-smoke.yml'))"` — YAML valid
- `npx tsc --noEmit --project tsconfig.json` — no errors in changed files
- `npx vitest run` (full frontend suite) — 565 passed, 0 failed
- `grep -n "pull_request" .github/workflows/compose-smoke.yml` — no matches (confirms no PR trigger)

Automated tests added or updated:

- None (workflow creation + config addition; existing `compose-smoke.spec.ts` is unchanged).

Manual verification:

- Confirmed the workflow has only `merge_group` and `schedule` triggers — no `pull_request` or `push`.
- Confirmed lifecycle step order: checkout → Node → npm ci → Playwright install → Docker Buildx → .env → Compose up → bootstrap → backend readiness → frontend readiness → smoke → upload (failure only) → teardown (always).
- Confirmed the artifact upload uses `if: failure()`, `if-no-files-found: ignore`, `continue-on-error: true`, and 7-day retention.
- Confirmed the teardown uses `if: always()`.
- Confirmed `pr-checks.yml` is unchanged (direct E2E job not modified).
- Local Compose smoke execution and disposable-failure validation require the full Docker stack; CI will validate on merge-queue/nightly runs.

## Deviations From Issue Plan

None.

## Follow-Up Work

None. Per HD-001, the workflow can be removed as the bounded rollback if it proves disproportionate.
