### PR TITLE
test: preserve Playwright failure diagnostics for direct E2E (#557)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -162,6 +162,16 @@ jobs:
           S3_ACCESS_KEY: minioadmin
           S3_SECRET_KEY: minioadmin
 
+      - name: Upload Playwright failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-e2e-test-results
+          path: frontend/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+        continue-on-error: true
+
       - name: Tear down infrastructure
         if: always()
         run: docker compose down --volumes

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
   use: {
     baseURL: "http://127.0.0.1:5173",
     headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
   webServer: [
     {


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Added `trace: "retain-on-failure"` and `screenshot: "only-on-failure"` to `frontend/playwright.config.ts` (the direct-uvicorn E2E config).
- Added a failure-only artifact upload step to the `playwright-tests` CI job in `.github/workflows/pr-checks.yml` with unique name `playwright-e2e-test-results`, 7-day retention, `if-no-files-found: ignore`, and `continue-on-error: true`.
- Passing runs produce no browser diagnostic artifacts.

## Linked Issue

Closes #557

## Issue Alignment

This PR implements the issue by:

- Configuring `trace: "retain-on-failure"` and `screenshot: "only-on-failure"` directly in the existing direct-E2E config (`playwright.config.ts`).
- Adding one `actions/upload-artifact@v4` step guarded by `if: failure()` after the test step and before the always-run teardown.
- Using a unique artifact name (`playwright-e2e-test-results`), 7-day retention, and `if-no-files-found: ignore`.

Scope covered:

- Direct-E2E Playwright config trace/screenshot options.
- Direct-E2E CI job failure-only artifact upload.

Out of scope / intentionally not included:

- Videos or retries.
- Passing-run artifacts.
- Compose workflow/config changes (T-03/#559 handles those independently).
- Shared Playwright config abstraction.
- Increasing Playwright workers.

## Implementation Notes

- The upload step is placed between the test step and the teardown step. It uses `if: failure()` so it only triggers on test failure. `continue-on-error: true` ensures a broken upload cannot mask a test failure.
- The teardown step remains `if: always()` so infrastructure is cleaned up regardless.
- The `playwright.config.ts` additions are 2 lines in the existing `use` block — no abstraction or shared config.

## Tests

Commands run:

- `npx vitest run` (full frontend suite) — 565 passed, 0 failed
- Disposable failing assertion in `graph-sandbox-security.spec.ts`:
  - `npx playwright test tests/graph-sandbox-security.spec.ts --grep "DISPOSABLE"` — failed as expected, generated `trace.zip` (4730 bytes) and `error-context.md` in `test-results/`
- Normal focused spec after removing disposable assertion:
  - `npx playwright test tests/graph-sandbox-security.spec.ts` — 2 passed, no trace/screenshot artifacts generated
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-checks.yml'))"` — YAML valid

Automated tests added or updated:

- None (config + CI workflow changes only; existing specs unchanged).

Manual verification:

- **Disposable failure:** Added `expect(false).toBe(true)` test, ran it, confirmed `trace.zip` and `error-context.md` were generated in `frontend/test-results/`. Inspected the trace zip file (4730 bytes).
- **Passing run:** Removed the disposable test, reran the spec — 2 passed, `test-results/` contained only `.last-run.json` (no trace/screenshot).
- **CI failing case:** Will be validated by CI on this PR (the workflow change itself is in the same job; a future failing E2E test will trigger the upload).
- **CI passing case:** Will be validated by CI on this PR — all checks passing means no `playwright-e2e-test-results` artifact should appear.

## Deviations From Issue Plan

None.

## Follow-Up Work

None. T-03 (#559) independently applies the diagnostic contract to Compose smoke via PR #566.
