### PR TITLE
Remove 21 import-free placeholder packages

### DIFF
--- a/backend/app/domain/auth/__init__.py
+++ b/backend/app/domain/auth/__init__.py
@@ -1,1 +1,0 @@
-"""Authentication domain namespace."""

--- a/backend/app/domain/config/__init__.py
+++ b/backend/app/domain/config/__init__.py
@@ -1,1 +1,0 @@
-"""Config domain namespace."""

--- a/backend/app/domain/exam/__init__.py
+++ b/backend/app/domain/exam/__init__.py
@@ -1,1 +1,0 @@
-"""Exam domain namespace."""

--- a/backend/app/domain/media/__init__.py
+++ b/backend/app/domain/media/__init__.py
@@ -1,1 +1,0 @@
-"""Media domain namespace."""

--- a/backend/app/domain/observability/__init__.py
+++ b/backend/app/domain/observability/__init__.py
@@ -1,1 +1,0 @@
-"""Observability domain namespace."""

--- a/backend/app/domain/problem/__init__.py
+++ b/backend/app/domain/problem/__init__.py
@@ -1,1 +1,0 @@
-"""Problem domain namespace."""

--- a/backend/app/domain/storage/__init__.py
+++ b/backend/app/domain/storage/__init__.py
@@ -1,1 +1,0 @@
-"""Storage domain namespace."""

--- a/backend/app/domain/tracking/__init__.py
+++ b/backend/app/domain/tracking/__init__.py
@@ -1,1 +1,0 @@
-"""Tracking domain namespace."""

--- a/backend/app/domain/vlm/__init__.py
+++ b/backend/app/domain/vlm/__init__.py
@@ -1,1 +1,0 @@
-"""VLM domain namespace."""

--- a/backend/app/infrastructure/exam/__init__.py
+++ b/backend/app/infrastructure/exam/__init__.py
@@ -1,1 +1,0 @@
-"""Exam infrastructure namespace."""

--- a/backend/app/infrastructure/media/__init__.py
+++ b/backend/app/infrastructure/media/__init__.py
@@ -1,1 +1,0 @@
-"""Media infrastructure namespace."""

--- a/backend/app/infrastructure/observability/__init__.py
+++ b/backend/app/infrastructure/observability/__init__.py
@@ -1,1 +1,0 @@
-"""Observability infrastructure namespace."""

--- a/backend/app/infrastructure/problem/__init__.py
+++ b/backend/app/infrastructure/problem/__init__.py
@@ -1,1 +1,0 @@
-"""Problem infrastructure namespace."""

--- a/backend/app/infrastructure/tracking/__init__.py
+++ b/backend/app/infrastructure/tracking/__init__.py
@@ -1,1 +1,0 @@
-"""Tracking infrastructure namespace."""

--- a/backend/app/presentation/config/__init__.py
+++ b/backend/app/presentation/config/__init__.py
@@ -1,1 +1,0 @@
-"""Config presentation namespace."""

--- a/backend/app/presentation/exam/__init__.py
+++ b/backend/app/presentation/exam/__init__.py
@@ -1,1 +1,0 @@
-"""Exam presentation namespace."""

--- a/backend/app/presentation/observability/__init__.py
+++ b/backend/app/presentation/observability/__init__.py
@@ -1,1 +1,0 @@
-"""Observability presentation namespace."""

--- a/backend/app/presentation/problem/__init__.py
+++ b/backend/app/presentation/problem/__init__.py
@@ -1,1 +1,0 @@
-"""Problem presentation namespace."""

--- a/backend/app/presentation/storage/__init__.py
+++ b/backend/app/presentation/storage/__init__.py
@@ -1,1 +1,0 @@
-"""Storage presentation namespace."""

--- a/backend/app/presentation/tracking/__init__.py
+++ b/backend/app/presentation/tracking/__init__.py
@@ -1,1 +1,0 @@
-"""Tracking presentation namespace."""

--- a/backend/app/presentation/vlm/__init__.py
+++ b/backend/app/presentation/vlm/__init__.py
@@ -1,1 +1,0 @@
-"""VLM presentation namespace."""


### PR DESCRIPTION
Model-Signature: ollama-cloud/glm-5.2

## Summary

- Delete exactly 21 verified import-free placeholder `__init__.py` files from the fixed allowlist.
- All paths audited immediately before deletion: each contains only a one-line namespace docstring, no other tracked files, no bare-package importers.
- Application import, full backend suite, and wheel/sdist build all pass.

## Linked Issue

Closes #576

## Issue Alignment

This PR implements the issue by:

- Re-auditing all 21 allowlisted paths immediately before deletion.
- Deleting exactly the 21 tracked placeholder `__init__.py` files by explicit path (no wildcard).
- Verifying `import app.main` succeeds, full backend suite passes, and `uv build` produces both wheel and sdist.

Scope covered:

- 21 placeholder `__init__.py` files deleted from the fixed allowlist.
- Pre-deletion content and import audit.

Out of scope / intentionally not included:

- No `__pycache__` cleanup.
- No paths outside the allowlist.
- No active/re-exporting package changes.
- No build configuration or dependency changes.

## Implementation Notes

### Pre-deletion audit

**Content audit** (`git ls-files` + `ls -A` for each path):
All 21 paths contain only the tracked one-line placeholder `__init__.py` — no other tracked files, no untracked files, no `__pycache__`.

**Import audit** (ripgrep for bare-package imports):
```
rg -n --pcre2 "from app\.(domain|infrastructure|presentation)\.(auth|config|exam|media|observability|problem|storage|tracking|vlm) import |(^|[^.\w])import app\.(domain|infrastructure|presentation)\.(auth|config|exam|media|observability|problem|storage|tracking|vlm)([^.\w]|$)" app/ tests/
```
Result: no bare-package imports found for any of the 21 allowlisted packages.

**Dependency check**: #572 landed (PR #578 merged); `backend/app/exam_grading.py` is the root grading destination; `backend/app/domain/exam` remains unused.

### Deletion

Deleted by explicit `git rm` with 21 explicit paths — no wildcard.

### Diff

`git diff --stat --cached`: 21 files changed, 21 deletions (one line each). No product code touched.

## Tests

Commands run:

- `python -c "import app.main"` — exit 0 (OK)
- `python -m pytest` (full backend suite) — 1017 passed, 14 skipped
- `uv build --directory backend --out-dir <tmpdir> --clear` — produced `learnloop_backend-0.1.0-py3-none-any.whl` and `learnloop_backend-0.1.0.tar.gz`

Manual verification:

- `git diff --stat`: exactly 21 files deleted, 21 lines removed, no other changes.
- Confirmed active/re-exporting packages (`domain/coaching`, `domain/ingestion`, `domain/whiteboard`, `infrastructure/auth`, `infrastructure/config`, `infrastructure/ingestion`, `infrastructure/storage`, `infrastructure/vlm`, `infrastructure/worker`, and layer root packages) untouched.

## Deviations From Issue Plan

None.

## Follow-Up Work

None.

## Rollback Scope

To revert, restore exactly these 21 files:

1. `backend/app/domain/auth/__init__.py`
2. `backend/app/domain/config/__init__.py`
3. `backend/app/domain/exam/__init__.py`
4. `backend/app/domain/media/__init__.py`
5. `backend/app/domain/observability/__init__.py`
6. `backend/app/domain/problem/__init__.py`
7. `backend/app/domain/storage/__init__.py`
8. `backend/app/domain/tracking/__init__.py`
9. `backend/app/domain/vlm/__init__.py`
10. `backend/app/infrastructure/exam/__init__.py`
11. `backend/app/infrastructure/media/__init__.py`
12. `backend/app/infrastructure/observability/__init__.py`
13. `backend/app/infrastructure/problem/__init__.py`
14. `backend/app/infrastructure/tracking/__init__.py`
15. `backend/app/presentation/config/__init__.py`
16. `backend/app/presentation/exam/__init__.py`
17. `backend/app/presentation/observability/__init__.py`
18. `backend/app/presentation/problem/__init__.py`
19. `backend/app/presentation/storage/__init__.py`
20. `backend/app/presentation/tracking/__init__.py`
21. `backend/app/presentation/vlm/__init__.py`