### PR TITLE
Centralize full selection settings adapters

### DIFF
--- a/backend/app/presentation/exams.py
+++ b/backend/app/presentation/exams.py
@@ -12,7 +12,7 @@ from app.domain.models import ExamState, GradingStatus, ProblemType, SelectionPo
 from app.domain.selection import select_problems
 from app.domain.state import transition_exam_state
 from app.exam_grading import build_exam_summary, build_tracking_update, grade_item
-from app.presentation.selection_config import problem_selection_config
+from app.presentation.selection_config import problem_selection_config_from_settings
 from app.presentation.exam_helpers import (
     exam_requires_vlm_grading,
     find_item,
@@ -60,13 +60,7 @@ async def create_exam(
         "userId": current_user["_id"],
         "state": {"$in": [ExamState.IN_PROGRESS.value, ExamState.GRADING.value]},
     }
-    selection_config = problem_selection_config(
-        cooldown_days=settings.problem_selection_cooldown_days,
-        last_wrong_weight=settings.problem_selection_last_wrong_weight,
-        failure_rate_weight=settings.problem_selection_failure_rate_weight,
-        recency_weight=settings.problem_selection_recency_weight,
-        min_problem_age_days=settings.problem_selection_min_age_days,
-    )
+    selection_config = problem_selection_config_from_settings(settings)
     selection_policy = SelectionPolicyConfig(
         cooldownDays=settings.problem_selection_cooldown_days,
         lastWrongWeight=settings.problem_selection_last_wrong_weight,

--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -12,7 +12,7 @@ from app.domain.models import ExamState, GradingStatus
 from app.domain.selection import compute_score_breakdown, ensure_utc
 from app.presentation.deps import CurrentUserDependency, DatabaseDependency, SettingsDependency
 from app.presentation.problem_serialization import problem_document_to_model
-from app.presentation.selection_config import problem_selection_config
+from app.presentation.selection_config import problem_selection_config_from_settings
 
 router = APIRouter(prefix="/home", tags=["home"])
 
@@ -69,13 +69,7 @@ class HomeSummaryResponse(BaseModel):
 
 
 def _selection_config_from_settings(settings: Any):
-    return problem_selection_config(
-        cooldown_days=settings.problem_selection_cooldown_days,
-        last_wrong_weight=settings.problem_selection_last_wrong_weight,
-        failure_rate_weight=settings.problem_selection_failure_rate_weight,
-        recency_weight=settings.problem_selection_recency_weight,
-        min_problem_age_days=settings.problem_selection_min_age_days,
-    )
+    return problem_selection_config_from_settings(settings)
 
 
 def _build_score_distribution(

--- a/backend/app/presentation/practice.py
+++ b/backend/app/presentation/practice.py
@@ -15,7 +15,10 @@ from app.domain.practice_selection import (
     select_practice_problem,
 )
 from app.infrastructure.config.settings import get_settings
-from app.presentation.selection_config import practice_selection_config
+from app.presentation.selection_config import (
+    practice_selection_config,
+    practice_selection_config_from_settings,
+)
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.storage.s3 import S3StorageAdapter
 from app.infrastructure.vlm.client import VLMClient, VLMError
@@ -130,13 +133,7 @@ async def get_next_practice_problem(
     if not eligible_documents:
         return PracticeNextResponse(status="no_problems")
 
-    config = practice_selection_config(
-        cooldown_days=settings.problem_selection_cooldown_days,
-        last_wrong_weight=settings.problem_selection_last_wrong_weight,
-        failure_rate_weight=settings.problem_selection_failure_rate_weight,
-        recency_weight=settings.problem_selection_recency_weight,
-        min_problem_age_days=settings.problem_selection_min_age_days,
-    )
+    config = practice_selection_config_from_settings(settings)
 
     problem_models = [problem_document_to_model(p) for p in eligible_documents]
     now = datetime.now(UTC)

--- a/backend/app/presentation/problems.py
+++ b/backend/app/presentation/problems.py
@@ -15,7 +15,7 @@ from app.domain.normalization import normalize_answer
 from app.domain.practice_selection import compute_problem_weight_breakdown
 from app.infrastructure.auth.password import verify_password
 from app.infrastructure.config.settings import Settings, get_settings
-from app.presentation.selection_config import practice_selection_config
+from app.presentation.selection_config import practice_selection_config_from_settings
 from app.observability import log_teacher_password_event
 from app.presentation.deps import DatabaseDependency, get_current_user
 from app.presentation.errors import ApiError
@@ -124,13 +124,7 @@ async def _solution_state_problem_ids(
 
 
 def _practice_selection_config(settings: Settings):
-    return practice_selection_config(
-        cooldown_days=settings.problem_selection_cooldown_days,
-        last_wrong_weight=settings.problem_selection_last_wrong_weight,
-        failure_rate_weight=settings.problem_selection_failure_rate_weight,
-        recency_weight=settings.problem_selection_recency_weight,
-        min_problem_age_days=settings.problem_selection_min_age_days,
-    )
+    return practice_selection_config_from_settings(settings)
 
 
 def _problem_id_sort_value(problem: dict[str, Any]) -> str:

--- a/backend/app/presentation/selection_config.py
+++ b/backend/app/presentation/selection_config.py
@@ -1,7 +1,13 @@
 from app.domain.practice_selection import PracticeSelectionConfig
 from app.domain.selection import ProblemSelectionConfig
+from app.infrastructure.config.settings import Settings
 
-__all__ = ["problem_selection_config", "practice_selection_config"]
+__all__ = [
+    "problem_selection_config",
+    "practice_selection_config",
+    "problem_selection_config_from_settings",
+    "practice_selection_config_from_settings",
+]
 
 
 def problem_selection_config(
@@ -47,4 +53,26 @@ def practice_selection_config(
         failure_rate_weight=failure_rate_weight if failure_rate_weight is not None else 1.0,
         recency_weight=recency_weight if recency_weight is not None else 1.0,
         min_problem_age_days=min_problem_age_days if min_problem_age_days is not None else 3,
+    )
+
+
+def problem_selection_config_from_settings(settings: Settings) -> ProblemSelectionConfig:
+    """Build a ``ProblemSelectionConfig`` from a full ``Settings`` instance."""
+    return problem_selection_config(
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
+        min_problem_age_days=settings.problem_selection_min_age_days,
+    )
+
+
+def practice_selection_config_from_settings(settings: Settings) -> PracticeSelectionConfig:
+    """Build a ``PracticeSelectionConfig`` from a full ``Settings`` instance."""
+    return practice_selection_config(
+        cooldown_days=settings.problem_selection_cooldown_days,
+        last_wrong_weight=settings.problem_selection_last_wrong_weight,
+        failure_rate_weight=settings.problem_selection_failure_rate_weight,
+        recency_weight=settings.problem_selection_recency_weight,
+        min_problem_age_days=settings.problem_selection_min_age_days,
     )

--- a/backend/tests/presentation/test_selection_config.py
+++ b/backend/tests/presentation/test_selection_config.py
@@ -1,8 +1,11 @@
 from app.domain.practice_selection import PracticeSelectionConfig
 from app.domain.selection import ProblemSelectionConfig
+from app.infrastructure.config.settings import Settings
 from app.presentation.selection_config import (
     practice_selection_config,
+    practice_selection_config_from_settings,
     problem_selection_config,
+    problem_selection_config_from_settings,
 )
 
 
@@ -90,3 +93,37 @@ def test_problem_selection_config_and_practice_selection_config_to_shared_values
     )
 
     assert problem_config == practice_config.to_shared_config()
+
+
+def _non_default_settings() -> Settings:
+    return Settings(
+        problem_selection_cooldown_days=5,
+        problem_selection_last_wrong_weight=1.5,
+        problem_selection_failure_rate_weight=2.0,
+        problem_selection_recency_weight=2.5,
+        problem_selection_min_age_days=0,
+    )
+
+
+def test_problem_selection_config_from_settings_maps_all_five_fields() -> None:
+    settings = _non_default_settings()
+    mapped = problem_selection_config_from_settings(settings)
+
+    assert isinstance(mapped, ProblemSelectionConfig)
+    assert mapped.cooldown_days == 5
+    assert mapped.last_wrong_weight == 1.5
+    assert mapped.failure_rate_weight == 2.0
+    assert mapped.recency_weight == 2.5
+    assert mapped.min_problem_age_days == 0
+
+
+def test_practice_selection_config_from_settings_maps_all_five_fields() -> None:
+    settings = _non_default_settings()
+    mapped = practice_selection_config_from_settings(settings)
+
+    assert isinstance(mapped, PracticeSelectionConfig)
+    assert mapped.cooldown_days == 5
+    assert mapped.last_wrong_weight == 1.5
+    assert mapped.failure_rate_weight == 2.0
+    assert mapped.recency_weight == 2.5
+    assert mapped.min_problem_age_days == 0


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Add two explicit `Settings`-to-selection-config adapters (`problem_selection_config_from_settings`, `practice_selection_config_from_settings`) in `selection_config.py`.
- Replace exactly four repeated full-profile `Settings` mappings across `home.py`, `exams.py`, `problems.py`, and `practice.py` (`/practice/next` only).
- Partial `/practice/stats` construction and exam `SelectionPolicyConfig` snapshot remain unchanged.
- Add non-default tests for both adapters asserting all five fields and concrete return types.

## Linked Issue

Closes #574

## Issue Alignment

This PR implements the issue by:

- Adding `problem_selection_config_from_settings(settings: Settings)` and `practice_selection_config_from_settings(settings: Settings)` to `selection_config.py`.
- Importing concrete `Settings` from `app.infrastructure.config.settings` (no protocol).
- Adding both names to `__all__`, which now contains exactly four factory names (two old primitive factories + two new adapters).
- Replacing exactly four full-profile call sites:
  1. `home.py` — `_selection_config_from_settings` delegates to `problem_selection_config_from_settings`.
  2. `exams.py` — exam creation uses `problem_selection_config_from_settings`.
  3. `problems.py` — `_practice_selection_config` delegates to `practice_selection_config_from_settings`.
  4. `practice.py` — `/practice/next` uses `practice_selection_config_from_settings`.

Scope covered:

- Two new adapter functions with concrete `Settings` parameter.
- Four full-profile mapping replacements.
- `__all__` updated to exactly four names.
- Two non-default adapter tests.

Out of scope / intentionally not included:

- No generic `kind` parameter or unified factory.
- No merging of `ProblemSelectionConfig`, `PracticeSelectionConfig`, or `SelectionPolicyConfig`.
- Partial `/practice/stats` construction unchanged.
- Exam `SelectionPolicyConfig` snapshot construction/serialization unchanged.
- Selection algorithms or default values unchanged.

## Implementation Notes

- Each adapter delegates to the matching primitive factory with all five settings fields.
- `practice.py` imports both `practice_selection_config` (for the partial `/practice/stats` mapping) and `practice_selection_config_from_settings` (for the full `/practice/next` mapping).
- `home.py` and `problems.py` keep their existing local wrapper functions (`_selection_config_from_settings`, `_practice_selection_config`) which now delegate to the new adapters, preserving their call sites.

## Tests

Commands run:

- `python -m pytest tests/presentation/test_selection_config.py` — 8 passed (6 existing + 2 new)
- `python -m pytest tests/presentation/test_selection_config.py tests/domain/test_selection.py tests/domain/test_practice_selection.py tests/api/test_practice.py tests/api/test_problems.py tests/api/test_exams.py tests/api/test_home.py tests/api/test_settings_info.py` — 239 passed
- `python -m pytest` (full backend suite) — 1015 passed, 14 skipped

Automated tests added or updated:

- `test_problem_selection_config_from_settings_maps_all_five_fields` — asserts all five non-default values and `ProblemSelectionConfig` type.
- `test_practice_selection_config_from_settings_maps_all_five_fields` — asserts all five non-default values and `PracticeSelectionConfig` type.

Manual verification:

- Inspected `exams.py` diff: the `SelectionPolicyConfig` snapshot block (lines 70-76) is unchanged.
- Inspected `practice.py` diff: the partial `/practice/stats` construction (lines 106-109, 2 fields only) is unchanged.
- Counted exactly four full-profile source mappings replaced (home.py, exams.py, problems.py, practice.py/next).

## Deviations From Issue Plan

None.

## Follow-Up Work

None.