### PR TITLE
Add option-letter keyboard shortcuts to Practice and Exam

### DIFF
--- a/frontend/src/components/AnswerInput.test.tsx
+++ b/frontend/src/components/AnswerInput.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
-import { parseOptions, extractOptionKey } from "./AnswerInput";
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { AnswerInput, parseOptions, extractOptionKey } from "./AnswerInput";
 
 describe("parseOptions", () => {
   it("returns lettered choices when present", () => {
@@ -62,5 +63,151 @@ describe("extractOptionKey", () => {
 
   it("returns trimmed option when no marker is found", () => {
     expect(extractOptionKey("no marker")).toBe("no marker");
+  });
+});
+
+describe("AnswerInput option-letter keyboard shortcuts", () => {
+  const ABC = ["A. One", "B. Two", "C. Three"];
+
+  function renderSingleChoice(overrides: { value?: string; options?: string[]; disabled?: boolean } = {}) {
+    const onChange = vi.fn();
+    const result = render(
+      <AnswerInput
+        problemType="single-choice"
+        value={overrides.value ?? ""}
+        onChange={onChange}
+        options={overrides.options ?? ABC}
+        disabled={overrides.disabled}
+      />,
+    );
+    return { ...result, onChange };
+  }
+
+  function renderMultiChoice(overrides: { value?: string; options?: string[]; disabled?: boolean } = {}) {
+    const onChange = vi.fn();
+    const result = render(
+      <AnswerInput
+        problemType="multi-choice"
+        value={overrides.value ?? ""}
+        onChange={onChange}
+        options={overrides.options ?? ABC}
+        disabled={overrides.disabled}
+      />,
+    );
+    return { ...result, onChange };
+  }
+
+  it("selects the matching single-choice option on a lowercase letter", () => {
+    const { onChange } = renderSingleChoice();
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).toHaveBeenCalledWith("A");
+  });
+
+  it("selects the matching single-choice option on an uppercase Shift letter", () => {
+    const { onChange } = renderSingleChoice();
+    fireEvent.keyDown(window, { key: "A", shiftKey: true });
+    expect(onChange).toHaveBeenCalledWith("A");
+  });
+
+  it("matches a single-letter option identifier outside the A-E range", () => {
+    const { onChange } = renderSingleChoice({ options: ["F. Sixth", "G. Seventh"] });
+    fireEvent.keyDown(window, { key: "f" });
+    expect(onChange).toHaveBeenCalledWith("F");
+  });
+
+  it("ignores unmatched letters", () => {
+    const { onChange } = renderSingleChoice();
+    fireEvent.keyDown(window, { key: "z" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores numeric option identifiers", () => {
+    const { onChange } = renderSingleChoice({ options: ["1. First", "2. Second"] });
+    fireEvent.keyDown(window, { key: "1" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores Ctrl, Meta, and Alt modifiers", () => {
+    const { onChange } = renderSingleChoice();
+    fireEvent.keyDown(window, { key: "a", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "a", metaKey: true });
+    fireEvent.keyDown(window, { key: "a", altKey: true });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores repeated keydown events", () => {
+    const { onChange } = renderSingleChoice();
+    fireEvent.keyDown(window, { key: "a", repeat: true });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not handle shortcuts when disabled", () => {
+    const { onChange } = renderSingleChoice({ disabled: true });
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not handle shortcuts for non-choice question types", () => {
+    const onChange = vi.fn();
+    render(<AnswerInput problemType="short-answer" value="" onChange={onChange} options={ABC} />);
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores keys originating from a text input", () => {
+    const { onChange } = renderSingleChoice();
+    const textInput = document.createElement("input");
+    textInput.type = "text";
+    document.body.appendChild(textInput);
+    fireEvent.keyDown(textInput, { key: "a" });
+    expect(onChange).not.toHaveBeenCalled();
+    document.body.removeChild(textInput);
+  });
+
+  it("treats a focused radio control as an eligible target", () => {
+    const { container, onChange } = renderSingleChoice();
+    const radio = container.querySelector('input[type="radio"]') as HTMLInputElement;
+    fireEvent.keyDown(radio, { key: "a" });
+    expect(onChange).toHaveBeenCalledWith("A");
+  });
+
+  it("toggles a multi-choice option on and then off", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <AnswerInput problemType="multi-choice" value="" onChange={onChange} options={ABC} />,
+    );
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).toHaveBeenCalledWith("A");
+
+    rerender(<AnswerInput problemType="multi-choice" value="A" onChange={onChange} options={ABC} />);
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("toggles a second multi-choice option alongside an already-checked one", () => {
+    const onChange = vi.fn();
+    render(<AnswerInput problemType="multi-choice" value="A" onChange={onChange} options={ABC} />);
+    fireEvent.keyDown(window, { key: "b" });
+    expect(onChange).toHaveBeenCalledWith("A, B");
+  });
+
+  it("removes the keyboard listener on unmount", () => {
+    const onChange = vi.fn();
+    const { unmount } = render(
+      <AnswerInput problemType="single-choice" value="" onChange={onChange} options={ABC} />,
+    );
+    unmount();
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not call onChange more than once for a single key press after a rerender", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <AnswerInput problemType="single-choice" value="" onChange={onChange} options={ABC} />,
+    );
+    rerender(<AnswerInput problemType="single-choice" value="" onChange={onChange} options={ABC} />);
+    fireEvent.keyDown(window, { key: "a" });
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/AnswerInput.tsx
+++ b/frontend/src/components/AnswerInput.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 export function extractOptionKey(option: string): string {
   const match = option.trim().match(/^([A-Za-z]|\d+)\s*[.):\-]?(?:\s|$)/);
   return (match?.[1] ?? option).trim();
@@ -20,6 +22,43 @@ export function parseOptions(text: string): string[] {
   return [];
 }
 
+function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.tagName === "TEXTAREA" || target.tagName === "SELECT" || target.isContentEditable) {
+    return true;
+  }
+  if (target.tagName === "INPUT") {
+    const type = (target as HTMLInputElement).type;
+    return type !== "radio" && type !== "checkbox";
+  }
+  return false;
+}
+
+function useOptionKeyShortcut(options: string[], onMatch: (optionValue: string) => void, disabled?: boolean) {
+  useEffect(() => {
+    if (disabled) return;
+    const letterToValue = new Map<string, string>();
+    for (const option of options) {
+      const optionValue = extractOptionKey(option);
+      if (/^[A-Za-z]$/.test(optionValue)) {
+        letterToValue.set(optionValue.toLowerCase(), optionValue);
+      }
+    }
+    if (letterToValue.size === 0) return;
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.repeat) return;
+      if (event.ctrlKey || event.metaKey || event.altKey) return;
+      if (isTextEditingTarget(event.target)) return;
+      const match = letterToValue.get(event.key.toLowerCase());
+      if (match === undefined) return;
+      event.preventDefault();
+      onMatch(match);
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [options, onMatch, disabled]);
+}
+
 interface SingleChoiceInputProps {
   value: string;
   onChange: (value: string) => void;
@@ -29,6 +68,7 @@ interface SingleChoiceInputProps {
 }
 
 export function SingleChoiceInput({ value, onChange, options, onBlur, disabled }: SingleChoiceInputProps) {
+  useOptionKeyShortcut(options, onChange, disabled);
   if (options.length === 0) {
     return (
       <input
@@ -92,6 +132,8 @@ export function MultiChoiceInput({ value, onChange, options, onBlur, disabled }:
       : [...selectedValues, optionValue];
     onChange(newValues.join(", "));
   };
+
+  useOptionKeyShortcut(options, handleToggle, disabled);
 
   if (options.length === 0) {
     return (

--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -604,5 +604,149 @@ describe("ActiveExamPage", () => {
     });
 
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  const singleChoiceExamItem = {
+    ...baseExamItem,
+    itemId: "item1",
+    problem: {
+      text: "Pick one.\nA. One\nB. Two\nC. Three",
+      problemType: "single-choice",
+      correctAnswer: { display: "A", normalizedText: "a", normalizedSet: ["a"], format: "single" },
+    },
+    answer: { raw: "", savedAt: undefined },
+  };
+
+  const singleChoiceExam = {
+    ...baseExam,
+    items: [singleChoiceExamItem],
+  };
+
+  async function renderSingleChoiceExam() {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: singleChoiceExam }),
+    });
+    const result = renderActiveExamPage();
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+    return result;
+  }
+
+  it("updates the current exam answer via shortcut without an immediate save request", async () => {
+    const { container } = await renderSingleChoiceExam();
+
+    fireEvent.keyDown(window, { key: "a" });
+
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    await waitFor(() => expect(radioA.checked).toBe(true));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(
+      mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+      ),
+    ).toBe(false);
+  });
+
+  it("saves a keyboard-selected exam answer when navigating to the next question", async () => {
+    const user = userEvent.setup();
+    const examWithTwoItems = {
+      ...singleChoiceExam,
+      items: [
+        singleChoiceExamItem,
+        {
+          ...singleChoiceExamItem,
+          itemId: "item2",
+          order: 2,
+          problem: { text: "Second question?", problemType: "fill-in-the-blank" },
+        },
+      ],
+      summary: { ...baseExam.summary, totalProblems: 2 },
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ exam: examWithTwoItems }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          item: { ...singleChoiceExamItem, answer: { raw: "A", savedAt: "2024-01-01T01:00:00Z" } },
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ exam: examWithTwoItems }),
+      });
+
+    const { container } = renderActiveExamPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "a" });
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    await waitFor(() => expect(radioA.checked).toBe(true));
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+      )).toBe(true);
+    });
+
+    const patchCall = mockFetch.mock.calls.find((call) =>
+      String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+    );
+    expect(patchCall).toBeDefined();
+    expect(patchCall![1].method).toBe("PATCH");
+    expect(JSON.parse(patchCall![1].body)).toEqual({ answer: "A" });
+  });
+
+  it("blocks background shortcut changes while the submit dialog is open", async () => {
+    const user = userEvent.setup();
+    const { container } = await renderSingleChoiceExam();
+
+    await user.click(screen.getByRole("button", { name: "Submit Exam" }));
+    await waitFor(() => {
+      expect(screen.getByText("Submit Exam?")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "a" });
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    expect(radioA.checked).toBe(false);
+  });
+
+  it("blocks background shortcut changes while the discard dialog is open", async () => {
+    const user = userEvent.setup();
+    const { container } = await renderSingleChoiceExam();
+
+    await user.click(screen.getByRole("button", { name: "Discard" }));
+    await waitFor(() => {
+      expect(screen.getByText("Discard Exam?")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "a" });
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    expect(radioA.checked).toBe(false);
+  });
+
+  it("blocks background shortcut changes while the print preview is open", async () => {
+    const user = userEvent.setup();
+    const { container } = await renderSingleChoiceExam();
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "a" });
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    expect(radioA.checked).toBe(false);
   });
 });

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -353,7 +353,7 @@ export function ActiveExamPage() {
             onChange={setLocalAnswer}
             onBlur={handleBlur}
             options={options}
-            disabled={isMutating}
+            disabled={isMutating || showSubmitConfirm || showDiscardConfirm || showPrintPreview}
           />
           <div
             style={{ marginTop: "0.5rem", fontSize: "0.875rem", color:

--- a/frontend/src/pages/ActivePracticePage.test.tsx
+++ b/frontend/src/pages/ActivePracticePage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -372,5 +372,49 @@ describe("ActivePracticePage", () => {
       expect(screen.getByTestId("submit-button")).toBeInTheDocument();
     });
     expect(screen.queryByTestId("jsxgraph-iframe")).not.toBeInTheDocument();
+  });
+
+  const singleChoiceProblem = {
+    id: "problem-sc",
+    text: "Pick one.\nA. One\nB. Two\nC. Three",
+    type: "single-choice",
+  };
+
+  it("selects a practice choice via an option-letter shortcut", async () => {
+    const { container } = renderActivePracticePage(singleChoiceProblem);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-button")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "a" });
+
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    await waitFor(() => expect(radioA.checked).toBe(true));
+  });
+
+  it("does not change the practice answer via shortcut while grading", async () => {
+    const user = userEvent.setup();
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    const { container } = renderActivePracticePage(singleChoiceProblem);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("submit-button")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "a" });
+    const radioA = container.querySelector('input[type="radio"][value="A"]') as HTMLInputElement;
+    await waitFor(() => expect(radioA.checked).toBe(true));
+
+    await user.click(screen.getByTestId("submit-button"));
+    await waitFor(() => {
+      expect(screen.getByText("Grading...")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "b" });
+    const radioB = container.querySelector('input[type="radio"][value="B"]') as HTMLInputElement;
+    expect(radioB.checked).toBe(false);
+    expect(radioA.checked).toBe(true);
   });
 });


### PR DESCRIPTION
Model-Signature: ark-coding-plan/glm-5.2

## Summary

- Add option-letter keyboard shortcuts to `single-choice` and `multi-choice` questions so users can answer without the mouse.
- Single-choice selects the matching option; multi-choice toggles it. Matching is case-insensitive (Shift allowed), uses the rendered option identifier via `extractOptionKey` (not hard-coded A-E), and is routed through the existing `onChange` contract so mouse and keyboard produce identical values.
- Guard the listener against modifiers (Ctrl/Meta/Alt), repeat events, disabled state, non-choice types, and text-editing targets (radio/checkbox remain eligible). Listener is attached to `window` and cleaned up on unmount/dependency change.
- In `ActiveExamPage`, extend the answer-input `disabled` condition to include the submit, discard, and print-preview dialogs so background answers cannot be changed while a dialog is open. No immediate Exam save is added; keyboard selection is persisted by the existing blur/navigation/submit flow.

## Linked Issue

Closes #583

## Issue Alignment

This PR implements the issue by:

- Adding a single shared `useOptionKeyShortcut` hook used by both `SingleChoiceInput` and `MultiChoiceInput`, implementing the behavior once in the shared answer-input path.
- Reusing `extractOptionKey` to resolve actual option identifiers and matching only single-letter keys.
- Mirroring the repo's established keyboard-shortcut convention from `BulkDetectStep.tsx` (window `keydown` listener with `repeat` / `ctrlKey` / `metaKey` / `altKey` and text-editing-target guards), refined to keep radio/checkbox targets eligible per the issue.
- Updating `ActiveExamPage` so `showSubmitConfirm`, `showDiscardConfirm`, and `showPrintPreview` all disable the background answer input.

Scope covered:

- Keyboard handling for `single-choice` and `multi-choice` in the shared `AnswerInput`.
- Case-insensitive matching incl. Shift; any single-letter option identifier; multi-choice toggle; modifier/repeat/disabled/non-choice/text-target guards; listener cleanup.
- Exam submit/discard/print dialogs block background shortcut changes; Exam save timing unchanged.
- Component tests (`AnswerInput.test.tsx`) and page integration tests (`ActivePracticePage.test.tsx`, `ActiveExamPage.test.tsx`).

Out of scope / intentionally not included:

- Numeric option shortcuts; fill-in-the-blank / short-answer shortcuts; submit/navigation/skip/quit shortcuts; shortcut-help UI; backend/API/data-format changes (all explicitly out of scope per the issue).

## Implementation Notes

- `useOptionKeyShortcut(options, onMatch, disabled)` builds a lowercase-letter -> option-value map from `extractOptionKey`, attaches one `keydown` listener on `window` when not disabled and at least one lettered option exists, and removes it in the effect cleanup. It `preventDefault`s only on a matched letter so other keys/shortcuts are unaffected.
- `isTextEditingTarget` rejects `TEXTAREA`, `SELECT`, `contentEditable`, and `INPUT` types other than `radio`/`checkbox`. A `window`-originated event (target not an `HTMLElement`) is treated as eligible.
- Hooks are called unconditionally before the `options.length === 0` early returns to respect the rules of hooks; the hook no-ops when there are no lettered options or when disabled.
- `ActiveExamPage` change is a single `disabled` expression; `disabled` does not fire `onBlur`, so opening a dialog does not trigger a save (verified by the existing "no save on preview" test, still passing).

## Tests

Commands run:

- `vitest run src/components/AnswerInput.test.tsx src/pages/ActivePracticePage.test.tsx src/pages/ActiveExamPage.test.tsx` -> passed (66 tests).
- `vitest run` (full frontend suite) -> passed (596 tests, 37 files).
- `tsc -b` -> passed (exit 0, no type errors).
- `biome check` on changed files -> no new diagnostics (all reported diagnostics pre-exist on `master`).

Note on the prescribed command: the issue's manual-verification step specifies `./scripts/agent-env.sh test frontend`. That command could not complete in this environment because the reusable tools-image fingerprint changed (`db6fe30f…` vs the locally cached `21641e41…`), and rebuilding `Dockerfile.agent` (which reinstalls backend + frontend deps) hangs beyond the available time. As a faithful equivalent, `vitest run` was executed against the identical `frontend/package-lock.json` (byte-identical to the main checkout) and its matching `node_modules`, which is exactly what the agent-env frontend lane runs inside the container.

Automated tests added or updated:

- `AnswerInput.test.tsx` (+15 tests): lowercase/Shift selection, option outside A-E, unmatched/numeric/modifier/repeat/disabled/non-choice rejection, text-input rejection, radio eligibility, multi-choice toggle on/off and second-option toggle, unmount cleanup, no-duplicate-after-rerender.
- `ActivePracticePage.test.tsx` (+2 tests): shortcut selects a practice choice; shortcut blocked while grading.
- `ActiveExamPage.test.tsx` (+5 tests): shortcut updates local answer with no immediate save; navigation saves the keyboard-selected value via the existing PATCH flow; submit/discard/print dialogs each block background shortcut changes.

Manual verification:

Automated component and integration tests assert every acceptance criterion directly. Interactive browser verification (one single-choice and one multi-choice question in both Practice and Exam) is left for the reviewer with the issue's prescribed steps:
1. Start the stack and open an active Practice single-choice question; press `a` then `A` (Shift) and confirm the option selects; repeat for multi-choice to confirm check/uncheck.
2. Repeat in an active Exam; confirm the selected value is saved on Next/Submit (not on key press).
3. Open the submit, discard, and print dialogs and confirm letter keys do not change the background answer.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (shared hook in `AnswerInput`, reuse `extractOptionKey`, route through `onChange`, extend the Exam `disabled` condition for all three dialogs, no immediate persistence). The only environment-level deviation is running `vitest run` directly instead of via `./scripts/agent-env.sh test frontend`, explained above; the executed suite and dependency inputs are identical.

## Follow-Up Work

None.
