### PR TITLE
Give shared exam grading policy a non-presentation owner

### DIFF
--- a/backend/app/exam_grading.py
+++ b/backend/app/exam_grading.py
@@ -5,10 +5,19 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any
 
-from app.domain.models import GradingStatus, ProblemType
+from app.domain.models import ExamItem, GradingStatus, ProblemType
 from app.domain.normalization import compare_answers, normalize_answer
+from app.domain.scoring import compute_summary
 from app.infrastructure.storage.s3 import S3StorageAdapter, load_source_image_base64
 from app.infrastructure.vlm.client import VLMClient, VLMError
+
+
+# Terminal item grading statuses: once set, the item should not be re-graded.
+TERMINAL_GRADING_STATUSES = frozenset({
+    GradingStatus.CORRECT.value,
+    GradingStatus.INCORRECT.value,
+    GradingStatus.PENDING_REVIEW.value,
+})
 
 
 def build_grading_result(
@@ -159,3 +168,16 @@ def build_tracking_update(tracking: Mapping[str, Any], *, now: datetime, is_corr
         "lastTestedAt": now,
         "lastAttemptCorrect": is_correct,
     }
+
+
+def build_exam_summary(items: list[dict[str, Any]]) -> dict[str, Any]:
+    models = [
+        ExamItem.model_validate(
+            {
+                **item,
+                "problemId": str(item["problemId"]),
+            }
+        )
+        for item in items
+    ]
+    return compute_summary(models).model_dump()

--- a/backend/app/infrastructure/worker/exam_grading_worker.py
+++ b/backend/app/infrastructure/worker/exam_grading_worker.py
@@ -16,8 +16,12 @@ from app.infrastructure.config.settings import Settings, get_settings
 from app.infrastructure.storage.mongo import EXAM_GRADING_TASKS_COLLECTION, _safe_get_collection
 from app.infrastructure.storage.s3 import S3StorageAdapter
 from app.infrastructure.vlm.client import VLMClient, build_grading_vlm_client
-from app.presentation.exam_grading import build_tracking_update, grade_item
-from app.presentation.exam_helpers import TERMINAL_GRADING_STATUSES, build_exam_summary
+from app.exam_grading import (
+    TERMINAL_GRADING_STATUSES,
+    build_exam_summary,
+    build_tracking_update,
+    grade_item,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/presentation/exam_helpers.py
+++ b/backend/app/presentation/exam_helpers.py
@@ -8,18 +8,10 @@ from bson import ObjectId
 from pydantic import ValidationError
 from pymongo.asynchronous.database import AsyncDatabase
 
-from app.domain.models import ExamItem, GradingStatus, ProblemType
-from app.domain.scoring import compute_summary
+from app.domain.models import GradingStatus, ProblemType
 from app.infrastructure.storage.mongo import Document
 from app.presentation.errors import ApiError
 from app.presentation.helpers import parse_object_id
-
-# Terminal item grading statuses: once set, the item should not be re-graded.
-TERMINAL_GRADING_STATUSES = frozenset({
-    GradingStatus.CORRECT.value,
-    GradingStatus.INCORRECT.value,
-    GradingStatus.PENDING_REVIEW.value,
-})
 
 
 def requires_vlm_grading(item: Mapping[str, Any]) -> bool:
@@ -33,18 +25,6 @@ def requires_vlm_grading(item: Mapping[str, Any]) -> bool:
 
 def exam_requires_vlm_grading(items: list[Mapping[str, Any]]) -> bool:
     return any(requires_vlm_grading(item) for item in items)
-
-def build_exam_summary(items: list[dict[str, Any]]) -> dict[str, Any]:
-    models = [
-        ExamItem.model_validate(
-            {
-                **item,
-                "problemId": str(item["problemId"]),
-            }
-        )
-        for item in items
-    ]
-    return compute_summary(models).model_dump()
 
 
 def make_exam_item(problem: Mapping[str, Any], *, order: int) -> dict[str, Any]:

--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -11,10 +11,9 @@ from fastapi import APIRouter, Query
 from app.domain.models import ExamState, GradingStatus, ProblemType, SelectionPolicyConfig
 from app.domain.selection import select_problems
 from app.domain.state import transition_exam_state
-from app.presentation.exam_grading import build_tracking_update, grade_item
+from app.exam_grading import build_exam_summary, build_tracking_update, grade_item
 from app.presentation.selection_config import problem_selection_config
 from app.presentation.exam_helpers import (
-    build_exam_summary,
     exam_requires_vlm_grading,
     find_item,
     get_owned_exam,

--- a/backend/docs/exam_grading_parity.md
+++ b/backend/docs/exam_grading_parity.md
@@ -12,7 +12,7 @@ only; no production behavior or module location was changed.
 | Worker | `app.infrastructure.worker.exam_grading_worker.process_exam_grading_task` | Celery task `exam_grading_task` when at least one item needs VLM grading | Per-item updates outside a transaction; finalization uses `with_transaction` for exam state, tracking, and task completion |
 | Self-report | `app.presentation.exams.self_report_exam_item` | `POST /api/v1/exams/{id}/items/{itemId}/self-report` for a `pending-review` item | Single `with_transaction` covering item grading, summary, and problem tracking |
 
-All three paths use the same item-grading helpers in `app.presentation.exam_grading`:
+All three paths use the same item-grading helpers in `app.exam_grading`:
 
 - `grade_item`
 - `grade_objective_item`
@@ -38,8 +38,7 @@ items[].grading:
 ```
 
 Terminal item statuses (`CORRECT`, `INCORRECT`, `PENDING_REVIEW`) are never
-re-graded by the worker (`TERMINAL_GRADING_STATUSES` in
-`app.presentation.exam_helpers`).
+re-graded by the worker (`TERMINAL_GRADING_STATUSES` in `app.exam_grading`).
 
 The exam summary is produced by `build_exam_summary` using `compute_summary`:
 
@@ -101,7 +100,7 @@ prompt.
 - If the VLM returns a parseable verdict, the item becomes `correct` or
 `incorrect` with `method: vlm`.
 - If the VLM raises a retryable `VLMError`, `grade_short_answer_item` performs
-exactly **one** retry (hardcoded limit in `backend/app/presentation/exam_grading.py`).
+exactly **one** retry (hardcoded limit in `backend/app/exam_grading.py`).
 - After the retry is exhausted, or on a non-retryable or unexpected error, the
 item becomes `pending-review` with `method: vlm` and the error stored in
 `feedback` / `rawProviderResponse`.
@@ -219,8 +218,8 @@ answer normalization, summary computation, tracking deltas) into
 domain layer. That boundary is **not approved here**.
 
 - Current ownership: orchestration lives in `app.presentation.exams` and
-`app.infrastructure.worker.exam_grading_worker`; shared grading logic lives in
-`app.presentation.exam_grading`; domain models live in `app.domain.models`.
+  `app.infrastructure.worker.exam_grading_worker`; shared grading logic lives in
+  `app.exam_grading`; domain models live in `app.domain.models`.
 - Candidate ownership: pure, I/O-free grading rules under `app/domain/exam`;
 VLM client construction/close and S3 adapter lifecycle remain in presentation
 and infrastructure code.
@@ -261,7 +260,7 @@ metadata that the worker path does not reproduce.
 
 ## Human / council review gate
 
-Changes that alter `app.presentation.exam_grading`,
+Changes that alter `app.exam_grading`,
 `app.presentation.exams._submit_exam_synchronous`,
 `app.presentation.exams.self_report_exam_item`, or
 `app.infrastructure.worker.exam_grading_worker` must:

--- a/backend/tests/presentation/test_exam_grading.py
+++ b/backend/tests/presentation/test_exam_grading.py
@@ -8,7 +8,7 @@ import pytest
 from app.domain.models import GradingStatus, ProblemType
 from app.infrastructure.storage.s3 import S3StorageAdapter, StorageObjectNotFoundError
 from app.infrastructure.vlm.client import VLMClient, VLMError
-from app.presentation.exam_grading import (
+from app.exam_grading import (
     build_grading_result,
     build_tracking_update,
     grade_item,

--- a/backend/tests/presentation/test_exam_helpers.py
+++ b/backend/tests/presentation/test_exam_helpers.py
@@ -17,9 +17,9 @@ from app.domain.models import (
     ProblemSubject,
     ProblemType,
 )
+from app.exam_grading import build_exam_summary
 from app.presentation.errors import ApiError
 from app.presentation.exam_helpers import (
-    build_exam_summary,
     find_item,
     make_exam_item,
 )


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Move the seven shared exam-grading symbols to `backend/app/exam_grading.py` so workers and HTTP routes depend on a non-presentation owner.
- The exhausted `backend/app/presentation/exam_grading.py` module is deleted with no compatibility re-export.
- `build_exam_summary` and `TERMINAL_GRADING_STATUSES` are removed from `exam_helpers.py` (which otherwise remains intact).
- Grading parity, lifecycle behavior, implementations, and signatures are unchanged.

## Linked Issue

Closes #572

## Issue Alignment

This PR implements the issue by:

- Creating `backend/app/exam_grading.py` as the single owner of exactly the seven named symbols with unchanged implementations and signatures.
- Updating route (`app/presentation/exams.py`), worker (`app/infrastructure/worker/exam_grading_worker.py`), and direct test imports to `app.exam_grading`.
- Removing only `build_exam_summary` and `TERMINAL_GRADING_STATUSES` from `exam_helpers.py`.
- Deleting `app/presentation/exam_grading.py` after its contents moved.
- Updating `backend/docs/exam_grading_parity.md` ownership references and the review gate.

Scope covered:

- The seven symbols moved: `grade_item`, `grade_objective_item`, `grade_short_answer_item`, `build_grading_result`, `build_tracking_update`, `build_exam_summary`, `TERMINAL_GRADING_STATUSES`.
- Production and direct test import updates.
- Deletion of the old grading module.
- Parity document updates.
- Removal of the two moved symbols from `exam_helpers.py` (plus the now-orphaned `ExamItem`/`compute_summary` imports).

Out of scope / intentionally not included:

- Other exam helpers, HTTP lookup/error helpers.
- Route or worker orchestration changes.
- Function signature or implementation changes.
- Retry, pending-review, persistence, lease, stale-worker, transaction, exactly-once tracking, or serialization changes.
- VLM/S3 construction, ownership, or lifecycle changes.
- A move to `app/domain/exam`, a service layer, or a new package hierarchy.
- Compatibility exports from the old presentation path.

## Implementation Notes

- The new `app/exam_grading.py` combines the five symbols from the old `presentation/exam_grading.py` with `build_exam_summary` and `TERMINAL_GRADING_STATUSES` from `exam_helpers.py`; implementations and signatures are byte-for-byte unchanged.
- Module-level imports in route and worker modules are preserved, so existing monkeypatch seams (which target the worker module, not the presentation module) remain valid.
- `exam_helpers.py` retains `requires_vlm_grading`, `exam_requires_vlm_grading`, `make_exam_item`, `get_owned_exam`, and `find_item` unchanged.

## Tests

Commands run:

- `uv run --frozen pytest tests/presentation/test_exam_grading.py tests/presentation/test_exam_helpers.py tests/worker/test_exam_grading_worker.py tests/integration/test_exam_grading_parity.py tests/integration/test_exam_workflow.py tests/api/test_exams.py` — passed (93 passed)
- `uv run --frozen pytest` (full backend suite) — passed (1013 passed, 14 skipped)

Manual verification:

- `uv run --frozen python -c "from app.exam_grading import grade_item, grade_objective_item, grade_short_answer_item, build_grading_result, build_tracking_update, build_exam_summary, TERMINAL_GRADING_STATUSES"` — passed (exit 0)
- `grep -rn "app\.presentation\.exam_grading|presentation/exam_grading\.py|presentation import exam_grading" backend/app backend/tests backend/docs` — no matches (zero old-path references remain)
- `test ! -f backend/app/presentation/exam_grading.py` — passed (old module deleted)

Automated tests added or updated:

- No test assertions were weakened. `test_exam_grading.py` and `test_exam_helpers.py` imports were updated to the new owner; all existing assertions remain intact.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.
