### PR TITLE
Add a frontend exam transport module

### DIFF
--- a/frontend/src/api/exams.test.ts
+++ b/frontend/src/api/exams.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  getExamHistory,
+  createExam,
+  getActiveExam,
+  getExam,
+  saveExamAnswer,
+  submitExam,
+  discardExam,
+  selfReportExamItem,
+} from "./exams";
+import type {
+  CreateExamResponse,
+  ExamHistoryResponse,
+  ExamResponse,
+  SaveAnswerResponse,
+  SelfReportResponse,
+} from "@/types/exam";
+
+function mockOk(response: unknown) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(response),
+  });
+}
+
+describe("exams API module", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("getExamHistory GETs /exams with page, pageSize, includeDiscarded", async () => {
+    const response: ExamHistoryResponse = {
+      items: [],
+      page: 1,
+      pageSize: 10,
+      total: 0,
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await getExamHistory(2, 20, true);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/exams?page=2&pageSize=20&includeDiscarded=true",
+      { credentials: "include" },
+    );
+  });
+
+  it("createExam POSTs the request body to /exams", async () => {
+    const response: CreateExamResponse = {
+      exam: {
+        id: "e1",
+        state: "in-progress",
+        configSnapshot: {
+          maxProblemCount: 5,
+          selectionPolicy: {
+            cooldownDays: 0,
+            lastWrongWeight: 0,
+            failureRateWeight: 0,
+            recencyWeight: 0,
+            minProblemAgeDays: 0,
+          },
+          generatedAt: "2026-01-01T00:00:00Z",
+        },
+        items: [],
+        summary: {
+          totalProblems: 0,
+          answeredProblems: 0,
+          gradedProblems: 0,
+          pendingProblems: 0,
+          correctProblems: 0,
+          failedProblems: 0,
+          score: null,
+        },
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await createExam({ maxProblemCount: 5 });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/exams", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ maxProblemCount: 5 }),
+    });
+  });
+
+  it("getActiveExam GETs /exams/active", async () => {
+    const response: ExamResponse = {
+      exam: {
+        id: "e1",
+        state: "in-progress",
+        configSnapshot: {
+          maxProblemCount: 5,
+          selectionPolicy: {
+            cooldownDays: 0,
+            lastWrongWeight: 0,
+            failureRateWeight: 0,
+            recencyWeight: 0,
+            minProblemAgeDays: 0,
+          },
+          generatedAt: "2026-01-01T00:00:00Z",
+        },
+        items: [],
+        summary: {
+          totalProblems: 0,
+          answeredProblems: 0,
+          gradedProblems: 0,
+          pendingProblems: 0,
+          correctProblems: 0,
+          failedProblems: 0,
+          score: null,
+        },
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await getActiveExam();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/exams/active", {
+      credentials: "include",
+    });
+  });
+
+  it("getExam GETs /exams/{examId}", async () => {
+    const response: ExamResponse = {
+      exam: {
+        id: "e1",
+        state: "submitted",
+        configSnapshot: {
+          maxProblemCount: 5,
+          selectionPolicy: {
+            cooldownDays: 0,
+            lastWrongWeight: 0,
+            failureRateWeight: 0,
+            recencyWeight: 0,
+            minProblemAgeDays: 0,
+          },
+          generatedAt: "2026-01-01T00:00:00Z",
+        },
+        items: [],
+        summary: {
+          totalProblems: 0,
+          answeredProblems: 0,
+          gradedProblems: 0,
+          pendingProblems: 0,
+          correctProblems: 0,
+          failedProblems: 0,
+          score: null,
+        },
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await getExam("exam-123");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/exams/exam-123", {
+      credentials: "include",
+    });
+  });
+
+  it("saveExamAnswer PATCHes the answer to /exams/{examId}/items/{itemId}/answer", async () => {
+    const response: SaveAnswerResponse = {
+      item: {
+        itemId: "i1",
+        order: 0,
+        problemId: "p1",
+        problem: {
+          text: "Q",
+          problemType: "single-choice",
+        },
+        answer: { raw: "A", savedAt: "2026-01-01T00:00:00Z" },
+        grading: {
+          status: "ungraded",
+          retryCount: 0,
+        },
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await saveExamAnswer("exam-1", "item-1", { answer: "A" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/exams/exam-1/items/item-1/answer",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ answer: "A" }),
+      },
+    );
+  });
+
+  it("submitExam POSTs an empty body to /exams/{examId}/submit", async () => {
+    const response: ExamResponse = {
+      exam: {
+        id: "e1",
+        state: "submitted",
+        configSnapshot: {
+          maxProblemCount: 5,
+          selectionPolicy: {
+            cooldownDays: 0,
+            lastWrongWeight: 0,
+            failureRateWeight: 0,
+            recencyWeight: 0,
+            minProblemAgeDays: 0,
+          },
+          generatedAt: "2026-01-01T00:00:00Z",
+        },
+        items: [],
+        summary: {
+          totalProblems: 0,
+          answeredProblems: 0,
+          gradedProblems: 0,
+          pendingProblems: 0,
+          correctProblems: 0,
+          failedProblems: 0,
+          score: null,
+        },
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await submitExam("exam-1");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/exams/exam-1/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({}),
+    });
+  });
+
+  it("discardExam POSTs an empty body to /exams/{examId}/discard", async () => {
+    const response: ExamResponse = {
+      exam: {
+        id: "e1",
+        state: "discarded",
+        configSnapshot: {
+          maxProblemCount: 5,
+          selectionPolicy: {
+            cooldownDays: 0,
+            lastWrongWeight: 0,
+            failureRateWeight: 0,
+            recencyWeight: 0,
+            minProblemAgeDays: 0,
+          },
+          generatedAt: "2026-01-01T00:00:00Z",
+        },
+        items: [],
+        summary: {
+          totalProblems: 0,
+          answeredProblems: 0,
+          gradedProblems: 0,
+          pendingProblems: 0,
+          correctProblems: 0,
+          failedProblems: 0,
+          score: null,
+        },
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await discardExam("exam-1");
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("/api/v1/exams/exam-1/discard", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({}),
+    });
+  });
+
+  it("selfReportExamItem POSTs isCorrect to /exams/{examId}/items/{itemId}/self-report", async () => {
+    const response: SelfReportResponse = {
+      item: {
+        itemId: "i1",
+        order: 0,
+        problemId: "p1",
+        problem: {
+          text: "Q",
+          problemType: "short-answer",
+        },
+        answer: { raw: "A" },
+        grading: {
+          status: "correct",
+          method: "self-report",
+          isCorrect: true,
+          score: 1,
+          retryCount: 0,
+          selfReportedCorrect: true,
+        },
+      },
+      summary: {
+        totalProblems: 1,
+        answeredProblems: 1,
+        gradedProblems: 1,
+        pendingProblems: 0,
+        correctProblems: 1,
+        failedProblems: 0,
+        score: 1,
+      },
+    };
+    const mockFetch = mockOk(response);
+    vi.stubGlobal("fetch", mockFetch);
+
+    await selfReportExamItem("exam-1", "item-1", { isCorrect: true });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/v1/exams/exam-1/items/item-1/self-report",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ isCorrect: true }),
+      },
+    );
+  });
+});

--- a/frontend/src/api/exams.ts
+++ b/frontend/src/api/exams.ts
@@ -1,0 +1,65 @@
+import { api } from "./client";
+import type {
+  CreateExamRequest,
+  CreateExamResponse,
+  ExamHistoryResponse,
+  ExamResponse,
+  SaveAnswerRequest,
+  SaveAnswerResponse,
+  SelfReportRequest,
+  SelfReportResponse,
+} from "@/types/exam";
+
+export async function getExamHistory(
+  page: number,
+  pageSize: number,
+  includeDiscarded: boolean,
+): Promise<ExamHistoryResponse> {
+  return api.get<ExamHistoryResponse>(
+    `/exams?page=${page}&pageSize=${pageSize}&includeDiscarded=${includeDiscarded}`,
+  );
+}
+
+export async function createExam(
+  request: CreateExamRequest,
+): Promise<CreateExamResponse> {
+  return api.post<CreateExamResponse>("/exams", request);
+}
+
+export async function getActiveExam(): Promise<ExamResponse> {
+  return api.get<ExamResponse>("/exams/active");
+}
+
+export async function getExam(examId: string): Promise<ExamResponse> {
+  return api.get<ExamResponse>(`/exams/${examId}`);
+}
+
+export async function saveExamAnswer(
+  examId: string,
+  itemId: string,
+  request: SaveAnswerRequest,
+): Promise<SaveAnswerResponse> {
+  return api.patch<SaveAnswerResponse>(
+    `/exams/${examId}/items/${itemId}/answer`,
+    request,
+  );
+}
+
+export async function submitExam(examId: string): Promise<ExamResponse> {
+  return api.post<ExamResponse>(`/exams/${examId}/submit`, {});
+}
+
+export async function discardExam(examId: string): Promise<ExamResponse> {
+  return api.post<ExamResponse>(`/exams/${examId}/discard`, {});
+}
+
+export async function selfReportExamItem(
+  examId: string,
+  itemId: string,
+  request: SelfReportRequest,
+): Promise<SelfReportResponse> {
+  return api.post<SelfReportResponse>(
+    `/exams/${examId}/items/${itemId}/self-report`,
+    request,
+  );
+}

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -1,44 +1,20 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api, ApiError } from "@/api/client";
+import { ApiError } from "@/api/client";
+import {
+  createExam,
+  discardExam,
+  getActiveExam,
+  saveExamAnswer,
+  submitExam,
+} from "@/api/exams";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { LatexText } from "@/components/LatexText";
 import { AnswerInput, parseOptions } from "@/components/AnswerInput";
 import { Modal } from "@/components/Modal";
-import type {
-  ExamItem,
-  CreateExamRequest,
-  CreateExamResponse,
-  ExamResponse,
-  SaveAnswerRequest,
-  SaveAnswerResponse,
-} from "@/types/exam";
-
-async function fetchActiveExam(): Promise<ExamResponse> {
-  return api.get<ExamResponse>("/exams/active");
-}
-
-async function createExam(request: CreateExamRequest): Promise<CreateExamResponse> {
-  return api.post<CreateExamResponse>("/exams", request);
-}
-
-async function saveAnswer(
-  examId: string,
-  itemId: string,
-  request: SaveAnswerRequest,
-): Promise<SaveAnswerResponse> {
-  return api.patch<SaveAnswerResponse>(`/exams/${examId}/items/${itemId}/answer`, request);
-}
-
-async function submitExam(examId: string): Promise<ExamResponse> {
-  return api.post<ExamResponse>(`/exams/${examId}/submit`, {});
-}
-
-async function discardExam(examId: string): Promise<ExamResponse> {
-  return api.post<ExamResponse>(`/exams/${examId}/discard`, {});
-}
+import type { ExamItem, ExamResponse, SaveAnswerRequest } from "@/types/exam";
 
 export function ActiveExamPage() {
   const navigate = useNavigate();
@@ -57,7 +33,7 @@ export function ActiveExamPage() {
     refetch: refetchExam,
   } = useQuery<ExamResponse>({
     queryKey: ["active-exam"],
-    queryFn: fetchActiveExam,
+    queryFn: getActiveExam,
     retry: false,
     refetchOnWindowFocus: false,
   });
@@ -83,7 +59,7 @@ export function ActiveExamPage() {
 
   const saveAnswerMutation = useMutation({
     mutationFn: ({ examId, itemId, request }: { examId: string; itemId: string; request: SaveAnswerRequest }) =>
-      saveAnswer(examId, itemId, request),
+      saveExamAnswer(examId, itemId, request),
     onSuccess: () => {
       setSaveStatus("saved");
       queryClient.invalidateQueries({ queryKey: ["active-exam"] });

--- a/frontend/src/pages/CoachingPage.test.tsx
+++ b/frontend/src/pages/CoachingPage.test.tsx
@@ -5,9 +5,10 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 import { api } from "@/api/client";
-import { CoachingPage, type ExamResponse } from "./CoachingPage";
+import { CoachingPage } from "./CoachingPage";
 import type { PracticeHistoryResponse } from "@/types/practice";
 import type { CoachingConversation, CoachingMessage } from "@/types/coaching";
+import type { ExamResponse } from "@/types/exam";
 
 // Mock GraphSandbox component to easily verify DSL and trigger errors
 vi.mock("@/components/GraphSandbox", () => ({
@@ -125,18 +126,48 @@ const mockPracticeHistory: PracticeHistoryResponse = {
 const mockExamData: ExamResponse = {
   exam: {
     id: "exam-789",
+    state: "submitted",
+    configSnapshot: {
+      maxProblemCount: 1,
+      selectionPolicy: {
+        cooldownDays: 0,
+        lastWrongWeight: 0,
+        failureRateWeight: 0,
+        recencyWeight: 0,
+        minProblemAgeDays: 0,
+      },
+      generatedAt: "2026-01-01T00:00:00Z",
+    },
     items: [
       {
+        itemId: "item-1",
+        order: 0,
         problemId: "prob-123",
+        problem: {
+          text: "Given $x^2 = 4$, find $x$.",
+          problemType: "short-answer",
+        },
         answer: {
           raw: "2",
         },
         grading: {
           status: "correct",
           isCorrect: true,
+          retryCount: 0,
         },
       },
     ],
+    summary: {
+      totalProblems: 1,
+      answeredProblems: 1,
+      gradedProblems: 1,
+      pendingProblems: 0,
+      correctProblems: 1,
+      failedProblems: 0,
+      score: 1,
+    },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
   },
 };
 

--- a/frontend/src/pages/CoachingPage.tsx
+++ b/frontend/src/pages/CoachingPage.tsx
@@ -2,33 +2,17 @@ import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
+import { getExam } from "@/api/exams";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { MarkdownText } from "@/components/MarkdownText";
 import { LatexText } from "@/components/LatexText";
 import type { CoachingConversation } from "@/types/coaching";
 import type { ProblemDetail, ProblemResponse } from "@/types/problem";
+import type { ExamResponse } from "@/types/exam";
 import { getPracticeHistory, PRACTICE_HISTORY_KEY } from "@/api/practice";
 import type { PracticeHistoryResponse } from "@/types/practice";
 import { WhiteboardPanel } from "./WhiteboardPanel";
-
-interface ExamItem {
-  problemId: string;
-  answer: {
-    raw?: string;
-  };
-  grading: {
-    status: string;
-    isCorrect?: boolean;
-  };
-}
-
-export interface ExamResponse {
-  exam: {
-    id: string;
-    items: ExamItem[];
-  };
-}
 
 export function CoachingPage() {
   const { problemId = "" } = useParams<{ problemId: string }>();
@@ -74,7 +58,7 @@ export function CoachingPage() {
   const examId = isFromExam ? fromRoute.split("/")[2] : "";
   const { data: examData } = useQuery({
     queryKey: ["exam", examId],
-    queryFn: () => api.get<ExamResponse>(`/exams/${examId}`),
+    queryFn: () => getExam(examId),
     enabled: !!problemId && !!examId,
   });
 

--- a/frontend/src/pages/ExamDetailPage.tsx
+++ b/frontend/src/pages/ExamDetailPage.tsx
@@ -2,24 +2,13 @@ import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/api/client";
+import { getExam, selfReportExamItem } from "@/api/exams";
 import { formatDate, formatScore } from "@/utils/format";
 import { GraphSandbox } from "@/components/GraphSandbox";
 import { CollapsibleImage } from "@/components/CollapsibleImage";
 import { LatexText } from "@/components/LatexText";
 import { TeacherPasswordModal } from "@/components/TeacherPasswordModal";
-import type { Exam, ExamItem, ExamResponse, SelfReportRequest, SelfReportResponse } from "@/types/exam";
-
-async function fetchExam(examId: string): Promise<ExamResponse> {
-  return api.get<ExamResponse>(`/exams/${examId}`);
-}
-
-async function selfReportItem(
-  examId: string,
-  itemId: string,
-  request: SelfReportRequest,
-): Promise<SelfReportResponse> {
-  return api.post<SelfReportResponse>(`/exams/${examId}/items/${itemId}/self-report`, request);
-}
+import type { Exam, ExamItem, ExamResponse, SelfReportRequest } from "@/types/exam";
 
 function GradingStatusBadge({ status }: { status: string }) {
   const classes: Record<string, string> = {
@@ -408,7 +397,7 @@ export function ExamDetailPage() {
     error,
   } = useQuery<ExamResponse>({
     queryKey: ["exam", id],
-    queryFn: () => fetchExam(id!),
+    queryFn: () => getExam(id!),
     enabled: !!id,
     refetchInterval: (query) => {
       const state = query.state.data?.exam?.state;
@@ -418,7 +407,7 @@ export function ExamDetailPage() {
 
   const selfReportMutation = useMutation({
     mutationFn: ({ itemId, request }: { itemId: string; request: SelfReportRequest }) =>
-      selfReportItem(id!, itemId, request),
+      selfReportExamItem(id!, itemId, request),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["exam", id] });
     },

--- a/frontend/src/pages/ExamsPage.tsx
+++ b/frontend/src/pages/ExamsPage.tsx
@@ -2,9 +2,9 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { api } from "@/api/client";
+import { createExam, getExamHistory } from "@/api/exams";
 import { formatDate, formatScore } from "@/utils/format";
-import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest, CreateExamResponse } from "@/types/exam";
+import type { ExamHistoryResponse, ExamHistoryItem, CreateExamRequest } from "@/types/exam";
 import Pagination from "@/components/Pagination";
 import { Modal } from "@/components/Modal";
 
@@ -124,14 +124,11 @@ export function ExamsPage() {
 
   const { data, isLoading, error } = useQuery<ExamHistoryResponse>({
     queryKey: ["exams", page, pageSize, showDiscarded],
-    queryFn: () =>
-      api.get<ExamHistoryResponse>(
-        `/exams?page=${page}&pageSize=${pageSize}&includeDiscarded=${showDiscarded}`,
-      ),
+    queryFn: () => getExamHistory(page, pageSize, showDiscarded),
   });
 
   const createExamMutation = useMutation({
-    mutationFn: (req: CreateExamRequest) => api.post<CreateExamResponse>("/exams", req),
+    mutationFn: (req: CreateExamRequest) => createExam(req),
     onSuccess: () => {
       setShowCreateExamModal(false);
       queryClient.invalidateQueries({ queryKey: ["exams"] });


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Create `frontend/src/api/exams.ts` as the typed transport owner for the eight exam endpoint contracts.
- Migrate the four exam-related pages (`ExamsPage`, `ActiveExamPage`, `ExamDetailPage`, `CoachingPage`) to use the transport functions, preserving exact query keys, mutation ordering, polling, invalidation, and navigation behavior.
- Remove CoachingPage's local `ExamItem`/`ExamResponse` declarations and update its test fixture to satisfy the canonical `ExamResponse` from `@/types/exam` without type escapes.

## Linked Issue

Closes #573

## Issue Alignment

This PR implements the issue by:

- Adding eight typed transport functions in `frontend/src/api/exams.ts` matching the eight listed contracts.
- Adding `frontend/src/api/exams.test.ts` asserting exact URL, method, credentials, and body for all eight contracts.
- Replacing only exam-related `api.get/post/patch` calls in the four named pages.
- Removing CoachingPage's local `ExamItem`/`ExamResponse` and using the canonical `ExamResponse` from `@/types/exam`.
- Updating CoachingPage's test fixture to a valid canonical response without `as unknown as ExamResponse` or equivalent type escapes.

Scope covered:

- The eight transport functions and their contract tests.
- The four named consumer migrations.
- CoachingPage canonical typing and fixture fix.

Out of scope / intentionally not included:

- TanStack Query keys, polling, enable gates, retries, focus/refetch options, invalidations/removals, or their ordering.
- Problem, folder, auth, coaching-message, or solution-status transport migration.
- Custom hooks, cache-key normalization, feature-folder changes, or a generated client.
- Changes to `api/client.ts` behavior.

## Implementation Notes

- `ActiveExamPage` previously defined local wrapper functions (`fetchActiveExam`, `createExam`, `saveAnswer`, `submitExam`, `discardExam`) that exactly matched the transport contracts; these were removed and the mutations now reference the imported transport functions directly, preserving all `onSuccess`/`onError` callbacks and ordering.
- `ExamDetailPage` retains `api.getSolutionStatus` (a solution-status call, not exam transport) and its `solution-status` query key unchanged.
- `CoachingPage` retains its non-exam `api.get<ProblemResponse>` and `api.getCoachingConversation` calls unchanged.
- Query keys `['active-exam']`, `['exams', page, pageSize, showDiscarded]`, and `['exam', id]` are unchanged.

## Tests

Commands run:

- `npx vitest run src/api/client.test.ts src/api/exams.test.ts src/pages/ExamsPage.test.tsx src/pages/ActiveExamPage.test.tsx src/pages/ExamDetailPage.test.tsx src/pages/CoachingPage.test.tsx` — passed (94 passed)
- `npx vitest run` (full frontend suite) — passed (574 passed, 37 files)
- `npm run build` (production build) — passed (built in 1.23s)

Manual verification:

- `grep -n "api\.get.*exams\|api\.post.*exams\|api\.patch.*exams"` across the four pages returned no matches — no direct exam `api` calls remain.

Automated tests added or updated:

- `src/api/exams.test.ts` — 8 new contract tests pinning exact paths, methods, credentials, and bodies for all eight contracts.
- `src/pages/CoachingPage.test.tsx` — `mockExamData` fixture updated to satisfy the canonical `ExamResponse` without type escapes.

## Deviations From Issue Plan

The focused E2E test (`tests/active-exam-print.spec.ts`) could not be run in this environment because it requires a live MongoDB replica set and backend services (the Playwright webServer config starts the backend, which fails to connect to MongoDB). This is an environment limitation, not a code issue. The CI pipeline on GitHub will run the E2E suite with the required services.

## Follow-Up Work

None.
