### PR TITLE
Decouple solution regeneration conflicts from HTTP errors

### DIFF
--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -36,7 +36,10 @@ from app.presentation.problem_serialization import (
     _serialize_tracking,
     problem_document_to_model,
 )
-from app.solution_generation import regenerate_solution_task_for_problem
+from app.solution_generation import (
+    SolutionRegenerationConflict,
+    regenerate_solution_task_for_problem,
+)
 from app.presentation.tag_registration import _register_tags
 from app.presentation.teacher_password import _ensure_teacher_password_hash
 
@@ -474,11 +477,14 @@ async def regenerate_solution(
         current_user["_id"],
         allow_deleted=False,
     )
-    status = await regenerate_solution_task_for_problem(
-        database,
-        str(problem["_id"]),
-        str(current_user["_id"]),
-    )
+    try:
+        status = await regenerate_solution_task_for_problem(
+            database,
+            str(problem["_id"]),
+            str(current_user["_id"]),
+        )
+    except SolutionRegenerationConflict as exc:
+        raise ApiError(409, exc.code, exc.message) from exc
     return SolutionStatusResponse(status=status)
 
 

--- a/backend/app/solution_generation.py
+++ b/backend/app/solution_generation.py
@@ -14,9 +14,21 @@ from app.infrastructure.storage.mongo import (
     SOLUTION_GENERATION_TASKS_COLLECTION,
 )
 from app.observability import log_solution_generation_event
-from app.presentation.errors import ApiError
 
 SOLUTION_BACKFILL_BATCH_SIZE = 100
+
+
+class SolutionRegenerationConflict(Exception):
+    """Raised when a solution cannot be regenerated because of state conflict.
+
+    Carries the stable semantic code and message only; the HTTP presentation
+    layer translates it into a 409 ``ApiError`` response.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
 
 
 def _utc_now() -> datetime:
@@ -49,6 +61,13 @@ async def enqueue_solution_generation_task_for_problem(
     *,
     now: datetime | None = None,
 ) -> bool:
+    """Enqueue a pending solution-generation task for a problem.
+
+    Returns ``True`` when a task was created, ``False`` when a task or
+    canonical solution already exists for the problem (idempotent no-op).
+    Raises ``KeyError`` when the solution-generation collections are
+    unavailable.
+    """
     tasks = _safe_get_collection(database, SOLUTION_GENERATION_TASKS_COLLECTION)
     solutions = _safe_get_collection(database, CANONICAL_SOLUTIONS_COLLECTION)
     if tasks is None or solutions is None:
@@ -156,7 +175,7 @@ async def regenerate_solution_task_for_problem(
       - ``failed``: reset the failed task to pending.
 
     Ineligible states (``none``, ``pending``, ``generating``) raise
-    ``ApiError(409)``.
+    ``SolutionRegenerationConflict``.
 
     Returns ``"pending"`` on success.
     """
@@ -193,14 +212,12 @@ async def regenerate_solution_task_for_problem(
             await _reset_task_to_pending(tasks, existing_task["_id"], now=current_time)
             log_solution_generation_event("regenerate", problem_id)
             return SolutionGenerationStatus.PENDING.value
-        raise ApiError(
-            409,
+        raise SolutionRegenerationConflict(
             "SOLUTION_REGENERATION_CONFLICT",
             "Solution is already pending or generating.",
         )
 
-    raise ApiError(
-        409,
+    raise SolutionRegenerationConflict(
         "SOLUTION_REGENERATION_CONFLICT",
         "No solution to regenerate.",
     )

--- a/backend/tests/api/test_problems.py
+++ b/backend/tests/api/test_problems.py
@@ -768,7 +768,9 @@ async def test_regenerate_solution_rejects_ineligible_active_states(
     response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
 
     assert response.status_code == 409
-    assert response.json()["error"]["code"] == "SOLUTION_REGENERATION_CONFLICT"
+    body = response.json()["error"]
+    assert body["code"] == "SOLUTION_REGENERATION_CONFLICT"
+    assert body["message"] == "Solution is already pending or generating."
 
     # task unchanged
     tasks = await database["solution_generation_tasks"].find(
@@ -791,7 +793,9 @@ async def test_regenerate_solution_rejects_none_state(
     response = await client.post(f"/api/v1/problems/{problem_id_str}/solution-regeneration")
 
     assert response.status_code == 409
-    assert response.json()["error"]["code"] == "SOLUTION_REGENERATION_CONFLICT"
+    body = response.json()["error"]
+    assert body["code"] == "SOLUTION_REGENERATION_CONFLICT"
+    assert body["message"] == "No solution to regenerate."
 
 
 @pytest.mark.asyncio

--- a/backend/tests/presentation/test_solution_generation.py
+++ b/backend/tests/presentation/test_solution_generation.py
@@ -3,7 +3,8 @@
 These tests lock down the current enqueue/backfill/regenerate behavior of the
 solution-generation orchestration module so a module move can be verified to
 preserve behavior. They assert task document shape, idempotency, unavailable
-collection handling, backfill cases, and exact ``ApiError`` semantics.
+collection handling, backfill cases, and exact
+``SolutionRegenerationConflict`` semantics.
 """
 
 from __future__ import annotations
@@ -15,9 +16,9 @@ import pytest
 from bson import ObjectId
 
 from app.domain.models import SolutionGenerationStatus
-from app.presentation.errors import ApiError
 from app.solution_generation import (
     SOLUTION_BACKFILL_BATCH_SIZE,
+    SolutionRegenerationConflict,
     backfill_solution_generation_tasks,
     enqueue_solution_generation_task_for_problem,
     regenerate_solution_task_for_problem,
@@ -298,7 +299,7 @@ async def test_regenerate_failed_resets_task_to_pending() -> None:
 
 
 @pytest.mark.asyncio
-async def test_regenerate_pending_conflict_raises_exact_api_error() -> None:
+async def test_regenerate_pending_conflict_raises_exact_conflict() -> None:
     database = FakeDatabase()
     problem = _make_problem()
     problem_id = str(problem["_id"])
@@ -306,18 +307,17 @@ async def test_regenerate_pending_conflict_raises_exact_api_error() -> None:
         {"problem_id": problem_id, "status": SolutionGenerationStatus.PENDING.value}
     )
 
-    with pytest.raises(ApiError) as exc_info:
+    with pytest.raises(SolutionRegenerationConflict) as exc_info:
         await regenerate_solution_task_for_problem(
             database, problem_id, str(problem["userId"]), now=NOW
         )
 
-    assert exc_info.value.status_code == 409
     assert exc_info.value.code == "SOLUTION_REGENERATION_CONFLICT"
     assert exc_info.value.message == "Solution is already pending or generating."
 
 
 @pytest.mark.asyncio
-async def test_regenerate_generating_conflict_raises_exact_api_error() -> None:
+async def test_regenerate_generating_conflict_raises_exact_conflict() -> None:
     database = FakeDatabase()
     problem = _make_problem()
     problem_id = str(problem["_id"])
@@ -325,27 +325,25 @@ async def test_regenerate_generating_conflict_raises_exact_api_error() -> None:
         {"problem_id": problem_id, "status": SolutionGenerationStatus.GENERATING.value}
     )
 
-    with pytest.raises(ApiError) as exc_info:
+    with pytest.raises(SolutionRegenerationConflict) as exc_info:
         await regenerate_solution_task_for_problem(
             database, problem_id, str(problem["userId"]), now=NOW
         )
 
-    assert exc_info.value.status_code == 409
     assert exc_info.value.code == "SOLUTION_REGENERATION_CONFLICT"
     assert exc_info.value.message == "Solution is already pending or generating."
 
 
 @pytest.mark.asyncio
-async def test_regenerate_no_solution_no_task_raises_exact_api_error() -> None:
+async def test_regenerate_no_solution_no_task_raises_exact_conflict() -> None:
     database = FakeDatabase()
     problem = _make_problem()
     problem_id = str(problem["_id"])
 
-    with pytest.raises(ApiError) as exc_info:
+    with pytest.raises(SolutionRegenerationConflict) as exc_info:
         await regenerate_solution_task_for_problem(
             database, problem_id, str(problem["userId"]), now=NOW
         )
 
-    assert exc_info.value.status_code == 409
     assert exc_info.value.code == "SOLUTION_REGENERATION_CONFLICT"
     assert exc_info.value.message == "No solution to regenerate."


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Remove the HTTP-layer `ApiError` dependency from the shared solution-regeneration workflow by introducing a workflow-specific `SolutionRegenerationConflict` exception.
- The presentation route becomes the sole HTTP translation point, constructing the existing 409 `ApiError` payload from the workflow exception.
- Public 409 responses, semantic code, messages, and all non-conflict workflow behavior are unchanged.

## Linked Issue

Closes #571

## Issue Alignment

This PR implements the issue by:

- Defining `SolutionRegenerationConflict` in `backend/app/solution_generation.py` carrying the semantic code `SOLUTION_REGENERATION_CONFLICT` and a message, with no HTTP status.
- Replacing only the two conflict-branch `ApiError` raises (pending/generating and no-solution) with `SolutionRegenerationConflict`.
- Catching and translating the exception in `backend/app/presentation/problems.py` to the existing 409 `ApiError` payload.
- Correcting the regeneration docstring to name `SolutionRegenerationConflict` instead of `ApiError(409)`.
- Adding a short enqueue return-contract docstring documenting idempotent `False` behavior.

Scope covered:

- `SolutionRegenerationConflict` exception class.
- Two conflict-branch raises replaced.
- Route translation point.
- Regeneration and enqueue docstrings.
- Workflow and API test assertions.

Out of scope / intentionally not included:

- Generic error base classes or a shared error framework.
- The unavailable-collections `KeyError` path.
- Changes to enqueue/backfill behavior or idempotent `False` returns.
- Changes to task reset/state semantics, persistence, logging, or workers.

## Implementation Notes

- `SolutionRegenerationConflict` is defined beside the regeneration workflow in `solution_generation.py` and carries only `code` and `message` (no HTTP status).
- The route wraps the workflow call in `try/except SolutionRegenerationConflict` and re-raises as `ApiError(409, exc.code, exc.message)`, preserving the exact public contract.
- The `KeyError`, ready/failed transitions, enqueue, backfill, task state, persistence, and logging paths are untouched.

## Tests

Commands run:

- `uv run --frozen pytest tests/presentation/test_solution_generation.py tests/presentation/test_problem_creation.py tests/api/test_problems.py tests/worker/test_solution_worker.py` — passed (91 passed)
- `uv run --frozen pytest` (full backend suite) — passed (1013 passed, 14 skipped)
- `uv run --frozen python -c "import app.main; from app.solution_generation import backfill_solution_generation_tasks"` — passed (exit 0; startup and backfill imports remain valid)

Automated tests added or updated:

- `test_regenerate_pending_conflict_raises_exact_conflict` — asserts `SolutionRegenerationConflict` code/message for pending state.
- `test_regenerate_generating_conflict_raises_exact_conflict` — asserts `SolutionRegenerationConflict` code/message for generating state.
- `test_regenerate_no_solution_no_task_raises_exact_conflict` — asserts `SolutionRegenerationConflict` code/message for no-solution state.
- `test_regenerate_solution_rejects_ineligible_active_states` — strengthened to assert exact 409 status, code, and message for pending/generating.
- `test_regenerate_solution_rejects_none_state` — strengthened to assert exact 409 status, code, and message for no-solution.

Manual verification:

- Import smoke check confirms startup and backfill imports remain valid after removing the presentation import.
- Diff review confirms only the conflict boundary, associated tests, and the two scoped docstrings changed.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
