### PR TITLE
Repair two unresolved postponed annotations

### DIFF
--- a/backend/app/presentation/home.py
+++ b/backend/app/presentation/home.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
 from app.domain.models import ExamState, GradingStatus
-from app.domain.selection import compute_score_breakdown, ensure_utc
+from app.domain.selection import ProblemSelectionConfig, compute_score_breakdown, ensure_utc
 from app.presentation.deps import CurrentUserDependency, DatabaseDependency, SettingsDependency
 from app.presentation.problem_serialization import problem_document_to_model
 from app.presentation.selection_config import problem_selection_config_from_settings

--- a/backend/app/presentation/ingestion.py
+++ b/backend/app/presentation/ingestion.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from app.domain import IngestionPreviewStatus, ProblemSubject, ProblemType
 from app.infrastructure.storage.mongo import Document
 from app.infrastructure.vlm.client import VLMError
+from pymongo.asynchronous.database import AsyncDatabase
 from app.presentation.deps import (
     CurrentUserDependency,
     DatabaseDependency,

--- a/backend/tests/presentation/test_type_annotations.py
+++ b/backend/tests/presentation/test_type_annotations.py
@@ -1,0 +1,17 @@
+from typing import get_type_hints, get_origin
+
+from app.domain.selection import ProblemSelectionConfig
+from pymongo.asynchronous.database import AsyncDatabase
+
+from app.presentation.home import _build_score_distribution
+from app.presentation.ingestion import _get_owned_preview
+
+
+def test_build_score_distribution_annotations_resolve() -> None:
+    hints = get_type_hints(_build_score_distribution)
+    assert hints["config"] is ProblemSelectionConfig
+
+
+def test_get_owned_preview_annotations_resolve() -> None:
+    hints = get_type_hints(_get_owned_preview)
+    assert get_origin(hints["database"]) is AsyncDatabase


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Add `ProblemSelectionConfig` to the existing `app.domain.selection` import in `home.py` so `get_type_hints(_build_score_distribution)` resolves.
- Add `from pymongo.asynchronous.database import AsyncDatabase` to `ingestion.py` so `get_type_hints(_get_owned_preview)` resolves.
- Add `backend/tests/presentation/test_type_annotations.py` with two focused regression tests.

## Linked Issue

Closes #575

## Issue Alignment

This PR implements the issue by:

- Adding exactly the two missing production imports (`ProblemSelectionConfig` in `home.py`, `AsyncDatabase` in `ingestion.py`).
- Adding a dedicated two-test regression file calling `get_type_hints` only for `_build_score_distribution` and `_get_owned_preview`.
- Asserting the repaired parameter annotations resolve to their intended concrete types.

Scope covered:

- Two production import additions.
- One new test file with two focused `get_type_hints` regression tests.

Out of scope / intentionally not included:

- No other import or annotation cleanup.
- No signature or runtime-logic changes.
- No removal of `from __future__ import annotations`.
- No `TYPE_CHECKING` branches (runtime introspection must resolve the names).

## Implementation Notes

- `ProblemSelectionConfig` added to the existing `app.domain.selection` import line in `home.py` (line 15), preserving alphabetical order.
- `AsyncDatabase` imported as a normal runtime import in `ingestion.py` after the existing infrastructure imports.
- The `_get_owned_preview` annotation uses `AsyncDatabase[Document]` (a generic alias), so the test uses `get_origin()` to assert the origin is `AsyncDatabase`.
- `home.py` was rebased on top of the #574/#580 merge — the `problem_selection_config_from_settings` import from that PR is preserved unchanged.

## Tests

Commands run:

- `python -m pytest tests/presentation/test_type_annotations.py` — 2 passed
- `python -m pytest tests/presentation/test_type_annotations.py tests/api/test_home.py tests/api/test_ingestion.py tests/integration/test_ingestion_workflow.py` — 89 passed
- `python -m pytest` (full backend suite) — 1017 passed, 14 skipped

Manual verification:

- `python -c "from typing import get_type_hints; from app.presentation.home import _build_score_distribution; from app.presentation.ingestion import _get_owned_preview; get_type_hints(_build_score_distribution); get_type_hints(_get_owned_preview)"` — exit 0.
- Inspected production diff: exactly two import additions, no annotation or logic changes.

Automated tests added or updated:

- `test_build_score_distribution_annotations_resolve` — asserts `config` hint resolves to `ProblemSelectionConfig`.
- `test_get_owned_preview_annotations_resolve` — asserts `database` hint origin is `AsyncDatabase`.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.