### PR TITLE
Add arrow-key question navigation to active Exam mode

### DIFF
--- a/frontend/src/pages/ActiveExamPage.test.tsx
+++ b/frontend/src/pages/ActiveExamPage.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -604,5 +604,231 @@ describe("ActiveExamPage", () => {
     });
 
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  const examWithTwoItems = {
+    ...baseExam,
+    items: [
+      { ...baseExamItem, itemId: "item1", order: 1, problem: { ...baseExamItem.problem, text: "First question?" } },
+      { ...baseExamItem, itemId: "item2", order: 2, problem: { ...baseExamItem.problem, text: "Second question?" } },
+    ],
+    summary: { ...baseExam.summary, totalProblems: 2 },
+  };
+
+  async function renderTwoItemExam() {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: examWithTwoItems }),
+    });
+    const result = renderActiveExamPage();
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+    return result;
+  }
+
+  it("navigates forward with ArrowRight and back with ArrowLeft", async () => {
+    await renderTwoItemExam();
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+    await waitFor(() => {
+      expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+    });
+  });
+
+  it("PATCHes a changed answer when navigating with ArrowRight", async () => {
+    const user = userEvent.setup();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ exam: examWithTwoItems }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          item: { ...examWithTwoItems.items[0], answer: { raw: "42", savedAt: "2024-01-01T01:00:00Z" } },
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ exam: examWithTwoItems }),
+      });
+
+    renderActiveExamPage();
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "42");
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    await waitFor(() => {
+      expect(mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+      )).toBe(true);
+    });
+
+    const patchCall = mockFetch.mock.calls.find((call) =>
+      String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+    );
+    expect(patchCall).toBeDefined();
+    expect(patchCall![1].method).toBe("PATCH");
+    expect(JSON.parse(patchCall![1].body)).toEqual({ answer: "42" });
+  });
+
+  it("ArrowLeft on the first question neither navigates nor saves", async () => {
+    await renderTwoItemExam();
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "ArrowLeft" });
+
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+    expect(
+      mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+      ),
+    ).toBe(false);
+  });
+
+  it("ArrowRight on the last question neither navigates nor saves", async () => {
+    await renderTwoItemExam();
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    expect(screen.getByText(/Question 2 of 2/)).toBeInTheDocument();
+    expect(
+      mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/items/item2/answer"),
+      ),
+    ).toBe(false);
+  });
+
+  it("ignores arrow keys originating from a text answer input", async () => {
+    await renderTwoItemExam();
+    const input = screen.getByRole("textbox");
+
+    fireEvent.keyDown(input, { key: "ArrowRight" });
+
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+  });
+
+  it("ignores arrow keys originating from a radio answer control", async () => {
+    const singleChoiceExam = {
+      ...examWithTwoItems,
+      items: [
+        {
+          ...examWithTwoItems.items[0],
+          problem: { text: "Pick one.\nA. One\nB. Two", problemType: "single-choice" },
+        },
+        examWithTwoItems.items[1],
+      ],
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ exam: singleChoiceExam }),
+    });
+    const { container } = renderActiveExamPage();
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    const radio = container.querySelector('input[type="radio"]') as HTMLInputElement;
+    fireEvent.keyDown(radio, { key: "ArrowRight" });
+
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+  });
+
+  it("blocks arrow navigation while the submit dialog is open", async () => {
+    const user = userEvent.setup();
+    await renderTwoItemExam();
+
+    await user.click(screen.getByRole("button", { name: "Submit Exam" }));
+    await waitFor(() => {
+      expect(screen.getByText("Submit Exam?")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+  });
+
+  it("blocks arrow navigation while the discard dialog is open", async () => {
+    const user = userEvent.setup();
+    await renderTwoItemExam();
+
+    await user.click(screen.getByRole("button", { name: "Discard" }));
+    await waitFor(() => {
+      expect(screen.getByText("Discard Exam?")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+  });
+
+  it("blocks arrow navigation while the print preview is open", async () => {
+    const user = userEvent.setup();
+    await renderTwoItemExam();
+
+    await user.click(screen.getByRole("button", { name: "Print" }));
+    await waitFor(() => {
+      expect(screen.getByText("Exam Paper")).toBeInTheDocument();
+    });
+
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+  });
+
+  it("ignores modifier-key and repeated arrow events", async () => {
+    await renderTwoItemExam();
+
+    fireEvent.keyDown(window, { key: "ArrowRight", ctrlKey: true });
+    fireEvent.keyDown(window, { key: "ArrowRight", metaKey: true });
+    fireEvent.keyDown(window, { key: "ArrowRight", altKey: true });
+    fireEvent.keyDown(window, { key: "ArrowRight", shiftKey: true });
+    fireEvent.keyDown(window, { key: "ArrowRight", repeat: true });
+
+    expect(screen.getByText(/Question 1 of 2/)).toBeInTheDocument();
+  });
+
+  it("removes the arrow-key listener on unmount", async () => {
+    const user = userEvent.setup();
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ exam: examWithTwoItems }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ exam: examWithTwoItems }),
+      });
+
+    const { unmount } = renderActiveExamPage();
+    await waitFor(() => {
+      expect(screen.getByText("Active Exam")).toBeInTheDocument();
+    });
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "42");
+
+    unmount();
+    fireEvent.keyDown(window, { key: "ArrowRight" });
+
+    expect(
+      mockFetch.mock.calls.some((call) =>
+        String(call[0]).includes("/api/v1/exams/exam123/items/item1/answer"),
+      ),
+    ).toBe(false);
   });
 });

--- a/frontend/src/pages/ActiveExamPage.tsx
+++ b/frontend/src/pages/ActiveExamPage.tsx
@@ -163,6 +163,37 @@ export function ActiveExamPage() {
     window.print();
   }, []);
 
+  useEffect(() => {
+    function handleArrowKey(event: KeyboardEvent) {
+      if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+      if (event.repeat) return;
+      if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      if (showSubmitConfirm || showDiscardConfirm || showPrintPreview) return;
+      if (isMutating) return;
+      if (event.key === "ArrowLeft") {
+        if (currentItemIndex <= 0) return;
+        event.preventDefault();
+        void handlePrevious();
+      } else {
+        if (currentItemIndex >= items.length - 1) return;
+        event.preventDefault();
+        void handleNext();
+      }
+    }
+    window.addEventListener("keydown", handleArrowKey);
+    return () => window.removeEventListener("keydown", handleArrowKey);
+  }, [handlePrevious, handleNext, currentItemIndex, items.length, showSubmitConfirm, showDiscardConfirm, showPrintPreview, isMutating]);
+
   const pageCanvasStyle: React.CSSProperties = {
     minHeight: "calc(100vh - 60px)",
     backgroundColor: "var(--color-surface-muted)",


### PR DESCRIPTION
Model-Signature: ark-coding-plan/glm-5.2

## Summary

- Add left/right arrow-key question navigation to the active Exam page so users can move between questions without clicking Previous/Next.
- `ArrowLeft`/`ArrowRight` reuse the existing `handlePrevious`/`handleNext` callbacks, so a changed answer is saved through the same save-and-navigate flow as the buttons.
- Guards: only plain (no Ctrl/Meta/Alt/Shift), non-repeated arrow events; ignored when the target is an `input`/`textarea`/`select`/`contentEditable` element (including radio/checkbox answer controls, preserving their native arrow behavior); ignored while the submit, discard, or print-preview modal is open or while submit/discard is pending; first/last question boundaries are no-ops that do not trigger an answer save.
- `preventDefault` is called only when an in-range navigation is actually handled. The listener is attached to `window` with symmetric effect cleanup on unmount/dependency change.

## Linked Issue

Closes #584

## Issue Alignment

This PR implements the issue by:

- Registering a single lifecycle-managed `window` `keydown` listener from `ActiveExamPage` via `useEffect`, with cleanup.
- Reusing the existing `handlePrevious`/`handleNext` callbacks (no duplicated save/navigation logic).
- Mirroring the repository's keyboard-shortcut precedent in `BulkDetectStep.tsx` for the editable-target filter, as the issue explicitly references.
- Checking the first/last boundary before invoking a handler so boundary presses neither navigate nor save.

Scope covered:

- Active-Exam-only `ArrowLeft`/`ArrowRight` handling with event, focus, modal, mutation, modifier, repeat, and boundary guards.
- Component tests in `ActiveExamPage.test.tsx` for navigation, save-on-navigate, boundaries, editable/form targets, each modal, modifiers/repeat, and unmount cleanup.

Out of scope / intentionally not included:

- Previous/Next button behavior/presentation changes, shortcut hint UI, Practice/exam-history/exam-detail navigation, and backend/API/type changes (all explicitly out of scope per the issue).

## Implementation Notes

- The effect is placed before the component's early returns (rules of hooks) and reads `currentItemIndex`, `items.length`, the three modal flags, and `isMutating` directly, with all of them in the dependency array so the handler never closes over stale question/modal/mutation state.
- Boundary checks (`currentItemIndex <= 0` for left, `currentItemIndex >= items.length - 1` for right) return before `preventDefault` and before calling the handler, satisfying "no switch and no unnecessary save at the boundary" (the existing handlers would otherwise save via `handleSaveAnswer`).
- The editable-target guard rejects any `INPUT` (including `radio`/`checkbox`), `TEXTAREA`, `SELECT`, or `contentEditable` target, so arrow keys retain native behavior inside answer controls. A `window`-originated event (e.g. target `document.body`) is treated as eligible.
- This change is independent of #583 (option-letter shortcuts in `AnswerInput`): the two listeners handle disjoint keys (arrows vs. option letters), so they coexist without conflict. This PR is based on `master` and does not depend on #583.

## Tests

Commands run:

- `vitest run src/pages/ActiveExamPage.test.tsx` -> passed (28 tests: 17 existing + 11 new).
- `vitest run` (full frontend suite) -> passed (585 tests, 37 files).
- `tsc -b` -> passed (exit 0, no type errors).
- `biome check` on `ActiveExamPage.tsx` -> no new diagnostics (18 pre-existing `useButtonType` warnings on `master`, unchanged).

Note on the prescribed command: the issue specifies `./scripts/agent-env.sh test frontend`. That command could not complete in this environment because the reusable tools-image fingerprint changed (`db6fe30f…` vs the locally cached `21641e41…`), and rebuilding `Dockerfile.agent` (which reinstalls backend + frontend deps) hangs beyond the available time. As a faithful equivalent, `vitest run` was executed against the byte-identical `frontend/package-lock.json` and its matching `node_modules`, which is exactly what the agent-env frontend lane runs inside the container.

Automated tests added:

- `navigates forward with ArrowRight and back with ArrowLeft`
- `PATCHes a changed answer when navigating with ArrowRight`
- `ArrowLeft on the first question neither navigates nor saves`
- `ArrowRight on the last question neither navigates nor saves`
- `ignores arrow keys originating from a text answer input`
- `ignores arrow keys originating from a radio answer control`
- `blocks arrow navigation while the submit dialog is open`
- `blocks arrow navigation while the discard dialog is open`
- `blocks arrow navigation while the print preview is open`
- `ignores modifier-key and repeated arrow events`
- `removes the arrow-key listener on unmount`

Manual verification:

Automated tests assert every acceptance criterion directly. Interactive browser verification (start a 2+ question exam, click a non-editable area, confirm Right/Left advance/return, confirm a changed answer is preserved on arrow navigation, confirm arrow keys retain native behavior inside answer controls, confirm boundary and modal no-ops) is left for the reviewer with the issue's prescribed steps.

## Deviations From Issue Plan

None. The implementation follows the issue's chosen approach (window `keydown` listener in `ActiveExamPage`, reuse `handlePrevious`/`handleNext`, all confirmed guards, boundary no-ops). The `isMutating` (submit/discard pending) guard is implemented for defense-in-depth; in the current UI flow a submit/discard mutation is always accompanied by its open confirmation modal, so the modal guard already blocks arrows during pending state (covered by the three modal tests). The only environment-level deviation is running `vitest run` directly instead of via `./scripts/agent-env.sh test frontend`, explained above; the executed suite and dependency inputs are identical.

## Follow-Up Work

None.
